### PR TITLE
fix(proxy): set explicit `proxy_buffers` to avoid default fallback

### DIFF
--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -196,6 +196,7 @@ http {
 
       # Allow for CSP and other response headers on general API routes
       proxy_buffer_size 16k;
+      proxy_buffers 4 32k;
 
       # 120s timeout on API requests
       proxy_read_timeout ${PROXY_TIMEOUT_SECONDS}s;


### PR DESCRIPTION
## Description
Not setting explicit `proxy_buffers` breaks Nginx since the default is less than the newly introduced value of 16k for the `proxy_busy_buffers_size`. 

Closes https://github.com/Budibase/budibase/issues/17672

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set explicit Nginx buffer pool with `proxy_buffers 4 32k` on API routes to avoid small default buffers. This prevents startup errors after raising `proxy_buffer_size` and `proxy_busy_buffers_size` to 16k.

- **Bug Fixes**
  - Add `proxy_buffers 4 32k` to align with 16k buffer sizes and avoid “proxy_busy_buffers_size is bigger than the size of all proxy_buffers” errors.

<sup>Written for commit 29e0fcdffefe6e1c99e4d3a759648326f52607ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

