### PR TITLE
Add external PR ticket check and enforce issue linking

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,11 +23,12 @@ The standard CI Build job is what runs when you raise a PR to master.
 
 External pull requests from users who are not repository owners, members, or
 collaborators must reference an existing issue in this repository that is
-assigned to the pull request author. The issue may be linked with its full
-GitHub URL or a `#123` reference. Bot-authored pull requests are excluded. Pull
-requests without a valid assigned issue are tagged with the persistent
-`closed: missing-ticket` label, commented on, and closed. They can be reopened
-after an assigned issue is added.
+open, assigned to the pull request author, and does not have a `needs-triage`,
+`wontfix`, `out-of-scope`, or `closed-stale` label. The issue may be linked with
+its full GitHub URL or a `#123` reference. Bot-authored pull requests are
+excluded. Pull requests without a valid assigned issue are tagged with the
+persistent `closed: missing-ticket` label, commented on, and closed. They can be
+reopened after a valid assigned issue is added.
 
 ### Release Job (tag-release.yml)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,10 +26,11 @@ collaborators must reference an existing issue in this repository that is
 open, assigned to the pull request author, and does not have a `needs-triage`,
 `wontfix`, `out-of-scope`, or `closed-stale` label. The issue may be linked with
 its full GitHub URL or a `#123` reference. Bot-authored pull requests are
-excluded. Pull requests without a valid assigned issue are tagged with the
-persistent `closed: missing-ticket` label, commented on, and closed. They can be
-reopened after a valid assigned issue is added. Open external pull requests are
-also revalidated when a referenced issue is closed, receives a label, or has an
+excluded. At most ten distinct issue references are checked per pull request.
+Pull requests without a valid assigned issue are tagged with the persistent
+`closed: missing-ticket` label, commented on, and closed. They can be reopened
+after a valid assigned issue is added. Open external pull requests are also
+revalidated when a referenced issue is closed, receives a label, or has an
 assignee removed.
 
 ### Release Job (tag-release.yml)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,9 +29,7 @@ its full GitHub URL or a `#123` reference. Bot-authored pull requests are
 excluded. At most ten distinct issue references are checked per pull request.
 Pull requests without a valid assigned issue are tagged with the persistent
 `closed: missing-ticket` label, commented on, and closed. They can be reopened
-after a valid assigned issue is added. Open external pull requests are also
-revalidated when a referenced issue is closed, receives a label, or has an
-assignee removed.
+after a valid assigned issue is added.
 
 ### Release Job (tag-release.yml)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,11 +22,12 @@ The standard CI Build job is what runs when you raise a PR to master.
 ### External PR Ticket Check (external-pr-ticket.yml)
 
 External pull requests from users who are not repository owners, members, or
-collaborators must reference an existing issue in this repository. The issue may
-be linked with its full GitHub URL or a `#123` reference. Bot-authored pull
-requests are excluded. Pull requests without a valid issue reference are
-tagged with the persistent `closed: missing-ticket` label, commented on, and
-closed. They can be reopened after an issue is added.
+collaborators must reference an existing issue in this repository that is
+assigned to the pull request author. The issue may be linked with its full
+GitHub URL or a `#123` reference. Bot-authored pull requests are excluded. Pull
+requests without a valid assigned issue are tagged with the persistent
+`closed: missing-ticket` label, commented on, and closed. They can be reopened
+after an assigned issue is added.
 
 ### Release Job (tag-release.yml)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -25,7 +25,8 @@ External pull requests from users who are not repository owners, members, or
 collaborators must reference an existing issue in this repository. The issue may
 be linked with its full GitHub URL or a `#123` reference. Bot-authored pull
 requests are excluded. Pull requests without a valid issue reference are
-commented on and closed, and can be reopened after an issue is added.
+tagged with the persistent `closed: missing-ticket` label, commented on, and
+closed. They can be reopened after an issue is added.
 
 ### Release Job (tag-release.yml)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,6 +19,14 @@ The standard CI Build job is what runs when you raise a PR to master.
 - Run the integration tests
 - Check that the pro and account portal submodules are pointing to the lastest master head
 
+### External PR Ticket Check (external-pr-ticket.yml)
+
+External pull requests from users who are not repository owners, members, or
+collaborators must reference an existing issue in this repository. The issue may
+be linked with its full GitHub URL or a `#123` reference. Bot-authored pull
+requests are excluded. Pull requests without a valid issue reference are
+commented on and closed, and can be reopened after an issue is added.
+
 ### Release Job (tag-release.yml)
 
 Triggers:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,7 +28,9 @@ open, assigned to the pull request author, and does not have a `needs-triage`,
 its full GitHub URL or a `#123` reference. Bot-authored pull requests are
 excluded. Pull requests without a valid assigned issue are tagged with the
 persistent `closed: missing-ticket` label, commented on, and closed. They can be
-reopened after a valid assigned issue is added.
+reopened after a valid assigned issue is added. Open external pull requests are
+also revalidated when a referenced issue is closed, receives a label, or has an
+assignee removed.
 
 ### Release Job (tag-release.yml)
 

--- a/.github/workflows/external-pr-ticket.yml
+++ b/.github/workflows/external-pr-ticket.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo
+            const pullRequestNumber = context.payload.pull_request.number
             const maxReferencedIssues = 10
             const invalidIssueLabels = new Set([
               "needs-triage",
@@ -34,159 +35,112 @@ jobs:
               "closed-stale",
             ])
 
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullRequestNumber,
+            })
+            const pullRequestAuthor = pullRequest.user.login.toLowerCase()
+            const body = pullRequest.body || ""
+            const issueNumbers = new Set()
             const escapedOwner = owner.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
             const escapedRepo = repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-            const issueUrlPattern = new RegExp(
-              `https?:\\/\\/github\\.com\\/${escapedOwner}\\/${escapedRepo}\\/issues\\/(\\d+)`,
-              "gi"
-            )
-            const shortReferencePattern = /(?:^|[\s(])#(\d+)\b/gm
+            const patterns = [
+              new RegExp(
+                `https?:\\/\\/github\\.com\\/${escapedOwner}\\/${escapedRepo}\\/issues\\/(\\d+)`,
+                "gi"
+              ),
+              /(?:^|[\s(])#(\d+)\b/gm,
+            ]
 
-            const getReferencedIssueNumbers = body => {
-              const issueNumbers = new Set()
-
-              for (const match of (body || "").matchAll(issueUrlPattern)) {
+            for (const pattern of patterns) {
+              for (const match of body.matchAll(pattern)) {
                 issueNumbers.add(Number(match[1]))
                 if (issueNumbers.size === maxReferencedIssues) break
               }
-              if (issueNumbers.size < maxReferencedIssues) {
-                for (const match of (body || "").matchAll(shortReferencePattern)) {
-                  issueNumbers.add(Number(match[1]))
-                  if (issueNumbers.size === maxReferencedIssues) break
-                }
-              }
-
-              return issueNumbers
+              if (issueNumbers.size === maxReferencedIssues) break
             }
 
-            const findValidIssue = async pullRequest => {
-              const pullRequestAuthor = pullRequest.user.login.toLowerCase()
-              const issueNumbers = getReferencedIssueNumbers(pullRequest.body)
-
-              for (const issueNumber of issueNumbers) {
-                try {
-                  const { data: issue } = await github.rest.issues.get({
-                    owner,
-                    repo,
-                    issue_number: issueNumber,
-                  })
-                  const isAssignedToAuthor = issue.assignees?.some(
-                    assignee => assignee.login.toLowerCase() === pullRequestAuthor
-                  )
-                  const hasInvalidLabel = issue.labels.some(issueLabel => {
-                    const labelName = typeof issueLabel === "string"
-                      ? issueLabel
-                      : issueLabel.name
-                    return invalidIssueLabels.has(labelName.toLowerCase())
-                  })
-                  const isValidIssue = !issue.pull_request &&
-                    issue.state === "open" &&
-                    isAssignedToAuthor &&
-                    !hasInvalidLabel
-
-                  if (isValidIssue) return issue
-                } catch (error) {
-                  if (error.status !== 404) throw error
-                }
-              }
-
-              return undefined
-            }
-
-            const enforcePullRequest = async pullRequestNumber => {
-              let { data: pullRequest } = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: pullRequestNumber,
-              })
-              let validIssue = await findValidIssue(pullRequest)
-
-              if (validIssue) {
-                core.info(`Found valid issue #${validIssue.number}`)
-                return
-              }
-
-              // Refresh and revalidate before mutating in case the PR was edited
-              // while this run was checking its referenced issues.
-              const refreshedPullRequest = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: pullRequestNumber,
-              })
-              pullRequest = refreshedPullRequest.data
-
-              if (pullRequest.state !== "open") {
-                core.info("Pull request is no longer open")
-                return
-              }
-
-              validIssue = await findValidIssue(pullRequest)
-              if (validIssue) {
-                core.info(`Found valid issue #${validIssue.number} after refresh`)
-                return
-              }
-
-              const label = {
-                name: "closed: missing-ticket",
-                color: "B60205",
-                description: "External PR closed because it lacked an assigned valid issue",
-              }
-
+            for (const issueNumber of issueNumbers) {
               try {
-                await github.rest.issues.getLabel({ owner, repo, name: label.name })
+                const { data: issue } = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                })
+                const isAssignedToAuthor = issue.assignees?.some(
+                  assignee => assignee.login.toLowerCase() === pullRequestAuthor
+                )
+                const hasInvalidLabel = issue.labels.some(issueLabel => {
+                  const labelName = typeof issueLabel === "string"
+                    ? issueLabel
+                    : issueLabel.name
+                  return invalidIssueLabels.has(labelName.toLowerCase())
+                })
+                const isValidIssue = !issue.pull_request &&
+                  issue.state === "open" &&
+                  isAssignedToAuthor &&
+                  !hasInvalidLabel
+
+                if (isValidIssue) {
+                  core.info(`Found valid issue #${issue.number}`)
+                  return
+                }
               } catch (error) {
                 if (error.status !== 404) throw error
-
-                try {
-                  await github.rest.issues.createLabel({ owner, repo, ...label })
-                } catch (createError) {
-                  // Another workflow run may have created the label concurrently.
-                  if (createError.status !== 422) throw createError
-                }
               }
+            }
 
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: pullRequest.number,
-                labels: [label.name],
-              })
+            if (pullRequest.state !== "open") return
 
-              const marker = "<!-- external-pr-ticket-check -->"
+            const label = {
+              name: "closed: missing-ticket",
+              color: "B60205",
+              description: "External PR closed because it lacked an assigned valid issue",
+            }
+
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label.name })
+            } catch (error) {
+              if (error.status !== 404) throw error
+              try {
+                await github.rest.issues.createLabel({ owner, repo, ...label })
+              } catch (createError) {
+                if (createError.status !== 422) throw createError
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pullRequestNumber,
+              labels: [label.name],
+            })
+
+            const marker = "<!-- external-pr-ticket-check -->"
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: pullRequestNumber, per_page: 100 }
+            )
+
+            if (!comments.some(comment => comment.body?.includes(marker))) {
               const message = [
                 marker,
-                "Thanks for contributing to Budibase. External pull requests must reference an open issue in this repository that is assigned to the pull request author. The issue must have completed triage and must not be marked `wontfix`, `out-of-scope`, or `closed-stale`. Add the issue in the **Addresses** section of the pull request description using its full URL or the `#123` format.",
+                "Thanks for contributing to Budibase. External pull requests must reference an open issue in this repository that is assigned to the pull request author. The issue must have completed triage and must not be marked `wontfix`, `out-of-scope`, or `closed-stale`. Add the issue in the **Addresses** section using its full URL or the `#123` format.",
                 "",
                 "This pull request has been closed because it does not reference a valid assigned issue. Once an assigned issue has been linked, you can reopen the pull request.",
               ].join("\n")
-
-              const comments = await github.paginate(
-                github.rest.issues.listComments,
-                {
-                  owner,
-                  repo,
-                  issue_number: pullRequest.number,
-                  per_page: 100,
-                }
-              )
-
-              if (!comments.some(comment => comment.body?.includes(marker))) {
-                await github.rest.issues.createComment({
-                  owner,
-                  repo,
-                  issue_number: pullRequest.number,
-                  body: message,
-                })
-              }
-
-              if (pullRequest.state === "open") {
-                await github.rest.pulls.update({
-                  owner,
-                  repo,
-                  pull_number: pullRequest.number,
-                  state: "closed",
-                })
-              }
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pullRequestNumber,
+                body: message,
+              })
             }
 
-            await enforcePullRequest(context.payload.pull_request.number)
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: pullRequestNumber,
+              state: "closed",
+            })

--- a/.github/workflows/external-pr-ticket.yml
+++ b/.github/workflows/external-pr-ticket.yml
@@ -23,6 +23,7 @@ jobs:
           script: |
             const { owner, repo } = context.repo
             const pullRequest = context.payload.pull_request
+            const pullRequestAuthor = pullRequest.user.login.toLowerCase()
             const body = pullRequest.body || ""
             const issueNumbers = new Set()
 
@@ -49,7 +50,10 @@ jobs:
                   repo,
                   issue_number: issueNumber,
                 })
-                if (!issue.pull_request) {
+                const isAssignedToAuthor = issue.assignees?.some(
+                  assignee => assignee.login.toLowerCase() === pullRequestAuthor
+                )
+                if (!issue.pull_request && isAssignedToAuthor) {
                   validIssue = issue
                   break
                 }
@@ -66,7 +70,7 @@ jobs:
             const label = {
               name: "closed: missing-ticket",
               color: "B60205",
-              description: "External PR closed because it did not reference a valid issue",
+              description: "External PR closed because it lacked an assigned valid issue",
             }
 
             try {
@@ -91,9 +95,9 @@ jobs:
 
             const marker = "<!-- external-pr-ticket-check -->"
             const message = `${marker}
-            Thanks for contributing to Budibase. External pull requests must reference an existing issue in this repository in the **Addresses** section of the pull request description. References can use a full issue URL or the \`#123\` format.
+            Thanks for contributing to Budibase. External pull requests must reference an existing issue in this repository that is assigned to the pull request author. Add the issue in the **Addresses** section of the pull request description using its full URL or the \`#123\` format.
 
-            This pull request has been closed because it does not reference a valid issue. Once an issue has been linked, you can reopen the pull request.`
+            This pull request has been closed because it does not reference a valid assigned issue. Once an assigned issue has been linked, you can reopen the pull request.`
 
             const comments = await github.paginate(
               github.rest.issues.listComments,

--- a/.github/workflows/external-pr-ticket.yml
+++ b/.github/workflows/external-pr-ticket.yml
@@ -1,0 +1,98 @@
+name: External PR ticket check
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-ticket:
+    if: |
+      github.event.pull_request.user.type != 'Bot' &&
+      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: write
+    steps:
+      - name: Check for a valid linked issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const pullRequest = context.payload.pull_request
+            const body = pullRequest.body || ""
+            const issueNumbers = new Set()
+
+            const escapedOwner = owner.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+            const escapedRepo = repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+            const issueUrlPattern = new RegExp(
+              `https?:\\/\\/github\\.com\\/${escapedOwner}\\/${escapedRepo}\\/issues\\/(\\d+)`,
+              "gi"
+            )
+            const shortReferencePattern = /(?:^|[\s(])#(\d+)\b/gm
+
+            for (const match of body.matchAll(issueUrlPattern)) {
+              issueNumbers.add(Number(match[1]))
+            }
+            for (const match of body.matchAll(shortReferencePattern)) {
+              issueNumbers.add(Number(match[1]))
+            }
+
+            let validIssue
+            for (const issueNumber of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                })
+                if (!issue.pull_request) {
+                  validIssue = issue
+                  break
+                }
+              } catch (error) {
+                if (error.status !== 404) throw error
+              }
+            }
+
+            if (validIssue) {
+              core.info(`Found valid issue #${validIssue.number}`)
+              return
+            }
+
+            const marker = "<!-- external-pr-ticket-check -->"
+            const message = `${marker}
+            Thanks for contributing to Budibase. External pull requests must reference an existing issue in this repository in the **Addresses** section of the pull request description. References can use a full issue URL or the \`#123\` format.
+
+            This pull request has been closed because it does not reference a valid issue. Once an issue has been linked, you can reopen the pull request.`
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number: pullRequest.number,
+                per_page: 100,
+              }
+            )
+
+            if (!comments.some(comment => comment.body?.includes(marker))) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pullRequest.number,
+                body: message,
+              })
+            }
+
+            if (pullRequest.state === "open") {
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: pullRequest.number,
+                state: "closed",
+              })
+            }

--- a/.github/workflows/external-pr-ticket.yml
+++ b/.github/workflows/external-pr-ticket.yml
@@ -14,7 +14,7 @@ jobs:
       !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     permissions:
-      issues: read
+      issues: write
       pull-requests: write
     steps:
       - name: Check for a valid linked issue
@@ -62,6 +62,32 @@ jobs:
               core.info(`Found valid issue #${validIssue.number}`)
               return
             }
+
+            const label = {
+              name: "closed: missing-ticket",
+              color: "B60205",
+              description: "External PR closed because it did not reference a valid issue",
+            }
+
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label.name })
+            } catch (error) {
+              if (error.status !== 404) throw error
+
+              try {
+                await github.rest.issues.createLabel({ owner, repo, ...label })
+              } catch (createError) {
+                // Another workflow run may have created the label concurrently.
+                if (createError.status !== 422) throw createError
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pullRequest.number,
+              labels: [label.name],
+            })
 
             const marker = "<!-- external-pr-ticket-check -->"
             const message = `${marker}

--- a/.github/workflows/external-pr-ticket.yml
+++ b/.github/workflows/external-pr-ticket.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -22,10 +26,7 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo
-            const pullRequest = context.payload.pull_request
-            const pullRequestAuthor = pullRequest.user.login.toLowerCase()
-            const body = pullRequest.body || ""
-            const issueNumbers = new Set()
+            const pullRequestNumber = context.payload.pull_request.number
             const invalidIssueLabels = new Set([
               "needs-triage",
               "wontfix",
@@ -41,46 +42,77 @@ jobs:
             )
             const shortReferencePattern = /(?:^|[\s(])#(\d+)\b/gm
 
-            for (const match of body.matchAll(issueUrlPattern)) {
-              issueNumbers.add(Number(match[1]))
-            }
-            for (const match of body.matchAll(shortReferencePattern)) {
-              issueNumbers.add(Number(match[1]))
-            }
+            const findValidIssue = async pullRequest => {
+              const pullRequestAuthor = pullRequest.user.login.toLowerCase()
+              const body = pullRequest.body || ""
+              const issueNumbers = new Set()
 
-            let validIssue
-            for (const issueNumber of issueNumbers) {
-              try {
-                const { data: issue } = await github.rest.issues.get({
-                  owner,
-                  repo,
-                  issue_number: issueNumber,
-                })
-                const isAssignedToAuthor = issue.assignees?.some(
-                  assignee => assignee.login.toLowerCase() === pullRequestAuthor
-                )
-                const hasInvalidLabel = issue.labels.some(issueLabel => {
-                  const labelName = typeof issueLabel === "string"
-                    ? issueLabel
-                    : issueLabel.name
-                  return invalidIssueLabels.has(labelName.toLowerCase())
-                })
-                const isValidIssue = !issue.pull_request &&
-                  issue.state === "open" &&
-                  isAssignedToAuthor &&
-                  !hasInvalidLabel
-
-                if (isValidIssue) {
-                  validIssue = issue
-                  break
-                }
-              } catch (error) {
-                if (error.status !== 404) throw error
+              for (const match of body.matchAll(issueUrlPattern)) {
+                issueNumbers.add(Number(match[1]))
               }
+              for (const match of body.matchAll(shortReferencePattern)) {
+                issueNumbers.add(Number(match[1]))
+              }
+
+              for (const issueNumber of issueNumbers) {
+                try {
+                  const { data: issue } = await github.rest.issues.get({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                  })
+                  const isAssignedToAuthor = issue.assignees?.some(
+                    assignee => assignee.login.toLowerCase() === pullRequestAuthor
+                  )
+                  const hasInvalidLabel = issue.labels.some(issueLabel => {
+                    const labelName = typeof issueLabel === "string"
+                      ? issueLabel
+                      : issueLabel.name
+                    return invalidIssueLabels.has(labelName.toLowerCase())
+                  })
+                  const isValidIssue = !issue.pull_request &&
+                    issue.state === "open" &&
+                    isAssignedToAuthor &&
+                    !hasInvalidLabel
+
+                  if (isValidIssue) return issue
+                } catch (error) {
+                  if (error.status !== 404) throw error
+                }
+              }
+
+              return undefined
             }
+
+            let { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullRequestNumber,
+            })
+            let validIssue = await findValidIssue(pullRequest)
 
             if (validIssue) {
               core.info(`Found valid issue #${validIssue.number}`)
+              return
+            }
+
+            // Refresh and revalidate before mutating in case the PR was edited
+            // while this run was checking its referenced issues.
+            const refreshedPullRequest = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullRequestNumber,
+            })
+            pullRequest = refreshedPullRequest.data
+
+            if (pullRequest.state !== "open") {
+              core.info("Pull request is no longer open")
+              return
+            }
+
+            validIssue = await findValidIssue(pullRequest)
+            if (validIssue) {
+              core.info(`Found valid issue #${validIssue.number} after refresh`)
               return
             }
 

--- a/.github/workflows/external-pr-ticket.yml
+++ b/.github/workflows/external-pr-ticket.yml
@@ -3,11 +3,9 @@ name: External PR ticket check
 on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
-  issues:
-    types: [closed, labeled, unassigned]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
@@ -16,9 +14,8 @@ permissions:
 jobs:
   validate-ticket:
     if: |
-      github.event_name == 'issues' ||
-      (github.event.pull_request.user.type != 'Bot' &&
-      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
+      github.event.pull_request.user.type != 'Bot' &&
+      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -29,7 +26,6 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo
-            const internalAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"])
             const maxReferencedIssues = 10
             const invalidIssueLabels = new Set([
               "needs-triage",
@@ -193,32 +189,4 @@ jobs:
               }
             }
 
-            let pullRequestNumbers
-            if (context.eventName === "issues") {
-              const changedLabel = context.payload.label?.name.toLowerCase()
-              if (changedLabel && !invalidIssueLabels.has(changedLabel)) {
-                core.info(`Label ${changedLabel} does not invalidate linked PRs`)
-                return
-              }
-
-              const issueNumber = context.payload.issue.number
-              const openPullRequests = await github.paginate(
-                github.rest.pulls.list,
-                { owner, repo, state: "open", per_page: 100 }
-              )
-              pullRequestNumbers = openPullRequests
-                .filter(pullRequest => pullRequest.user.type !== "Bot")
-                .filter(pullRequest => !internalAssociations.has(
-                  pullRequest.author_association
-                ))
-                .filter(pullRequest => getReferencedIssueNumbers(
-                  pullRequest.body
-                ).has(issueNumber))
-                .map(pullRequest => pullRequest.number)
-            } else {
-              pullRequestNumbers = [context.payload.pull_request.number]
-            }
-
-            for (const pullRequestNumber of pullRequestNumbers) {
-              await enforcePullRequest(pullRequestNumber)
-            }
+            await enforcePullRequest(context.payload.pull_request.number)

--- a/.github/workflows/external-pr-ticket.yml
+++ b/.github/workflows/external-pr-ticket.yml
@@ -45,19 +45,13 @@ jobs:
             const issueNumbers = new Set()
             const escapedOwner = owner.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
             const escapedRepo = repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-            const patterns = [
-              new RegExp(
-                `https?:\\/\\/github\\.com\\/${escapedOwner}\\/${escapedRepo}\\/issues\\/(\\d+)`,
-                "gi"
-              ),
-              /(?:^|[\s(])#(\d+)\b/gm,
-            ]
+            const issueReferencePattern = new RegExp(
+              `https?:\\/\\/github\\.com\\/${escapedOwner}\\/${escapedRepo}\\/issues\\/(\\d+)|(?:^|[\\s(])#(\\d+)\\b`,
+              "gim"
+            )
 
-            for (const pattern of patterns) {
-              for (const match of body.matchAll(pattern)) {
-                issueNumbers.add(Number(match[1]))
-                if (issueNumbers.size === maxReferencedIssues) break
-              }
+            for (const match of body.matchAll(issueReferencePattern)) {
+              issueNumbers.add(Number(match[1] || match[2]))
               if (issueNumbers.size === maxReferencedIssues) break
             }
 

--- a/.github/workflows/external-pr-ticket.yml
+++ b/.github/workflows/external-pr-ticket.yml
@@ -30,6 +30,7 @@ jobs:
           script: |
             const { owner, repo } = context.repo
             const internalAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"])
+            const maxReferencedIssues = 10
             const invalidIssueLabels = new Set([
               "needs-triage",
               "wontfix",
@@ -50,9 +51,13 @@ jobs:
 
               for (const match of (body || "").matchAll(issueUrlPattern)) {
                 issueNumbers.add(Number(match[1]))
+                if (issueNumbers.size === maxReferencedIssues) break
               }
-              for (const match of (body || "").matchAll(shortReferencePattern)) {
-                issueNumbers.add(Number(match[1]))
+              if (issueNumbers.size < maxReferencedIssues) {
+                for (const match of (body || "").matchAll(shortReferencePattern)) {
+                  issueNumbers.add(Number(match[1]))
+                  if (issueNumbers.size === maxReferencedIssues) break
+                }
               }
 
               return issueNumbers

--- a/.github/workflows/external-pr-ticket.yml
+++ b/.github/workflows/external-pr-ticket.yml
@@ -3,9 +3,11 @@ name: External PR ticket check
 on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
+  issues:
+    types: [closed, labeled, unassigned]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 permissions:
@@ -14,8 +16,9 @@ permissions:
 jobs:
   validate-ticket:
     if: |
-      github.event.pull_request.user.type != 'Bot' &&
-      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      github.event_name == 'issues' ||
+      (github.event.pull_request.user.type != 'Bot' &&
+      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -26,7 +29,7 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo
-            const pullRequestNumber = context.payload.pull_request.number
+            const internalAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"])
             const invalidIssueLabels = new Set([
               "needs-triage",
               "wontfix",
@@ -42,17 +45,22 @@ jobs:
             )
             const shortReferencePattern = /(?:^|[\s(])#(\d+)\b/gm
 
-            const findValidIssue = async pullRequest => {
-              const pullRequestAuthor = pullRequest.user.login.toLowerCase()
-              const body = pullRequest.body || ""
+            const getReferencedIssueNumbers = body => {
               const issueNumbers = new Set()
 
-              for (const match of body.matchAll(issueUrlPattern)) {
+              for (const match of (body || "").matchAll(issueUrlPattern)) {
                 issueNumbers.add(Number(match[1]))
               }
-              for (const match of body.matchAll(shortReferencePattern)) {
+              for (const match of (body || "").matchAll(shortReferencePattern)) {
                 issueNumbers.add(Number(match[1]))
               }
+
+              return issueNumbers
+            }
+
+            const findValidIssue = async pullRequest => {
+              const pullRequestAuthor = pullRequest.user.login.toLowerCase()
+              const issueNumbers = getReferencedIssueNumbers(pullRequest.body)
 
               for (const issueNumber of issueNumbers) {
                 try {
@@ -84,94 +92,128 @@ jobs:
               return undefined
             }
 
-            let { data: pullRequest } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: pullRequestNumber,
-            })
-            let validIssue = await findValidIssue(pullRequest)
+            const enforcePullRequest = async pullRequestNumber => {
+              let { data: pullRequest } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pullRequestNumber,
+              })
+              let validIssue = await findValidIssue(pullRequest)
 
-            if (validIssue) {
-              core.info(`Found valid issue #${validIssue.number}`)
-              return
-            }
+              if (validIssue) {
+                core.info(`Found valid issue #${validIssue.number}`)
+                return
+              }
 
-            // Refresh and revalidate before mutating in case the PR was edited
-            // while this run was checking its referenced issues.
-            const refreshedPullRequest = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: pullRequestNumber,
-            })
-            pullRequest = refreshedPullRequest.data
+              // Refresh and revalidate before mutating in case the PR was edited
+              // while this run was checking its referenced issues.
+              const refreshedPullRequest = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pullRequestNumber,
+              })
+              pullRequest = refreshedPullRequest.data
 
-            if (pullRequest.state !== "open") {
-              core.info("Pull request is no longer open")
-              return
-            }
+              if (pullRequest.state !== "open") {
+                core.info("Pull request is no longer open")
+                return
+              }
 
-            validIssue = await findValidIssue(pullRequest)
-            if (validIssue) {
-              core.info(`Found valid issue #${validIssue.number} after refresh`)
-              return
-            }
+              validIssue = await findValidIssue(pullRequest)
+              if (validIssue) {
+                core.info(`Found valid issue #${validIssue.number} after refresh`)
+                return
+              }
 
-            const label = {
-              name: "closed: missing-ticket",
-              color: "B60205",
-              description: "External PR closed because it lacked an assigned valid issue",
-            }
-
-            try {
-              await github.rest.issues.getLabel({ owner, repo, name: label.name })
-            } catch (error) {
-              if (error.status !== 404) throw error
+              const label = {
+                name: "closed: missing-ticket",
+                color: "B60205",
+                description: "External PR closed because it lacked an assigned valid issue",
+              }
 
               try {
-                await github.rest.issues.createLabel({ owner, repo, ...label })
-              } catch (createError) {
-                // Another workflow run may have created the label concurrently.
-                if (createError.status !== 422) throw createError
+                await github.rest.issues.getLabel({ owner, repo, name: label.name })
+              } catch (error) {
+                if (error.status !== 404) throw error
+
+                try {
+                  await github.rest.issues.createLabel({ owner, repo, ...label })
+                } catch (createError) {
+                  // Another workflow run may have created the label concurrently.
+                  if (createError.status !== 422) throw createError
+                }
               }
-            }
 
-            await github.rest.issues.addLabels({
-              owner,
-              repo,
-              issue_number: pullRequest.number,
-              labels: [label.name],
-            })
-
-            const marker = "<!-- external-pr-ticket-check -->"
-            const message = `${marker}
-            Thanks for contributing to Budibase. External pull requests must reference an open issue in this repository that is assigned to the pull request author. The issue must have completed triage and must not be marked \`wontfix\`, \`out-of-scope\`, or \`closed-stale\`. Add the issue in the **Addresses** section of the pull request description using its full URL or the \`#123\` format.
-
-            This pull request has been closed because it does not reference a valid assigned issue. Once an assigned issue has been linked, you can reopen the pull request.`
-
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
+              await github.rest.issues.addLabels({
                 owner,
                 repo,
                 issue_number: pullRequest.number,
-                per_page: 100,
-              }
-            )
-
-            if (!comments.some(comment => comment.body?.includes(marker))) {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: pullRequest.number,
-                body: message,
+                labels: [label.name],
               })
+
+              const marker = "<!-- external-pr-ticket-check -->"
+              const message = [
+                marker,
+                "Thanks for contributing to Budibase. External pull requests must reference an open issue in this repository that is assigned to the pull request author. The issue must have completed triage and must not be marked `wontfix`, `out-of-scope`, or `closed-stale`. Add the issue in the **Addresses** section of the pull request description using its full URL or the `#123` format.",
+                "",
+                "This pull request has been closed because it does not reference a valid assigned issue. Once an assigned issue has been linked, you can reopen the pull request.",
+              ].join("\n")
+
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner,
+                  repo,
+                  issue_number: pullRequest.number,
+                  per_page: 100,
+                }
+              )
+
+              if (!comments.some(comment => comment.body?.includes(marker))) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pullRequest.number,
+                  body: message,
+                })
+              }
+
+              if (pullRequest.state === "open") {
+                await github.rest.pulls.update({
+                  owner,
+                  repo,
+                  pull_number: pullRequest.number,
+                  state: "closed",
+                })
+              }
             }
 
-            if (pullRequest.state === "open") {
-              await github.rest.pulls.update({
-                owner,
-                repo,
-                pull_number: pullRequest.number,
-                state: "closed",
-              })
+            let pullRequestNumbers
+            if (context.eventName === "issues") {
+              const changedLabel = context.payload.label?.name.toLowerCase()
+              if (changedLabel && !invalidIssueLabels.has(changedLabel)) {
+                core.info(`Label ${changedLabel} does not invalidate linked PRs`)
+                return
+              }
+
+              const issueNumber = context.payload.issue.number
+              const openPullRequests = await github.paginate(
+                github.rest.pulls.list,
+                { owner, repo, state: "open", per_page: 100 }
+              )
+              pullRequestNumbers = openPullRequests
+                .filter(pullRequest => pullRequest.user.type !== "Bot")
+                .filter(pullRequest => !internalAssociations.has(
+                  pullRequest.author_association
+                ))
+                .filter(pullRequest => getReferencedIssueNumbers(
+                  pullRequest.body
+                ).has(issueNumber))
+                .map(pullRequest => pullRequest.number)
+            } else {
+              pullRequestNumbers = [context.payload.pull_request.number]
+            }
+
+            for (const pullRequestNumber of pullRequestNumbers) {
+              await enforcePullRequest(pullRequestNumber)
             }

--- a/.github/workflows/external-pr-ticket.yml
+++ b/.github/workflows/external-pr-ticket.yml
@@ -26,6 +26,12 @@ jobs:
             const pullRequestAuthor = pullRequest.user.login.toLowerCase()
             const body = pullRequest.body || ""
             const issueNumbers = new Set()
+            const invalidIssueLabels = new Set([
+              "needs-triage",
+              "wontfix",
+              "out-of-scope",
+              "closed-stale",
+            ])
 
             const escapedOwner = owner.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
             const escapedRepo = repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
@@ -53,7 +59,18 @@ jobs:
                 const isAssignedToAuthor = issue.assignees?.some(
                   assignee => assignee.login.toLowerCase() === pullRequestAuthor
                 )
-                if (!issue.pull_request && isAssignedToAuthor) {
+                const hasInvalidLabel = issue.labels.some(issueLabel => {
+                  const labelName = typeof issueLabel === "string"
+                    ? issueLabel
+                    : issueLabel.name
+                  return invalidIssueLabels.has(labelName.toLowerCase())
+                })
+                const isValidIssue = !issue.pull_request &&
+                  issue.state === "open" &&
+                  isAssignedToAuthor &&
+                  !hasInvalidLabel
+
+                if (isValidIssue) {
                   validIssue = issue
                   break
                 }
@@ -95,7 +112,7 @@ jobs:
 
             const marker = "<!-- external-pr-ticket-check -->"
             const message = `${marker}
-            Thanks for contributing to Budibase. External pull requests must reference an existing issue in this repository that is assigned to the pull request author. Add the issue in the **Addresses** section of the pull request description using its full URL or the \`#123\` format.
+            Thanks for contributing to Budibase. External pull requests must reference an open issue in this repository that is assigned to the pull request author. The issue must have completed triage and must not be marked \`wontfix\`, \`out-of-scope\`, or \`closed-stale\`. Add the issue in the **Addresses** section of the pull request description using its full URL or the \`#123\` format.
 
             This pull request has been closed because it does not reference a valid assigned issue. Once an assigned issue has been linked, you can reopen the pull request.`
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,6 +17,7 @@ If you do plan to raise a pull request, please take a look at the guide below.
 ## Table of contents
 
 - [Vouching](#vouching)
+- [External PR Ticket Check](#external-pr-ticket-check)
 - [Where to start](#not-sure-where-to-start)
 - [Contributor Licence Agreement](#contributor-license-agreement-cla)
 - [Glossary of Terms](#glossary-of-terms)
@@ -31,6 +32,26 @@ You do not need to be vouched for before opening or merging a pull request. Pull
 Each contributor may have only one open pull request at a time.
 
 All pull requests remain subject to our normal review and contribution requirements.
+
+## External PR Ticket Check
+
+Pull requests from external contributors must reference an existing issue in
+this repository. The issue must:
+
+- Be open.
+- Be assigned to the pull request author.
+- Have completed triage and not have a `needs-triage`, `wontfix`,
+  `out-of-scope`, or `closed-stale` label.
+
+Add the issue to the **Addresses** section of the pull request description using
+its full GitHub URL or a `#123` reference. At most ten distinct issue references
+are checked per pull request.
+
+Pull requests without a valid assigned issue are tagged with
+`closed: missing-ticket`, given an explanatory comment, and closed automatically.
+After linking a valid assigned issue, you can reopen the pull request. Bot-authored
+pull requests and pull requests from repository owners, members, and collaborators
+are excluded from this check.
 
 ## Not Sure Where to Start?
 


### PR DESCRIPTION
## Description
Adds an automated check for pull requests opened by external contributors.

External PRs must reference a valid GitHub issue that:
- Is open.
- Is assigned to the PR author.
- Has completed triage.
- Is not labelled wontfix, out-of-scope, or closed-stale.

PRs that do not meet these requirements are labelled closed: missing-ticket, given an explanatory comment, and closed. The label is retained for reporting purposes, and the PR can be reopened once a valid assigned issue is linked.

Repository owners, members, collaborators, and bot accounts are excluded from the check.

The workflow was validated with YAML parsing, reference-extraction checks, and ticket-validity checks.

## Launchcontrol
External contributions must now be linked to an approved, assigned issue before they can proceed. This reduces unsolicited PR noise while giving contributors clear instructions for reopening their PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workflow to ensure external PRs link a valid, open issue assigned to the author; non-compliant PRs are labeled `closed: missing-ticket`, commented, and closed. Simplifies the check to run only on PR events and updates CI and contributor docs.

- **New Features**
  - `external-pr-ticket.yml` validates external PRs link an issue that is open, assigned to the author, and not labeled `needs-triage`, `wontfix`, `out-of-scope`, or `closed-stale`; accepts full URLs or `#123` references (max 10).
  - Excludes owners, members, collaborators, and bot accounts; on failure, adds the label, comments with instructions, and closes the PR (can be reopened after linking a valid issue).

- **Refactors**
  - Removed redundant issue-event handling; streamlined validation and issue-reference extraction, with action concurrency, improved error handling, and de-duplicated comments.

<sup>Written for commit 8108c527e42efa635e1b7228a06d705962d635cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

