### PR TITLE
map legacy agent query-tool bindings

### DIFF
--- a/packages/server/src/sdk/workspace/ai/agents/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/crud.spec.ts
@@ -381,13 +381,11 @@ describe("agents crud", () => {
       ])
       expect(mockDbPut).not.toHaveBeenCalled()
 
-      mockDbAllDocs
-        .mockResolvedValueOnce({ rows: [{ doc: datasource }] })
-        .mockResolvedValueOnce({ rows: [{ doc: query }] })
       mockDbPut.mockResolvedValue({ rev: "2-abc" })
 
       await agentsCrud.update(agent)
 
+      expect(mockDbAllDocs).toHaveBeenCalledTimes(2)
       expect(mockDbPut).toHaveBeenCalledWith(
         expect.objectContaining({
           operations: [

--- a/packages/server/src/sdk/workspace/ai/agents/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/crud.spec.ts
@@ -2,6 +2,22 @@ const mockDbRemove = jest.fn()
 const mockDbTryGet = jest.fn()
 const mockDbPut = jest.fn()
 const mockDbAllDocs = jest.fn().mockResolvedValue({ rows: [] })
+const mockReplacementCache = new Map<string, [string, string][]>()
+const mockCacheWithCache = jest.fn(
+  async (
+    key: string,
+    _ttl: number,
+    fetchFn: () => Promise<[string, string][]>
+  ) => {
+    const cached = mockReplacementCache.get(key)
+    if (cached) {
+      return cached
+    }
+    const value = await fetchFn()
+    mockReplacementCache.set(key, value)
+    return value
+  }
+)
 const mockGetWorkspaceDB = jest.fn(() => ({
   tryGet: (...args: any[]) => mockDbTryGet(...args),
   remove: (...args: any[]) => mockDbRemove(...args),
@@ -37,8 +53,14 @@ jest.mock("@budibase/backend-core", () => {
   const actual = jest.requireActual("@budibase/backend-core")
   return {
     ...actual,
+    cache: {
+      ...actual.cache,
+      withCache: (...args: Parameters<typeof mockCacheWithCache>) =>
+        mockCacheWithCache(...args),
+    },
     context: {
       ...actual.context,
+      getOrThrowWorkspaceId: () => "app_1",
       getWorkspaceDB: (...args: Parameters<typeof mockGetWorkspaceDB>) =>
         mockGetWorkspaceDB(...args),
     },
@@ -84,6 +106,7 @@ import { generator } from "@budibase/backend-core/tests"
 describe("agents crud", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockReplacementCache.clear()
   })
 
   describe("fetch", () => {
@@ -144,6 +167,64 @@ describe("agents crud", () => {
         },
       ])
       expect(mockDbPut).not.toHaveBeenCalled()
+    })
+
+    it("skips compatibility lookups for bindings longer than legacy names", async () => {
+      const toolName = getQueryToolBindings({
+        sourceType: ToolType.REST_QUERY,
+        sourceLabel: "A very long datasource name",
+        queryName: "A very long query name",
+        queryId: "query_0123456789abcdef0123456789abcdef",
+      }).runtimeBinding
+      mockDbAllDocs.mockResolvedValueOnce({
+        rows: [
+          {
+            doc: {
+              _id: "agent_current",
+              name: "Current Agent",
+              operations: [
+                {
+                  id: "operation_1",
+                  name: "Main",
+                  live: true,
+                  enabledTools: [toolName],
+                },
+              ],
+            },
+          },
+        ],
+      })
+
+      await agentsCrud.fetch()
+
+      expect(mockDbAllDocs).toHaveBeenCalledTimes(1)
+      expect(mockCacheWithCache).not.toHaveBeenCalled()
+    })
+
+    it("caches lookups for bindings that could be legacy names", async () => {
+      const agent = {
+        _id: "agent_legacy",
+        name: "Legacy Agent",
+        operations: [
+          {
+            id: "operation_1",
+            name: "Main",
+            live: true,
+            enabledTools: ["rest_api_get_todo"],
+          },
+        ],
+      }
+      mockDbAllDocs
+        .mockResolvedValueOnce({ rows: [{ doc: agent }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ doc: agent }] })
+
+      await agentsCrud.fetch()
+      await agentsCrud.fetch()
+
+      expect(mockDbAllDocs).toHaveBeenCalledTimes(4)
+      expect(mockCacheWithCache).toHaveBeenCalledTimes(2)
     })
 
     it("migrates legacy promptInstructions into the default operation", async () => {

--- a/packages/server/src/sdk/workspace/ai/agents/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/crud.spec.ts
@@ -69,7 +69,15 @@ jest.mock("./utils", () => {
   }
 })
 
-import type { Agent, KnowledgeBase, KnowledgeBaseFile } from "@budibase/types"
+import { getQueryToolBindings } from "@budibase/shared-core"
+import { SourceName, ToolExecutionPrincipal, ToolType } from "@budibase/types"
+import type {
+  Agent,
+  Datasource,
+  KnowledgeBase,
+  KnowledgeBaseFile,
+  Query,
+} from "@budibase/types"
 import * as agentsCrud from "./crud"
 import { generator } from "@budibase/backend-core/tests"
 
@@ -79,6 +87,65 @@ describe("agents crud", () => {
   })
 
   describe("fetch", () => {
+    it("maps legacy query tools without writing the agent", async () => {
+      const datasource: Datasource = {
+        _id: "datasource_1",
+        name: "Legacy API",
+        type: "datasource",
+        source: SourceName.REST,
+        config: {},
+      }
+      const query: Query = {
+        _id: "query_rest_unique_identifier",
+        datasourceId: datasource._id!,
+        fields: {},
+        name: "Get todo",
+        parameters: [],
+        queryVerb: "read",
+        readable: true,
+        schema: {},
+        transformer: "return data",
+      }
+      mockDbAllDocs
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              doc: {
+                _id: "agent_legacy",
+                _rev: "1-abc",
+                name: "Legacy Agent",
+                aiconfig: "cfg_1",
+                operations: [
+                  {
+                    id: "operation_1",
+                    name: "Main",
+                    live: true,
+                    enabledTools: ["rest_legacy_api_get_todo"],
+                  },
+                ],
+              },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [{ doc: datasource }] })
+        .mockResolvedValueOnce({ rows: [{ doc: query }] })
+
+      const agents = await agentsCrud.fetch()
+
+      expect(agents[0].operations?.[0].enabledTools).toEqual([
+        {
+          toolName: getQueryToolBindings({
+            sourceType: ToolType.REST_QUERY,
+            sourceLabel: datasource.name,
+            queryName: query.name,
+            queryId: query._id!,
+          }).runtimeBinding,
+          executionPrincipal: ToolExecutionPrincipal.ADMIN,
+        },
+      ])
+      expect(mockDbPut).not.toHaveBeenCalled()
+    })
+
     it("migrates legacy promptInstructions into the default operation", async () => {
       mockDbAllDocs.mockResolvedValue({
         rows: [
@@ -177,6 +244,78 @@ describe("agents crud", () => {
           operations: [],
         }),
       ])
+    })
+  })
+
+  describe("getOrThrow", () => {
+    it("maps legacy query tools on read and persists them on save", async () => {
+      const datasource: Datasource = {
+        _id: "datasource_1",
+        name: "Warehouse",
+        type: "datasource",
+        source: SourceName.POSTGRES,
+        config: {},
+      }
+      const query: Query = {
+        _id: "query_sql_unique_identifier",
+        datasourceId: datasource._id!,
+        fields: {},
+        name: "Monthly sales",
+        parameters: [],
+        queryVerb: "read",
+        readable: true,
+        schema: {},
+        transformer: "return data",
+      }
+      mockDbTryGet.mockResolvedValue({
+        _id: "agent_legacy",
+        _rev: "1-abc",
+        name: "Legacy Agent",
+        aiconfig: "cfg_1",
+        operations: [
+          {
+            id: "operation_1",
+            name: "Main",
+            live: true,
+            enabledTools: ["ds_warehouse_monthly_sales"],
+          },
+        ],
+      })
+      mockDbAllDocs
+        .mockResolvedValueOnce({ rows: [{ doc: datasource }] })
+        .mockResolvedValueOnce({ rows: [{ doc: query }] })
+
+      const agent = await agentsCrud.getOrThrow("agent_legacy")
+
+      expect(agent.operations?.[0].enabledTools).toEqual([
+        {
+          toolName: getQueryToolBindings({
+            sourceType: ToolType.DATASOURCE_QUERY,
+            sourceLabel: datasource.name,
+            queryName: query.name,
+            queryId: query._id!,
+          }).runtimeBinding,
+          executionPrincipal: ToolExecutionPrincipal.ADMIN,
+        },
+      ])
+      expect(mockDbPut).not.toHaveBeenCalled()
+
+      mockDbAllDocs
+        .mockResolvedValueOnce({ rows: [{ doc: datasource }] })
+        .mockResolvedValueOnce({ rows: [{ doc: query }] })
+      mockDbPut.mockResolvedValue({ rev: "2-abc" })
+
+      await agentsCrud.update(agent)
+
+      expect(mockDbPut).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operations: [
+            expect.objectContaining({
+              enabledTools: agent.operations?.[0].enabledTools,
+            }),
+          ],
+        })
+      )
     })
   })
 

--- a/packages/server/src/sdk/workspace/ai/agents/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/crud.ts
@@ -1,4 +1,5 @@
 import {
+  cache,
   context,
   docIds,
   encryption,
@@ -23,7 +24,7 @@ import { cleanupKnowledgeForOperation, knowledgeSourceSyncQueue } from "../rag"
 import { getValidProjectIdsForDuplication } from "../../projects/utils"
 import {
   getLegacyQueryToolBindingReplacements,
-  hasQueryToolReferences,
+  hasPotentialLegacyQueryToolReferences,
   replaceLegacyQueryToolReferences,
 } from "./legacyQueryToolReferences"
 
@@ -69,6 +70,7 @@ const SECRET_MASK = "********"
 const SECRET_ENCODING_PREFIX = "bbai_enc::"
 const NAME_REQUIRED_ERROR = "Agent name is required."
 const DEFAULT_OPERATION_NAME = "Main operation"
+const LEGACY_QUERY_TOOL_REPLACEMENTS_CACHE_TTL_SECONDS = 60
 
 const fetchRaw = async (): Promise<DeprecatedAgent[]> => {
   const db = context.getWorkspaceDB()
@@ -266,31 +268,41 @@ const withAgentDefaults = (raw: DeprecatedAgent): Agent => {
 // TODO: remove after agents created before query tool IDs were introduced have
 // had enough time to be resaved with their current bindings.
 const withCurrentQueryToolReferences = async (agents: Agent[]) => {
-  if (!hasQueryToolReferences(agents)) {
+  if (!hasPotentialLegacyQueryToolReferences(agents)) {
     return agents
   }
 
-  const db = context.getWorkspaceDB()
-  const [datasourceResult, queryResult] = await Promise.all([
-    db.allDocs<Datasource>(
-      docIds.getDocParams(DocumentType.DATASOURCE, undefined, {
-        include_docs: true,
-      })
-    ),
-    db.allDocs<Query>(
-      docIds.getDocParams(DocumentType.QUERY, undefined, {
-        include_docs: true,
-      })
-    ),
-  ])
-  const replacements = getLegacyQueryToolBindingReplacements({
-    datasources: datasourceResult.rows
-      .map(row => row.doc)
-      .filter((doc): doc is Datasource => !!doc),
-    queries: queryResult.rows
-      .map(row => row.doc)
-      .filter((doc): doc is Query => !!doc),
-  })
+  const workspaceId = context.getOrThrowWorkspaceId()
+  const replacementEntries = await cache.withCache<[string, string][]>(
+    `legacy_agent_query_tool_replacements_${workspaceId}`,
+    LEGACY_QUERY_TOOL_REPLACEMENTS_CACHE_TTL_SECONDS,
+    async () => {
+      const db = context.getWorkspaceDB()
+      const [datasourceResult, queryResult] = await Promise.all([
+        db.allDocs<Datasource>(
+          docIds.getDocParams(DocumentType.DATASOURCE, undefined, {
+            include_docs: true,
+          })
+        ),
+        db.allDocs<Query>(
+          docIds.getDocParams(DocumentType.QUERY, undefined, {
+            include_docs: true,
+          })
+        ),
+      ])
+      return Array.from(
+        getLegacyQueryToolBindingReplacements({
+          datasources: datasourceResult.rows
+            .map(row => row.doc)
+            .filter((doc): doc is Datasource => !!doc),
+          queries: queryResult.rows
+            .map(row => row.doc)
+            .filter((doc): doc is Query => !!doc),
+        }).entries()
+      )
+    }
+  )
+  const replacements = new Map(replacementEntries)
 
   return agents.map(agent =>
     replaceLegacyQueryToolReferences({ agent, replacements })

--- a/packages/server/src/sdk/workspace/ai/agents/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/crud.ts
@@ -12,13 +12,20 @@ import type {
   AgentKnowledgeSource,
   AgentOperation,
   AgentOperationToolConfig,
+  Datasource,
   Optional,
+  Query,
 } from "@budibase/types"
 import { helpers } from "@budibase/shared-core"
 import * as knowledgeBaseSdk from "../knowledgeBase"
 import { assertAgentHasValidConfig } from "./utils"
 import { cleanupKnowledgeForOperation, knowledgeSourceSyncQueue } from "../rag"
 import { getValidProjectIdsForDuplication } from "../../projects/utils"
+import {
+  getLegacyQueryToolBindingReplacements,
+  hasQueryToolReferences,
+  replaceLegacyQueryToolReferences,
+} from "./legacyQueryToolReferences"
 
 // TODO: this will eventually go away, after a grace period
 type DeprecatedAgentOperationToolConfig = Omit<
@@ -63,12 +70,25 @@ const SECRET_ENCODING_PREFIX = "bbai_enc::"
 const NAME_REQUIRED_ERROR = "Agent name is required."
 const DEFAULT_OPERATION_NAME = "Main operation"
 
+const fetchRaw = async (): Promise<DeprecatedAgent[]> => {
+  const db = context.getWorkspaceDB()
+  const result = await db.allDocs<DeprecatedAgent>(
+    docIds.getDocParams(DocumentType.AGENT, undefined, {
+      include_docs: true,
+    })
+  )
+
+  return result.rows
+    .map(row => row.doc)
+    .filter((doc): doc is DeprecatedAgent => !!doc)
+}
+
 const guardName = async (name: string, id?: string) => {
   if (!name.trim()) {
     throw new HTTPError(NAME_REQUIRED_ERROR, 400)
   }
 
-  const agents = await fetch()
+  const agents = await fetchRaw()
   const normalizedName = helpers.normalizeForComparison(name)
   const duplicate = agents.find(
     agent =>
@@ -241,6 +261,40 @@ const withAgentDefaults = (raw: DeprecatedAgent): Agent => {
       raw.telegramIntegration
     ),
   }
+}
+
+// TODO: remove after agents created before query tool IDs were introduced have
+// had enough time to be resaved with their current bindings.
+const withCurrentQueryToolReferences = async (agents: Agent[]) => {
+  if (!hasQueryToolReferences(agents)) {
+    return agents
+  }
+
+  const db = context.getWorkspaceDB()
+  const [datasourceResult, queryResult] = await Promise.all([
+    db.allDocs<Datasource>(
+      docIds.getDocParams(DocumentType.DATASOURCE, undefined, {
+        include_docs: true,
+      })
+    ),
+    db.allDocs<Query>(
+      docIds.getDocParams(DocumentType.QUERY, undefined, {
+        include_docs: true,
+      })
+    ),
+  ])
+  const replacements = getLegacyQueryToolBindingReplacements({
+    datasources: datasourceResult.rows
+      .map(row => row.doc)
+      .filter((doc): doc is Datasource => !!doc),
+    queries: queryResult.rows
+      .map(row => row.doc)
+      .filter((doc): doc is Query => !!doc),
+  })
+
+  return agents.map(agent =>
+    replaceLegacyQueryToolReferences({ agent, replacements })
+  )
 }
 
 type AgentIntegrationKeys = {
@@ -510,17 +564,8 @@ const mergeTelegramIntegration = ({
 }
 
 export async function fetch(): Promise<Agent[]> {
-  const db = context.getWorkspaceDB()
-  const result = await db.allDocs<DeprecatedAgent>(
-    docIds.getDocParams(DocumentType.AGENT, undefined, {
-      include_docs: true,
-    })
-  )
-
-  return result.rows
-    .map(row => row.doc)
-    .filter(doc => !!doc)
-    .map(withAgentDefaults)
+  const agents = (await fetchRaw()).map(withAgentDefaults)
+  return withCurrentQueryToolReferences(agents)
 }
 
 export async function getOrThrow(agentId: string | undefined): Promise<Agent> {
@@ -529,13 +574,14 @@ export async function getOrThrow(agentId: string | undefined): Promise<Agent> {
   }
 
   const db = context.getWorkspaceDB()
-
-  const agent = await db.tryGet<DeprecatedAgent>(agentId)
-  if (!agent) {
+  const rawAgent = await db.tryGet<DeprecatedAgent>(agentId)
+  if (!rawAgent) {
     throw new HTTPError("Agent not found", 404)
   }
 
-  return withAgentDefaults(agent)
+  const agent = withAgentDefaults(rawAgent)
+  const [resolvedAgent] = await withCurrentQueryToolReferences([agent])
+  return resolvedAgent
 }
 
 export async function create(

--- a/packages/server/src/sdk/workspace/ai/agents/legacyQueryToolReferences.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/legacyQueryToolReferences.spec.ts
@@ -1,0 +1,255 @@
+import { getQueryToolBindings } from "@budibase/shared-core"
+import { SourceName, ToolExecutionPrincipal, ToolType } from "@budibase/types"
+import type { Agent, Datasource, Query } from "@budibase/types"
+import {
+  getLegacyQueryToolBindingReplacements,
+  getLegacyQueryToolRuntimeBinding,
+  replaceLegacyQueryToolReferences,
+} from "./legacyQueryToolReferences"
+
+const makeDatasource = ({
+  id,
+  name,
+  source,
+}: {
+  id: string
+  name: string
+  source: SourceName
+}): Datasource => ({
+  _id: id,
+  name,
+  type: "datasource",
+  source,
+  config: {},
+})
+
+const makeQuery = ({
+  id,
+  datasourceId,
+  name,
+}: {
+  id: string
+  datasourceId: string
+  name: string
+}): Query => ({
+  _id: id,
+  datasourceId,
+  fields: {},
+  name,
+  parameters: [],
+  queryVerb: "read",
+  readable: true,
+  schema: {},
+  transformer: "return data",
+})
+
+const getCurrentBinding = ({
+  datasource,
+  query,
+}: {
+  datasource: Datasource
+  query: Query
+}) =>
+  getQueryToolBindings({
+    sourceType:
+      datasource.source === SourceName.REST
+        ? ToolType.REST_QUERY
+        : ToolType.DATASOURCE_QUERY,
+    sourceLabel:
+      datasource.name ||
+      (datasource.source === SourceName.REST ? "API" : "Datasource"),
+    queryName: query.name,
+    queryId: query._id!,
+  }).runtimeBinding
+
+const makeAgent = (toolNames: string[]): Agent => ({
+  _id: "agent_1",
+  _rev: "1-agent",
+  name: "Agent",
+  aiconfig: "config_1",
+  operations: [
+    {
+      id: "operation_1",
+      name: "Main",
+      live: true,
+      enabledTools: toolNames.map((toolName, index) => ({
+        toolName,
+        executionPrincipal:
+          index === 0
+            ? ToolExecutionPrincipal.REQUESTER
+            : ToolExecutionPrincipal.ADMIN,
+      })),
+      allowKnowledgeSourceDownload: true,
+    },
+  ],
+})
+
+describe("legacy agent query tool references", () => {
+  it("maps unique REST and datasource bindings and preserves order", () => {
+    const restDatasource = makeDatasource({
+      id: "datasource_rest",
+      name: "GitHub API",
+      source: SourceName.REST,
+    })
+    const sqlDatasource = makeDatasource({
+      id: "datasource_sql",
+      name: "Sales Warehouse",
+      source: SourceName.POSTGRES,
+    })
+    const restQuery = makeQuery({
+      id: "query_rest_unique_identifier",
+      datasourceId: restDatasource._id!,
+      name: "Get repository",
+    })
+    const sqlQuery = makeQuery({
+      id: "query_sql_unique_identifier",
+      datasourceId: sqlDatasource._id!,
+      name: "Monthly sales",
+    })
+    const legacyRest = getLegacyQueryToolRuntimeBinding({
+      datasource: restDatasource,
+      query: restQuery,
+    })
+    const legacySql = getLegacyQueryToolRuntimeBinding({
+      datasource: sqlDatasource,
+      query: sqlQuery,
+    })
+    const currentRest = getCurrentBinding({
+      datasource: restDatasource,
+      query: restQuery,
+    })
+    const currentSql = getCurrentBinding({
+      datasource: sqlDatasource,
+      query: sqlQuery,
+    })
+    const replacements = getLegacyQueryToolBindingReplacements({
+      datasources: [restDatasource, sqlDatasource],
+      queries: [restQuery, sqlQuery],
+    })
+    const agent = makeAgent([legacyRest, "other_tool", currentRest, legacySql])
+
+    const resolved = replaceLegacyQueryToolReferences({ agent, replacements })
+
+    expect(resolved.operations?.[0].enabledTools).toEqual([
+      {
+        toolName: currentRest,
+        executionPrincipal: ToolExecutionPrincipal.REQUESTER,
+      },
+      {
+        toolName: "other_tool",
+        executionPrincipal: ToolExecutionPrincipal.ADMIN,
+      },
+      {
+        toolName: currentSql,
+        executionPrincipal: ToolExecutionPrincipal.ADMIN,
+      },
+    ])
+  })
+
+  it("leaves ambiguous and deleted query bindings unresolved", () => {
+    const firstDatasource = makeDatasource({
+      id: "datasource_first",
+      name: "Datasource shared prefix one",
+      source: SourceName.POSTGRES,
+    })
+    const secondDatasource = makeDatasource({
+      id: "datasource_second",
+      name: "Datasource shared prefix two",
+      source: SourceName.POSTGRES,
+    })
+    const firstQuery = makeQuery({
+      id: "query_first_unique_identifier",
+      datasourceId: firstDatasource._id!,
+      name: "Query name with shared prefix one",
+    })
+    const secondQuery = makeQuery({
+      id: "query_second_unique_identifier",
+      datasourceId: secondDatasource._id!,
+      name: "Query name with shared prefix two",
+    })
+    const ambiguousBinding = getLegacyQueryToolRuntimeBinding({
+      datasource: firstDatasource,
+      query: firstQuery,
+    })
+    const deletedBinding = "rest_deleted_api_deleted_query"
+    const agent = makeAgent([ambiguousBinding, deletedBinding])
+    const replacements = getLegacyQueryToolBindingReplacements({
+      datasources: [firstDatasource, secondDatasource],
+      queries: [firstQuery, secondQuery],
+    })
+
+    const resolved = replaceLegacyQueryToolReferences({ agent, replacements })
+
+    expect(resolved).toBe(agent)
+    expect(resolved.operations?.[0].enabledTools).toEqual([
+      {
+        toolName: ambiguousBinding,
+        executionPrincipal: ToolExecutionPrincipal.REQUESTER,
+      },
+      {
+        toolName: deletedBinding,
+        executionPrincipal: ToolExecutionPrincipal.ADMIN,
+      },
+    ])
+  })
+
+  it("does not replace a current binding that is also a legacy binding", () => {
+    const datasource = makeDatasource({
+      id: "datasource_1",
+      name: "D",
+      source: SourceName.REST,
+    })
+    const currentQuery = makeQuery({
+      id: "query_current_unique_identifier",
+      datasourceId: datasource._id!,
+      name: "get",
+    })
+    const currentBinding = getCurrentBinding({
+      datasource,
+      query: currentQuery,
+    })
+    const collidingLegacyQuery = makeQuery({
+      id: "query_legacy_unique_identifier",
+      datasourceId: datasource._id!,
+      name: currentBinding.replace("rest_d_", ""),
+    })
+    expect(
+      getLegacyQueryToolRuntimeBinding({
+        datasource,
+        query: collidingLegacyQuery,
+      })
+    ).toBe(currentBinding)
+    const agent = makeAgent([currentBinding])
+    const replacements = getLegacyQueryToolBindingReplacements({
+      datasources: [datasource],
+      queries: [currentQuery, collidingLegacyQuery],
+    })
+
+    const resolved = replaceLegacyQueryToolReferences({ agent, replacements })
+
+    expect(resolved).toBe(agent)
+    expect(resolved.operations?.[0].enabledTools).toEqual([
+      {
+        toolName: currentBinding,
+        executionPrincipal: ToolExecutionPrincipal.REQUESTER,
+      },
+    ])
+  })
+
+  it("reconstructs the legacy truncation and sanitisation", () => {
+    const datasource = makeDatasource({
+      id: "datasource_1",
+      name: "A very long datasource name",
+      source: SourceName.REST,
+    })
+    const query = makeQuery({
+      id: "query_1",
+      datasourceId: datasource._id!,
+      name: "A very long query name that exceeds the limit",
+    })
+
+    expect(getLegacyQueryToolRuntimeBinding({ datasource, query })).toBe(
+      "rest_a_very_long_datasour_a_very_long_query_name_t"
+    )
+  })
+})

--- a/packages/server/src/sdk/workspace/ai/agents/legacyQueryToolReferences.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/legacyQueryToolReferences.spec.ts
@@ -4,6 +4,7 @@ import type { Agent, Datasource, Query } from "@budibase/types"
 import {
   getLegacyQueryToolBindingReplacements,
   getLegacyQueryToolRuntimeBinding,
+  hasPotentialLegacyQueryToolReferences,
   replaceLegacyQueryToolReferences,
 } from "./legacyQueryToolReferences"
 
@@ -251,5 +252,26 @@ describe("legacy agent query tool references", () => {
     expect(getLegacyQueryToolRuntimeBinding({ datasource, query })).toBe(
       "rest_a_very_long_datasour_a_very_long_query_name_t"
     )
+  })
+
+  it("only flags query bindings that could fit the legacy format", () => {
+    const definitelyCurrent = getQueryToolBindings({
+      sourceType: ToolType.REST_QUERY,
+      sourceLabel: "A very long datasource name",
+      queryName: "A very long query name",
+      queryId: "query_0123456789abcdef0123456789abcdef",
+    }).runtimeBinding
+
+    expect(
+      hasPotentialLegacyQueryToolReferences([makeAgent([definitelyCurrent])])
+    ).toBe(false)
+    expect(
+      hasPotentialLegacyQueryToolReferences([
+        makeAgent(["rest_api_get_todo", "ds_warehouse_monthly_sales"]),
+      ])
+    ).toBe(true)
+    expect(
+      hasPotentialLegacyQueryToolReferences([makeAgent(["other_tool"])])
+    ).toBe(false)
   })
 })

--- a/packages/server/src/sdk/workspace/ai/agents/legacyQueryToolReferences.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/legacyQueryToolReferences.ts
@@ -15,6 +15,19 @@ const sanitiseLegacyNameSegment = (name: string, maxLength: number) =>
     .replace(/^_|_$/g, "")
     .substring(0, maxLength)
 
+const MAX_LEGACY_DATASOURCE_SEGMENT_LENGTH = 20
+const MAX_LEGACY_QUERY_SEGMENT_LENGTH = 24
+const MAX_LEGACY_REST_BINDING_LENGTH =
+  "rest_".length +
+  MAX_LEGACY_DATASOURCE_SEGMENT_LENGTH +
+  1 +
+  MAX_LEGACY_QUERY_SEGMENT_LENGTH
+const MAX_LEGACY_DATASOURCE_BINDING_LENGTH =
+  "ds_".length +
+  MAX_LEGACY_DATASOURCE_SEGMENT_LENGTH +
+  1 +
+  MAX_LEGACY_QUERY_SEGMENT_LENGTH
+
 const getSourceType = (datasource: Datasource): QueryToolType =>
   datasource.source === SourceName.REST
     ? ToolType.REST_QUERY
@@ -34,9 +47,15 @@ export const getLegacyQueryToolRuntimeBinding = ({
   const sourceType = getSourceType(datasource)
   const runtimePrefix = sourceType === ToolType.REST_QUERY ? "rest" : "ds"
   const datasourceSegment =
-    sanitiseLegacyNameSegment(getSourceLabel(datasource), 20) || "datasource"
+    sanitiseLegacyNameSegment(
+      getSourceLabel(datasource),
+      MAX_LEGACY_DATASOURCE_SEGMENT_LENGTH
+    ) || "datasource"
   const querySegment =
-    sanitiseLegacyNameSegment(query.name || "query", 24) || "query"
+    sanitiseLegacyNameSegment(
+      query.name || "query",
+      MAX_LEGACY_QUERY_SEGMENT_LENGTH
+    ) || "query"
 
   return `${runtimePrefix}_${datasourceSegment}_${querySegment}`
 }
@@ -166,13 +185,18 @@ export const replaceLegacyQueryToolReferences = ({
   return changed ? { ...agent, operations } : agent
 }
 
-export const hasQueryToolReferences = (agents: Agent[]) => {
+export const hasPotentialLegacyQueryToolReferences = (agents: Agent[]) => {
   return agents.some(agent =>
     agent.operations?.some(operation =>
-      operation.enabledTools?.some(
-        tool =>
-          tool.toolName.startsWith("rest_") || tool.toolName.startsWith("ds_")
-      )
+      operation.enabledTools?.some(tool => {
+        if (tool.toolName.startsWith("rest_")) {
+          return tool.toolName.length <= MAX_LEGACY_REST_BINDING_LENGTH
+        }
+        if (tool.toolName.startsWith("ds_")) {
+          return tool.toolName.length <= MAX_LEGACY_DATASOURCE_BINDING_LENGTH
+        }
+        return false
+      })
     )
   )
 }

--- a/packages/server/src/sdk/workspace/ai/agents/legacyQueryToolReferences.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/legacyQueryToolReferences.ts
@@ -1,0 +1,178 @@
+import { getQueryToolBindings, type QueryToolType } from "@budibase/shared-core"
+import { SourceName, ToolType } from "@budibase/types"
+import type {
+  Agent,
+  AgentOperationToolConfig,
+  Datasource,
+  Query,
+} from "@budibase/types"
+
+const sanitiseLegacyNameSegment = (name: string, maxLength: number) =>
+  name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "")
+    .substring(0, maxLength)
+
+const getSourceType = (datasource: Datasource): QueryToolType =>
+  datasource.source === SourceName.REST
+    ? ToolType.REST_QUERY
+    : ToolType.DATASOURCE_QUERY
+
+const getSourceLabel = (datasource: Datasource) =>
+  datasource.name ||
+  (datasource.source === SourceName.REST ? "API" : "Datasource")
+
+export const getLegacyQueryToolRuntimeBinding = ({
+  datasource,
+  query,
+}: {
+  datasource: Datasource
+  query: Query
+}) => {
+  const sourceType = getSourceType(datasource)
+  const runtimePrefix = sourceType === ToolType.REST_QUERY ? "rest" : "ds"
+  const datasourceSegment =
+    sanitiseLegacyNameSegment(getSourceLabel(datasource), 20) || "datasource"
+  const querySegment =
+    sanitiseLegacyNameSegment(query.name || "query", 24) || "query"
+
+  return `${runtimePrefix}_${datasourceSegment}_${querySegment}`
+}
+
+const getCurrentQueryToolRuntimeBinding = ({
+  datasource,
+  query,
+}: {
+  datasource: Datasource
+  query: Query
+}) => {
+  if (!query._id) {
+    return undefined
+  }
+
+  return getQueryToolBindings({
+    sourceType: getSourceType(datasource),
+    sourceLabel: getSourceLabel(datasource),
+    queryName: query.name,
+    queryId: query._id,
+  }).runtimeBinding
+}
+
+export const getLegacyQueryToolBindingReplacements = ({
+  datasources,
+  queries,
+}: {
+  datasources: Datasource[]
+  queries: Query[]
+}) => {
+  const datasourcesById = new Map(
+    datasources
+      .filter(datasource => !!datasource._id)
+      .map(datasource => [datasource._id!, datasource])
+  )
+  const candidatesByLegacy = new Map<
+    string,
+    { queryIds: Set<string>; currentBindings: Set<string> }
+  >()
+  const allCurrentBindings = new Set<string>()
+
+  for (const query of queries) {
+    const datasource = datasourcesById.get(query.datasourceId)
+    if (!datasource) {
+      continue
+    }
+    const current = getCurrentQueryToolRuntimeBinding({ datasource, query })
+    if (!current) {
+      continue
+    }
+
+    allCurrentBindings.add(current)
+    const legacy = getLegacyQueryToolRuntimeBinding({ datasource, query })
+    const candidates = candidatesByLegacy.get(legacy) || {
+      queryIds: new Set<string>(),
+      currentBindings: new Set<string>(),
+    }
+    candidates.queryIds.add(query._id!)
+    candidates.currentBindings.add(current)
+    candidatesByLegacy.set(legacy, candidates)
+  }
+
+  const replacements = new Map<string, string>()
+  for (const [legacy, candidates] of candidatesByLegacy) {
+    if (candidates.queryIds.size !== 1 || allCurrentBindings.has(legacy)) {
+      continue
+    }
+    const [current] = candidates.currentBindings
+    if (current) {
+      replacements.set(legacy, current)
+    }
+  }
+
+  return replacements
+}
+
+const replaceEnabledTools = ({
+  enabledTools,
+  replacements,
+}: {
+  enabledTools: AgentOperationToolConfig[] | undefined
+  replacements: Map<string, string>
+}) => {
+  if (!enabledTools?.length) {
+    return enabledTools
+  }
+
+  const replaced = enabledTools.map(tool => {
+    const toolName = replacements.get(tool.toolName) || tool.toolName
+    return toolName === tool.toolName ? tool : { ...tool, toolName }
+  })
+  if (replaced.every((tool, index) => tool === enabledTools[index])) {
+    return enabledTools
+  }
+
+  const seenToolNames = new Set<string>()
+  return replaced.filter(tool => {
+    if (seenToolNames.has(tool.toolName)) {
+      return false
+    }
+    seenToolNames.add(tool.toolName)
+    return true
+  })
+}
+
+export const replaceLegacyQueryToolReferences = ({
+  agent,
+  replacements,
+}: {
+  agent: Agent
+  replacements: Map<string, string>
+}) => {
+  let changed = false
+  const operations = agent.operations?.map(operation => {
+    const enabledTools = replaceEnabledTools({
+      enabledTools: operation.enabledTools,
+      replacements,
+    })
+    if (enabledTools === operation.enabledTools) {
+      return operation
+    }
+
+    changed = true
+    return { ...operation, enabledTools }
+  })
+
+  return changed ? { ...agent, operations } : agent
+}
+
+export const hasQueryToolReferences = (agents: Agent[]) => {
+  return agents.some(agent =>
+    agent.operations?.some(operation =>
+      operation.enabledTools?.some(
+        tool =>
+          tool.toolName.startsWith("rest_") || tool.toolName.startsWith("ds_")
+      )
+    )
+  )
+}


### PR DESCRIPTION
## Description

- restores query tools for agents saved before query ids were added to generated tool names
- reconstructs the legacy rest/datasource name and maps it only when exactly one current query matches
- applies the mapping in memory on agent reads, so affected agents work without a workspace migration or manual re-save
- skips compatibility lookups for names that cannot be legacy and caches ambiguous workspace mappings for 60 seconds
- preserves tool order and execution-principal metadata, and removes duplicates introduced by replacement
- leaves deleted, ambiguous, and cross-generation collisions unresolved rather than guessing
- persists the current query-id binding on the next ordinary agent save; reads do not write
- the stacked runtime safeguards are in [#19459](https://github.com/Budibase/budibase/pull/19459)
- validated with:
  - `yarn build`
  - 22 focused agent crud and legacy-mapping tests
  - the server type check

## Addresses

- follows up on the query tool-name change in [#19425](https://github.com/Budibase/budibase/pull/19425)

## App Export

- no app export included; the legacy persisted state is covered by focused fixtures and the manual version-switch repro

## Screenshots

- not applicable; there are no ui changes

## Launchcontrol

- existing agents can use previously selected query tools again without a workspace migration or manual re-save