### PR TITLE
Hide knowledge source download toggle when no files are available

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/index.svelte
@@ -382,34 +382,36 @@
     </div>
   </div>
 
-  <div class="sources-access">
-    <Toggle
-      bind:value={operation.allowKnowledgeSourceDownload}
-      disabled={savingAllowKnowledgeSourceDownload || !agentId}
-      on:change={async () => {
-        savingAllowKnowledgeSourceDownload = true
-        try {
-          await tick()
-          await onUpdated()
-        } finally {
-          savingAllowKnowledgeSourceDownload = false
-        }
-      }}
-    />
-    <div>
-      <Body
-        color={"var(--spectrum-global-color-gray-900)"}
-        weight="500"
-        size="XS"
-      >
-        Allow users to download knowledge source files from chat
-      </Body>
-      <Body color={"var(--spectrum-global-color-gray-700)"} size="XS">
-        When disabled, chat still shows which files were used, without a
-        download link.
-      </Body>
+  {#if knowledgeTableRows.length}
+    <div class="sources-access">
+      <Toggle
+        bind:value={operation.allowKnowledgeSourceDownload}
+        disabled={savingAllowKnowledgeSourceDownload || !agentId}
+        on:change={async () => {
+          savingAllowKnowledgeSourceDownload = true
+          try {
+            await tick()
+            await onUpdated()
+          } finally {
+            savingAllowKnowledgeSourceDownload = false
+          }
+        }}
+      />
+      <div>
+        <Body
+          color={"var(--spectrum-global-color-gray-900)"}
+          weight="500"
+          size="XS"
+        >
+          Allow users to download knowledge source files from chat
+        </Body>
+        <Body color={"var(--spectrum-global-color-gray-700)"} size="XS">
+          When disabled, chat still shows which files were used, without a
+          download link.
+        </Body>
+      </div>
     </div>
-  </div>
+  {/if}
 
   <KnowledgeTable
     {loading}


### PR DESCRIPTION
## Description
Hide knowledge source download toggle when no files are available, to remove confusing fields

https://github.com/user-attachments/assets/fb264e82-87a9-4634-bb08-0d2f4438a8b6


## Launchcontrol
Hide knowledge source download toggle when no files are available

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the knowledge source download toggle when there are no files, so the settings page doesn’t show irrelevant controls. The toggle now renders only when `knowledgeTableRows.length > 0`.

<sup>Written for commit 0470a301cf90fe99d2e3b98391d9fc5bef704945. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

