### PR TITLE
Fix external PR ticket checks, excluding all internal PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,12 +21,11 @@ The standard CI Build job is what runs when you raise a PR to master.
 
 ### External PR Ticket Check (external-pr-ticket.yml)
 
-External pull requests from users who are not repository owners, members, or
-collaborators must reference an existing issue in this repository that is
-open, assigned to the pull request author, and does not have a `needs-triage`,
-`wontfix`, `out-of-scope`, or `closed-stale` label. The issue may be linked with
-its full GitHub URL or a `#123` reference. Bot-authored pull requests are
-excluded. At most ten distinct issue references are checked per pull request.
+Pull requests whose branches come from outside this repository must reference an
+existing issue in this repository that is open, assigned to the pull request
+author, and does not have a `needs-triage`, `wontfix`, `out-of-scope`, or
+`closed-stale` label. The issue may be linked with its full GitHub URL or a `#123`
+reference. At most ten distinct issue references are checked per pull request.
 Pull requests without a valid assigned issue are tagged with the persistent
 `closed: missing-ticket` label, commented on, and closed. They can be reopened
 after a valid assigned issue is added.

--- a/.github/workflows/external-pr-ticket.yml
+++ b/.github/workflows/external-pr-ticket.yml
@@ -13,9 +13,7 @@ permissions:
 
 jobs:
   validate-ticket:
-    if: |
-      github.event.pull_request.user.type != 'Bot' &&
-      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+    if: github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,8 +35,8 @@ All pull requests remain subject to our normal review and contribution requireme
 
 ## External PR Ticket Check
 
-Pull requests from external contributors must reference an existing issue in
-this repository. The issue must:
+Pull requests whose branches come from outside this repository must reference an
+existing issue in this repository. The issue must:
 
 - Be open.
 - Be assigned to the pull request author.
@@ -49,9 +49,8 @@ are checked per pull request.
 
 Pull requests without a valid assigned issue are tagged with
 `closed: missing-ticket`, given an explanatory comment, and closed automatically.
-After linking a valid assigned issue, you can reopen the pull request. Bot-authored
-pull requests and pull requests from repository owners, members, and collaborators
-are excluded from this check.
+After linking a valid assigned issue, you can reopen the pull request. Pull
+requests whose branches are in this repository are excluded from this check.
 
 ## Not Sure Where to Start?
 


### PR DESCRIPTION
## Description
Fix external PR ticket checks, excluding all internal PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the external PR ticket workflow so it only runs for PRs from forks, excluding all internal PRs. Updates the workflow docs to match this behavior.

- **Bug Fixes**
  - Simplified condition in `external-pr-ticket.yml` to `if: github.event.pull_request.head.repo.full_name != github.repository`.
  - Updated `.github/workflows/README.md` and `docs/CONTRIBUTING.md` to state that only PRs from outside the repo must link a valid assigned issue; removed bot/association exclusions.

<sup>Written for commit f2fa55030caac8a36ddbc9b485bb31a12248fa31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

