### PR TITLE
Reduce API response header size

### DIFF
--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -194,6 +194,9 @@ http {
       # calls to the API are rate limited with bursting
       limit_req zone=ratelimit burst=20 nodelay;
 
+      # Allow for CSP and other response headers on general API routes
+      proxy_buffer_size 16k;
+
       # 120s timeout on API requests
       proxy_read_timeout ${PROXY_TIMEOUT_SECONDS}s;
       proxy_connect_timeout ${PROXY_TIMEOUT_SECONDS}s;

--- a/packages/backend-core/src/middleware/contentSecurityPolicy.ts
+++ b/packages/backend-core/src/middleware/contentSecurityPolicy.ts
@@ -195,8 +195,18 @@ export const contentSecurityPolicy = (async (ctx: Ctx, next: Next) => {
   }
 
   const cspHeader = Object.entries(directives)
-    .map(([key, sources]) => `${key} ${sources.join(" ")}`)
+    .map(([key, sources]) => `${key} ${Array.from(new Set(sources)).join(" ")}`)
     .join("; ")
   ctx.set("Content-Security-Policy", cspHeader)
   await next()
+
+  // CSP on JSON does not control the document that requested it and can make
+  // API response headers exceed proxy limits.
+  const responseType = ctx.response.type?.toLowerCase()
+  if (
+    !ctx.headerSent &&
+    (responseType === "application/json" || responseType?.endsWith("+json"))
+  ) {
+    ctx.remove("Content-Security-Policy")
+  }
 }) as Middleware

--- a/packages/backend-core/src/middleware/tests/contentSecurityPolicy.spec.ts
+++ b/packages/backend-core/src/middleware/tests/contentSecurityPolicy.spec.ts
@@ -44,7 +44,9 @@ describe("contentSecurityPolicy middleware", () => {
   beforeEach(() => {
     ctx = {
       state: {},
+      response: {},
       set: jest.fn(),
+      remove: jest.fn(),
     }
     next = jest.fn()
     // @ts-ignore
@@ -86,6 +88,45 @@ describe("contentSecurityPolicy middleware", () => {
     expect(cspHeader).toContain("worker-src blob:")
   })
 
+  it.each(["application/json", "application/problem+json"])(
+    "should remove CSP from %s responses",
+    async responseType => {
+      next.mockImplementation(() => {
+        ctx.response.type = responseType
+      })
+
+      await contentSecurityPolicy(ctx, next)
+
+      expect(ctx.state.nonce).toBe(mockNonce)
+      expect(ctx.remove).toHaveBeenCalledWith("Content-Security-Policy")
+    }
+  )
+
+  it("should retain CSP on HTML responses", async () => {
+    next.mockImplementation(() => {
+      ctx.response.type = "text/html"
+    })
+
+    await contentSecurityPolicy(ctx, next)
+
+    expect(ctx.set).toHaveBeenCalledWith(
+      "Content-Security-Policy",
+      expect.any(String)
+    )
+    expect(ctx.remove).not.toHaveBeenCalled()
+  })
+
+  it("should not modify headers after they have been sent", async () => {
+    next.mockImplementation(() => {
+      ctx.response.type = "application/json"
+      ctx.headerSent = true
+    })
+
+    await contentSecurityPolicy(ctx, next)
+
+    expect(ctx.remove).not.toHaveBeenCalled()
+  })
+
   it("should handle errors and log an error message", async () => {
     // Ctx setup to let us try and use CSP whitelist
     const fakeAppId = "app_sdfdsfsdfsdf"
@@ -112,7 +153,7 @@ describe("contentSecurityPolicy middleware", () => {
     consoleSpy.mockRestore()
   })
 
-  it("should add custom CSP whitelist", async () => {
+  it("should add and deduplicate custom CSP whitelist entries", async () => {
     const appId = "app_foo"
     const domain = "https://*.foo.bar"
 
@@ -141,7 +182,7 @@ describe("contentSecurityPolicy middleware", () => {
             id: "foo",
             name: "Test",
             location: "Head",
-            cspWhitelist: domain,
+            cspWhitelist: `${domain}\n${domain}`,
           },
         ],
       }


### PR DESCRIPTION
## Description
Reduces unnecessary API response header size while preserving CSP protection for document responses.

- Deduplicates exact CSP sources within each directive.
- Removes CSP from JSON responses when headers have not already been sent.
- Retains CSP for HTML and other non-JSON responses.
- Increases the cloud proxy response-header buffer for general API routes.
- Adds focused coverage for JSON, structured JSON, HTML, sent-header, and deduplication behavior.

The focused middleware test suite, lint, and formatting checks pass.

Fix for: `*617405 upstream sent too big header while reading response header from upstream`

## Addresses
Internal discussion

## Launchcontrol
Reduces unnecessary API response headers and improves proxy resilience while retaining CSP protection for document responses.