### PR TITLE
[Functions alpha] Fix compiler and automation runtime execution

### DIFF
--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -2,6 +2,7 @@ import { configs, context, events } from "@budibase/backend-core"
 import { mocks } from "@budibase/backend-core/tests"
 import {
   Automation,
+  AutomationActionStepId,
   AutomationResults,
   AutomationTriggerStepId,
   ConfigType,
@@ -116,9 +117,12 @@ describe("/automations", () => {
 
     it("returns all of the definitions in one", async () => {
       const { action, trigger } = await config.api.automation.getDefinitions()
+      const requiredActionIds = Object.keys(BUILTIN_ACTION_DEFINITIONS).filter(
+        actionId => actionId !== AutomationActionStepId.EXECUTE_FUNCTION
+      )
 
-      expect(Object.keys(action).length).toBeGreaterThanOrEqual(
-        Object.keys(BUILTIN_ACTION_DEFINITIONS).length
+      expect(Object.keys(action)).toEqual(
+        expect.arrayContaining(requiredActionIds)
       )
       expect(Object.keys(trigger).length).toEqual(
         Object.keys(TRIGGER_DEFINITIONS).length

--- a/packages/server/src/api/routes/tests/function.spec.ts
+++ b/packages/server/src/api/routes/tests/function.spec.ts
@@ -723,7 +723,7 @@ export default async function (): Promise<FunctionResult> {
           queryCount: 2,
           error: {
             code: FunctionErrorCode.FUNCTION_RUNTIME_ERROR,
-            message: "The Function query failed",
+            message: "The Function execution failed",
           },
         })
         expect(stored?.error?.message.length).toBeLessThanOrEqual(512)

--- a/packages/server/src/api/routes/tests/function.spec.ts
+++ b/packages/server/src/api/routes/tests/function.spec.ts
@@ -245,9 +245,7 @@ export default async function (): Promise<FunctionResult> {
       )
       expect(built.artifact).toEqual(
         expect.objectContaining({
-          compiledJavaScript: expect.stringContaining(
-            "__budibaseFunctionModule"
-          ),
+          compiledJavaScript: expect.stringContaining("export {"),
         })
       )
 

--- a/packages/server/src/automations/steps/executeFunction.ts
+++ b/packages/server/src/automations/steps/executeFunction.ts
@@ -119,7 +119,7 @@ const getJsonDepth = (value: JSONValue): number => {
 const parseInputs = (
   inputs: ExecuteFunctionStepInputs["inputs"]
 ): Record<string, JSONValue> => {
-  let value: unknown = inputs
+  let value: unknown = inputs ?? {}
   if (
     value &&
     typeof value === "object" &&

--- a/packages/server/src/automations/tests/actionDefinitions.spec.ts
+++ b/packages/server/src/automations/tests/actionDefinitions.spec.ts
@@ -64,7 +64,9 @@ describe("getActionDefinitions", () => {
 
     mockAreFunctionsEnabled.mockResolvedValue(true)
 
-    expect((await getActionDefinitions()).EXECUTE_FUNCTION).toBeDefined()
+    const definition = (await getActionDefinitions()).EXECUTE_FUNCTION
+    expect(definition).toBeDefined()
+    expect(definition?.inputs).toEqual({ inputs: { value: "{}" } })
   })
 
   it("adds self-hosted automation plugin definitions as custom actions", async () => {

--- a/packages/server/src/automations/tests/steps/executeFunction.spec.ts
+++ b/packages/server/src/automations/tests/steps/executeFunction.spec.ts
@@ -164,6 +164,22 @@ describe("Run Function automation action", () => {
     )
   })
 
+  it("defaults omitted Function inputs to an empty object", async () => {
+    const deps = dependencies()
+
+    await run(deps, {
+      functionId: fn._id,
+      // @ts-expect-error - older steps may not have persisted the editor default
+      inputs: undefined,
+    })
+
+    expect(deps.execute).toHaveBeenCalledWith(
+      deps.executor,
+      expect.objectContaining({ inputs: {} }),
+      expect.any(Object)
+    )
+  })
+
   it.each([
     [
       "disabled",

--- a/packages/server/src/functions/broker.spec.ts
+++ b/packages/server/src/functions/broker.spec.ts
@@ -362,7 +362,7 @@ describe("Function query broker", () => {
       executeFunctionQuery(request(), scope.workspaceId, deps)
     ).rejects.toMatchObject({
       code: FunctionErrorCode.FUNCTION_RUNTIME_ERROR,
-      message: "The Function query failed",
+      message: "The Function execution failed",
     })
     expect(JSON.stringify(record.mock.calls)).not.toContain(grantToken)
     expect(JSON.stringify(record.mock.calls)).not.toContain("active")

--- a/packages/server/src/functions/errors.ts
+++ b/packages/server/src/functions/errors.ts
@@ -19,7 +19,7 @@ const ERROR_MESSAGES: Partial<Record<FunctionErrorCode, string>> = {
     "The Function query request was denied",
   [FunctionErrorCode.FUNCTION_QUERY_LIMIT]:
     "The Function query request exceeded a limit",
-  [FunctionErrorCode.FUNCTION_RUNTIME_ERROR]: "The Function query failed",
+  [FunctionErrorCode.FUNCTION_RUNTIME_ERROR]: "The Function execution failed",
   [FunctionErrorCode.FUNCTION_PROTOCOL_ERROR]:
     "The Function runner returned an invalid response",
   [FunctionErrorCode.FUNCTION_ORCHESTRATOR_INTERRUPTED]:

--- a/packages/server/src/sdk/workspace/functions/compiler/bundle.ts
+++ b/packages/server/src/sdk/workspace/functions/compiler/bundle.ts
@@ -1,3 +1,4 @@
+import type { FunctionQueryCapability } from "@budibase/types"
 import { build, type BuildFailure, type Message } from "esbuild"
 import {
   FUNCTION_VIRTUAL_SOURCE_FILE,
@@ -23,14 +24,36 @@ const toBuildDiagnostic = (message: Message) =>
     message.location ? message.location.column + 1 : undefined
   )
 
+const renderRuntimeModule = (capabilities: FunctionQueryCapability[]) => {
+  const grouped = new Map<string, FunctionQueryCapability[]>()
+  for (const capability of capabilities) {
+    const datasourceCapabilities = grouped.get(capability.datasourceAlias) || []
+    datasourceCapabilities.push(capability)
+    grouped.set(capability.datasourceAlias, datasourceCapabilities)
+  }
+
+  const queries = [...grouped.entries()].map(
+    ([datasourceAlias, datasourceCapabilities]) =>
+      `${JSON.stringify(datasourceAlias)}: Object.freeze({${datasourceCapabilities
+        .map(
+          capability =>
+            `${JSON.stringify(capability.queryAlias)}: (parameters = {}) => globalThis.__budibaseInvokeQuery(${JSON.stringify(capability.capabilityId)}, parameters)`
+        )
+        .join(",")}})`
+  )
+
+  return `export const inputs = globalThis.__budibaseInputs
+export const queries = Object.freeze({${queries.join(",")}})`
+}
+
 export const bundleFunction = async (
-  source: string
+  source: string,
+  capabilities: FunctionQueryCapability[]
 ): Promise<FunctionCompilerResult> => {
   try {
     const result = await build({
       bundle: true,
-      format: "iife",
-      globalName: "__budibaseFunctionModule",
+      format: "esm",
       legalComments: "none",
       outfile: "function.js",
       platform: "neutral",
@@ -52,9 +75,7 @@ export const bundleFunction = async (
             build.onLoad(
               { filter: /.*/, namespace: VIRTUAL_MODULE_NAMESPACE },
               () => ({
-                contents: `const runtime = globalThis.__budibaseFunctionsRuntime
-export const inputs = runtime.inputs
-export const queries = runtime.queries`,
+                contents: renderRuntimeModule(capabilities),
                 loader: "js",
               })
             )

--- a/packages/server/src/sdk/workspace/functions/compiler/compile.spec.ts
+++ b/packages/server/src/sdk/workspace/functions/compiler/compile.spec.ts
@@ -1,13 +1,16 @@
 import { join } from "path"
+import type { FunctionQueryCapability } from "@budibase/types"
 import { generateFunctionDeclarations } from "../declarations"
 import { compileFunctionInProcess } from "./compile"
 import { runFunctionCompilerProcess } from "./index"
 
 const declarations = generateFunctionDeclarations([])
+const capabilities: FunctionQueryCapability[] = []
 
 describe("Function compiler", () => {
   it("type-checks and bundles a valid async entrypoint", async () => {
     const result = await compileFunctionInProcess({
+      capabilities,
       declarations,
       source: `import { inputs, type FunctionResult } from "@budibase/functions"
 
@@ -17,9 +20,8 @@ export default async function (): Promise<FunctionResult> {
     })
 
     expect(result.diagnostics).toEqual([])
-    expect(result.output?.compiledJavaScript).toContain(
-      "__budibaseFunctionsRuntime"
-    )
+    expect(result.output?.compiledJavaScript).toContain("__budibaseInputs")
+    expect(result.output?.compiledJavaScript).toContain("export {")
     expect(result.output?.compiledJavaScript).not.toContain(
       'from "@budibase/functions"'
     )
@@ -28,6 +30,7 @@ export default async function (): Promise<FunctionResult> {
 
   it("returns TypeScript diagnostics without bundling invalid source", async () => {
     const result = await compileFunctionInProcess({
+      capabilities,
       declarations,
       source: `export default async function () {
   const value: string = 42
@@ -60,7 +63,11 @@ export default async function (): Promise<FunctionResult> {
       code: "FUNCTION_IMPORT_NOT_ALLOWED",
     },
   ])("rejects prohibited module loading", async ({ source, code }) => {
-    const result = await compileFunctionInProcess({ declarations, source })
+    const result = await compileFunctionInProcess({
+      capabilities,
+      declarations,
+      source,
+    })
 
     expect(result.output).toBeUndefined()
     expect(result.diagnostics).toEqual(
@@ -73,7 +80,11 @@ export default async function (): Promise<FunctionResult> {
     "export const value = 1",
     "const entrypoint = async () => {}\nexport default entrypoint",
   ])("rejects an invalid entrypoint", async source => {
-    const result = await compileFunctionInProcess({ declarations, source })
+    const result = await compileFunctionInProcess({
+      capabilities,
+      declarations,
+      source,
+    })
 
     expect(result.output).toBeUndefined()
     expect(result.diagnostics).toEqual(
@@ -89,6 +100,7 @@ export default async function (): Promise<FunctionResult> {
       (_, index) => `const value${index}: string = ${index}`
     ).join("\n")
     const result = await compileFunctionInProcess({
+      capabilities,
       declarations,
       source: `${assignments}\nexport default async function () {}`,
     })
@@ -97,6 +109,31 @@ export default async function (): Promise<FunctionResult> {
     expect(result.diagnostics.every(item => item.message.length <= 512)).toBe(
       true
     )
+  })
+
+  it("embeds query aliases as capability calls", async () => {
+    const queryCapabilities: FunctionQueryCapability[] = [
+      {
+        capabilityId: "capability-1",
+        queryId: "query-1",
+        datasourceAlias: "CRM",
+        queryAlias: "findCustomer",
+        parameterNames: ["id"],
+      },
+    ]
+    const result = await compileFunctionInProcess({
+      capabilities: queryCapabilities,
+      declarations: generateFunctionDeclarations(queryCapabilities),
+      source: `import { queries } from "@budibase/functions"
+
+export default async function () {
+  return { output: await queries.CRM.findCustomer({ id: "customer-1" }) }
+}`,
+    })
+
+    expect(result.diagnostics).toEqual([])
+    expect(result.output?.compiledJavaScript).toContain("capability-1")
+    expect(result.output?.compiledJavaScript).toContain("__budibaseInvokeQuery")
   })
 
   it("terminates a compiler child at the deadline", async () => {

--- a/packages/server/src/sdk/workspace/functions/compiler/compile.spec.ts
+++ b/packages/server/src/sdk/workspace/functions/compiler/compile.spec.ts
@@ -138,7 +138,11 @@ export default async function () {
 
   it("terminates a compiler child at the deadline", async () => {
     const result = await runFunctionCompilerProcess(
-      { declarations, source: "export default async function () {}" },
+      {
+        capabilities,
+        declarations,
+        source: "export default async function () {}",
+      },
       {
         timeoutMs: 50,
         workerPath: join(__dirname, "tests/fixtures/hangingCompiler.js"),
@@ -154,7 +158,11 @@ export default async function () {
 
   it("contains compiler child failures", async () => {
     const result = await runFunctionCompilerProcess(
-      { declarations, source: "export default async function () {}" },
+      {
+        capabilities,
+        declarations,
+        source: "export default async function () {}",
+      },
       {
         timeoutMs: 5_000,
         workerPath: join(__dirname, "tests/fixtures/failedCompiler.js"),
@@ -170,7 +178,11 @@ export default async function () {
 
   it("rejects invalid diagnostics returned by the compiler child", async () => {
     const result = await runFunctionCompilerProcess(
-      { declarations, source: "export default async function () {}" },
+      {
+        capabilities,
+        declarations,
+        source: "export default async function () {}",
+      },
       {
         timeoutMs: 5_000,
         workerPath: join(__dirname, "tests/fixtures/invalidCompiler.js"),

--- a/packages/server/src/sdk/workspace/functions/compiler/compile.ts
+++ b/packages/server/src/sdk/workspace/functions/compiler/compile.ts
@@ -15,5 +15,5 @@ export const compileFunctionInProcess = async (
     return { diagnostics }
   }
 
-  return await bundleFunction(request.source)
+  return await bundleFunction(request.source, request.capabilities)
 }

--- a/packages/server/src/sdk/workspace/functions/compiler/index.ts
+++ b/packages/server/src/sdk/workspace/functions/compiler/index.ts
@@ -73,24 +73,10 @@ const isCompilerResult = (value: unknown): value is FunctionCompilerResult => {
   )
 }
 
-const getWorkerOptions = (memoryLimitMb: number) => {
-  if (env.isDev()) {
-    return {
-      execArgv: [
-        `--max-old-space-size=${memoryLimitMb}`,
-        "-r",
-        require.resolve("ts-node/register/transpile-only"),
-        "-r",
-        require.resolve("tsconfig-paths/register"),
-      ],
-      workerPath: join(__dirname, "../../../../threads/functionCompiler.ts"),
-    }
-  }
-  return {
-    execArgv: [`--max-old-space-size=${memoryLimitMb}`],
-    workerPath: join(__dirname, "functionCompiler.js"),
-  }
-}
+const getWorkerOptions = (memoryLimitMb: number) => ({
+  execArgv: [`--max-old-space-size=${memoryLimitMb}`],
+  workerPath: join(__dirname, "functionCompiler.js"),
+})
 
 export const runFunctionCompilerProcess = async (
   request: FunctionCompilerRequest,

--- a/packages/server/src/sdk/workspace/functions/compiler/types.ts
+++ b/packages/server/src/sdk/workspace/functions/compiler/types.ts
@@ -1,8 +1,12 @@
-import type { FunctionBuildDiagnostic } from "@budibase/types"
+import type {
+  FunctionBuildDiagnostic,
+  FunctionQueryCapability,
+} from "@budibase/types"
 
 export interface FunctionCompilerRequest {
   source: string
   declarations: string
+  capabilities: FunctionQueryCapability[]
 }
 
 export interface FunctionCompilerOutput {

--- a/packages/server/src/sdk/workspace/functions/index.ts
+++ b/packages/server/src/sdk/workspace/functions/index.ts
@@ -184,6 +184,7 @@ export const compile = async (draft: FunctionCompileInput) => {
   const result = await compileFunction({
     source: draft.source,
     declarations,
+    capabilities,
   })
   return getCompileDiagnostics(result.diagnostics, !!result.output)
 }
@@ -206,6 +207,7 @@ export const build = async (id: string, revision: string) => {
   const result = await compileFunction({
     source: fn.source,
     declarations: declarationResult.declarations,
+    capabilities: declarationResult.capabilities,
   })
   const diagnostics = getCompileDiagnostics(result.diagnostics, !!result.output)
 

--- a/packages/server/src/threads/functionCompiler.ts
+++ b/packages/server/src/threads/functionCompiler.ts
@@ -10,7 +10,9 @@ const isCompilerRequest = (
     "source" in value &&
     typeof value.source === "string" &&
     "declarations" in value &&
-    typeof value.declarations === "string"
+    typeof value.declarations === "string" &&
+    "capabilities" in value &&
+    Array.isArray(value.capabilities)
   )
 }
 

--- a/packages/shared-core/src/automations/steps/executeFunction.ts
+++ b/packages/shared-core/src/automations/steps/executeFunction.ts
@@ -18,7 +18,11 @@ export const definition: AutomationStepDefinition = {
   features: {
     [AutomationFeature.LOOPING]: true,
   },
-  inputs: {},
+  inputs: {
+    inputs: {
+      value: "{}",
+    },
+  },
   schema: {
     inputs: {
       properties: {


### PR DESCRIPTION
## Description
Fix the Function compiler/runtime contract so compiled artifacts use the ES module format expected by the isolate runner. The virtual module now binds inputs and scoped query aliases to the runner globals, and compilation receives the declared query capabilities.

This also makes local compilation use the built compiler worker, defaults omitted automation inputs to an empty object, and replaces the misleading generic query failure message with a Function execution failure.

## Addresses
- https://github.com/Budibase/budibase/issues/19256
- https://github.com/Budibase/budibase/issues/19264
- https://github.com/Budibase/budibase/issues/19266

## Launchcontrol
Functions compiled in local development can now run successfully, receive automation inputs, and invoke their configured query aliases.