### PR TITLE
guard agent execution

### DIFF
--- a/packages/server/src/automations/steps/ai/agent.ts
+++ b/packages/server/src/automations/steps/ai/agent.ts
@@ -14,6 +14,7 @@ import {
   prepareAgentRunContext,
   findIncompleteToolCalls,
   formatIncompleteToolCallError,
+  UnavailableAgentToolsError,
   updatePendingToolCalls,
 } from "../../../sdk/workspace/ai/agents"
 import { createSessionLogIndexer } from "../../../sdk/workspace/ai/agentLogs"
@@ -94,7 +95,7 @@ export async function run({
           }
         }
 
-        const { llm, selectedOperation, systemPrompt, tools } =
+        const { llm, selectedOperation, systemPrompt, tools, toolResolution } =
           await prepareAgentRunContext({
             agent: agentConfig,
             agentId,
@@ -106,6 +107,7 @@ export async function run({
         tracer.llmobs.annotate(agentSpan, {
           metadata: {
             toolCount: Object.keys(tools).length,
+            ...toolResolution,
             ...(selectedOperation
               ? {
                   operationId: selectedOperation.id,
@@ -189,13 +191,14 @@ export async function run({
         }
 
         const returnStreamingFailure = async (
-          errorMessage: string
+          errorMessage: string,
+          errorType = "StreamingError"
         ): Promise<AgentStepOutputs> => {
           sessionLogIndexer.addRequestId(requestId)
           await sessionLogIndexer.index()
           tracer.llmobs.annotate(agentSpan, {
             outputData: errorMessage,
-            tags: { error: "1", "error.type": "StreamingError" },
+            tags: { error: "1", "error.type": errorType },
           })
           return {
             success: false,
@@ -261,19 +264,29 @@ export async function run({
           return returnStreamingFailure(outputError)
         }
 
+        if (!responseText?.trim() && output === undefined) {
+          return returnStreamingFailure(
+            "Agent completed without producing a response.",
+            "EmptyAgentResponse"
+          )
+        }
+
         sessionLogIndexer.addRequestId(requestId)
         await sessionLogIndexer.index()
 
         tracer.llmobs.annotate(agentSpan, {
           outputData: responseText,
-          metadata: { stepCount: assistantMessage?.parts?.length ?? 0 },
+          metadata: {
+            responseLength: responseText?.length ?? 0,
+            stepCount: assistantMessage?.parts?.length ?? 0,
+          },
         })
 
         events.action.aiAgentExecuted({ agentId })
 
         return {
           success: true,
-          response: responseText,
+          response: responseText || "",
           usage,
           message: assistantMessage,
           sessionId,
@@ -283,8 +296,14 @@ export async function run({
         const errorMessage = automationUtils.getError(err)
         await sessionLogIndexer.index()
 
+        const toolResolutionMetadata =
+          err instanceof UnavailableAgentToolsError
+            ? err.toolResolution
+            : undefined
+
         tracer.llmobs.annotate(agentSpan, {
           outputData: errorMessage,
+          metadata: toolResolutionMetadata,
           tags: {
             error: "1",
             "error.type": err?.name || "UnknownError",

--- a/packages/server/src/sdk/workspace/ai/agents/agentRuntime.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/agentRuntime.spec.ts
@@ -397,6 +397,11 @@ describe("prepareAgentRunContext", () => {
       systemPrompt: "system prompt",
       tools: {},
       toolDisplayNames: {},
+      toolResolution: {
+        configuredToolCount: 0,
+        resolvedToolCount: 0,
+        unresolvedToolCount: 0,
+      },
     })
   })
 
@@ -613,6 +618,11 @@ describe("prepareAgentChatRun - escalate tool selection", () => {
       systemPrompt: "system prompt",
       tools: { escalate: escalatePlaceholder },
       toolDisplayNames: {},
+      toolResolution: {
+        configuredToolCount: 0,
+        resolvedToolCount: 0,
+        unresolvedToolCount: 0,
+      },
     })
 
     return prepareAgentChatRun({

--- a/packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts
@@ -40,6 +40,7 @@ import {
   buildPromptAndTools,
   getLiveOperations,
   type BuildPromptAndToolsOptions,
+  type ToolResolutionSummary,
 } from "./utils"
 import { estimateTokens } from "./usage"
 import { createReportUsedSourcesTool } from "../../../../ai/tools/budibase/knowledge/reportUsedSources"
@@ -349,6 +350,7 @@ export interface AgentRunContext {
   tools: ToolSet
   toolDisplayNames: Record<string, string>
   executionContext?: AgentExecutionContext
+  toolResolution: ToolResolutionSummary
 }
 
 const buildOperationsSummaryPrompt = (operations: AgentOperation[]) =>

--- a/packages/server/src/sdk/workspace/ai/agents/buildPromptAndTools.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/buildPromptAndTools.spec.ts
@@ -4,6 +4,7 @@ import {
   ToolExecutionPrincipal,
   ToolType,
   type Agent,
+  type AgentOperation,
 } from "@budibase/types"
 import type { Tool } from "ai"
 import { requesterTools } from "../tests/utils"
@@ -110,7 +111,11 @@ import {
   createKnowledgeFilesTool,
   createKnowledgeSearchTool,
 } from "../../../../ai/tools/budibase"
-import { buildPromptAndTools } from "./utils"
+import {
+  assertConfiguredToolsAvailable,
+  buildPromptAndTools,
+  UnavailableAgentToolsError,
+} from "./utils"
 import { generator } from "@budibase/backend-core/tests"
 import {
   authorizeAgentToolCall,
@@ -525,4 +530,79 @@ describe("buildPromptAndTools", () => {
     expect(Reflect.get(securedResult.tools, "list_automations")).toBeUndefined()
     expect(Reflect.get(securedResult.tools, "get_automation")).toBeUndefined()
   })
+})
+
+describe("assertConfiguredToolsAvailable", () => {
+  const makeOperation = (enabledTools: string[]): AgentOperation => ({
+    id: "operation_1",
+    name: "Main operation",
+    live: true,
+    enabledTools: requesterTools(...enabledTools),
+    allowKnowledgeSourceDownload: true,
+  })
+
+  it("returns resolution counts when every configured tool is available", () => {
+    expect(
+      assertConfiguredToolsAvailable(makeOperation(["first", "second"]), [
+        { name: "first" },
+        { name: "second" },
+        { name: "helper" },
+      ])
+    ).toEqual({
+      configuredToolCount: 2,
+      resolvedToolCount: 2,
+      unresolvedToolCount: 0,
+    })
+  })
+
+  it("allows operations that intentionally configure no tools", () => {
+    expect(assertConfiguredToolsAvailable(makeOperation([]), [])).toEqual({
+      configuredToolCount: 0,
+      resolvedToolCount: 0,
+      unresolvedToolCount: 0,
+    })
+  })
+
+  it("counts configured helper tools as available", () => {
+    expect(
+      assertConfiguredToolsAvailable(makeOperation(["list_tables"]), [
+        { name: "list_tables" },
+      ])
+    ).toEqual({
+      configuredToolCount: 1,
+      resolvedToolCount: 1,
+      unresolvedToolCount: 0,
+    })
+  })
+
+  it.each([
+    {
+      label: "some",
+      enabledTools: ["first", "missing"],
+      availableTools: [{ name: "first" }],
+      resolvedToolCount: 1,
+    },
+    {
+      label: "all",
+      enabledTools: ["first", "second"],
+      availableTools: [],
+      resolvedToolCount: 0,
+    },
+  ])(
+    "throws when $label configured tools are unavailable",
+    ({ enabledTools, availableTools, resolvedToolCount }) => {
+      expect(() =>
+        assertConfiguredToolsAvailable(
+          makeOperation(enabledTools),
+          availableTools
+        )
+      ).toThrow(
+        new UnavailableAgentToolsError(makeOperation(enabledTools), {
+          configuredToolCount: enabledTools.length,
+          resolvedToolCount,
+          unresolvedToolCount: enabledTools.length - resolvedToolCount,
+        })
+      )
+    }
+  )
 })

--- a/packages/server/src/sdk/workspace/ai/agents/utils.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/utils.ts
@@ -165,6 +165,51 @@ export interface BuildPromptAndToolsOptions {
   toolSecurityEnabled?: boolean
 }
 
+export interface ToolResolutionSummary {
+  configuredToolCount: number
+  resolvedToolCount: number
+  unresolvedToolCount: number
+}
+
+export class UnavailableAgentToolsError extends Error {
+  readonly toolResolution: ToolResolutionSummary
+
+  constructor(
+    operation: AgentOperation,
+    toolResolution: ToolResolutionSummary
+  ) {
+    super(
+      `Agent operation "${operation.name}" has unavailable tools. Re-select its tools and save the agent before running it.`
+    )
+    this.name = "UnavailableAgentToolsError"
+    this.toolResolution = toolResolution
+  }
+}
+
+export const assertConfiguredToolsAvailable = (
+  operation: AgentOperation | undefined,
+  availableTools: Pick<AiToolDefinition, "name">[]
+): ToolResolutionSummary => {
+  const configuredToolNames = new Set(
+    (operation?.enabledTools || []).map(config => config.toolName)
+  )
+  const availableToolNames = new Set(availableTools.map(tool => tool.name))
+  const resolvedToolCount = Array.from(configuredToolNames).filter(toolName =>
+    availableToolNames.has(toolName)
+  ).length
+  const toolResolution = {
+    configuredToolCount: configuredToolNames.size,
+    resolvedToolCount,
+    unresolvedToolCount: configuredToolNames.size - resolvedToolCount,
+  }
+
+  if (operation && toolResolution.unresolvedToolCount > 0) {
+    throw new UnavailableAgentToolsError(operation, toolResolution)
+  }
+
+  return toolResolution
+}
+
 export async function buildPromptAndTools(
   agent: Agent,
   operation?: AgentOperation,
@@ -173,6 +218,7 @@ export async function buildPromptAndTools(
   systemPrompt: string
   tools: ToolSet
   toolDisplayNames: Record<string, string>
+  toolResolution: ToolResolutionSummary
 }> {
   const {
     baseSystemPrompt,
@@ -188,6 +234,7 @@ export async function buildPromptAndTools(
   const allTools = await getAvailableTools(agent.aiconfig)
   const toolConfigs = operation?.enabledTools || []
   const enabledToolNames = new Set(toolConfigs.map(config => config.toolName))
+  const toolResolution = assertConfiguredToolsAvailable(operation, allTools)
   const configuredTools = allTools.filter(
     tool => enabledToolNames.has(tool.name) && !isHelperTool(tool)
   )
@@ -275,6 +322,7 @@ export async function buildPromptAndTools(
     systemPrompt: resolvedSystemPrompt,
     tools: toToolSet(enabledTools, runtimes),
     toolDisplayNames: getToolDisplayNames(enabledTools),
+    toolResolution,
   }
 }
 

--- a/packages/server/src/tests/api/chatConversations.spec.ts
+++ b/packages/server/src/tests/api/chatConversations.spec.ts
@@ -824,7 +824,16 @@ describe("chat conversation transient behavior", () => {
       sdk.ai.agents.buildPromptAndTools as jest.MockedFunction<
         typeof sdk.ai.agents.buildPromptAndTools
       >
-    ).mockResolvedValue({ systemPrompt: "system", tools, toolDisplayNames: {} })
+    ).mockResolvedValue({
+      systemPrompt: "system",
+      tools,
+      toolDisplayNames: {},
+      toolResolution: {
+        configuredToolCount: 0,
+        resolvedToolCount: 0,
+        unresolvedToolCount: 0,
+      },
+    })
     ;(
       sdk.ai.llm.createLLM as jest.MockedFunction<typeof sdk.ai.llm.createLLM>
     ).mockResolvedValue({
@@ -1416,6 +1425,11 @@ describe("Agent chat tool call tracking", () => {
       systemPrompt: "system",
       tools: { tool1: {} as any },
       toolDisplayNames: {},
+      toolResolution: {
+        configuredToolCount: 1,
+        resolvedToolCount: 1,
+        unresolvedToolCount: 0,
+      },
     })
     ;(
       sdk.ai.llm.createLLM as jest.MockedFunction<typeof sdk.ai.llm.createLLM>

--- a/packages/server/src/tests/automations/agentStep.spec.ts
+++ b/packages/server/src/tests/automations/agentStep.spec.ts
@@ -88,6 +88,7 @@ function makeToolLoopAgentMock(
     text?: Promise<string>
     usage?: Promise<{ totalTokens: number }>
     output?: Promise<Record<string, unknown> | undefined>
+    streamingError?: Error
   } = {}
 ) {
   return ({ onStepFinish }: any) => ({
@@ -98,7 +99,16 @@ function makeToolLoopAgentMock(
         toolResults,
       })
       return {
-        toUIMessageStream: jest.fn().mockReturnValue({}),
+        toUIMessageStream: jest
+          .fn()
+          .mockImplementation(
+            ({ onError }: { onError: (error: Error) => string }) => {
+              if (overrides.streamingError) {
+                onError(overrides.streamingError)
+              }
+              return {}
+            }
+          ),
         response:
           overrides.response ??
           Promise.resolve({
@@ -139,6 +149,11 @@ describe("Agent step tool call tracking", () => {
       systemPrompt: "You are a helpful assistant",
       tools: { queryTable: {}, callApi: {} },
       toolDisplayNames: {},
+      toolResolution: {
+        configuredToolCount: 2,
+        resolvedToolCount: 2,
+        unresolvedToolCount: 0,
+      },
     })
     jest.mocked(require("ai").ToolLoopAgent).mockClear()
     jest.spyOn(console, "error").mockImplementation(() => {})
@@ -204,6 +219,121 @@ describe("Agent step tool call tracking", () => {
     })
 
     expect(addActionMock).not.toHaveBeenCalled()
+  })
+
+  it("returns non-empty response text", async () => {
+    jest
+      .mocked(require("ai").ToolLoopAgent)
+      .mockImplementationOnce(makeToolLoopAgentMock([]))
+
+    const result = await run({
+      inputs: { agentId: "agent-id", prompt: "Answer directly" },
+      appId: "test",
+      context: {},
+      emitter: {} as any,
+    })
+
+    expect(result).toMatchObject({
+      success: true,
+      response: "Agent response",
+    })
+  })
+
+  it.each(["", "   "])(
+    "returns a controlled failure for empty text %p",
+    async text => {
+      jest
+        .mocked(require("ai").ToolLoopAgent)
+        .mockImplementationOnce(
+          makeToolLoopAgentMock([], { text: Promise.resolve(text) })
+        )
+
+      const result = await run({
+        inputs: { agentId: "agent-id", prompt: "Evaluate data" },
+        appId: "test",
+        context: {},
+        emitter: {} as any,
+      })
+
+      expect(result).toMatchObject({
+        success: false,
+        response: "Agent completed without producing a response.",
+        sessionId: expect.any(String),
+      })
+    }
+  )
+
+  it("allows structured output without response text", async () => {
+    const output = { sentiment: "positive" }
+    jest.mocked(require("ai").Output.object).mockReturnValueOnce({})
+    jest.mocked(require("ai").ToolLoopAgent).mockImplementationOnce(
+      makeToolLoopAgentMock([], {
+        text: Promise.resolve(""),
+        output: Promise.resolve(output),
+      })
+    )
+
+    const result = await run({
+      inputs: {
+        agentId: "agent-id",
+        prompt: "Evaluate data",
+        useStructuredOutput: true,
+        outputSchema: { sentiment: "string" },
+      },
+      appId: "test",
+      context: {},
+      emitter: {} as any,
+    })
+
+    expect(result).toMatchObject({
+      success: true,
+      response: "",
+      output,
+      sessionId: expect.any(String),
+    })
+  })
+
+  it("does not retry completed tool calls when the final response is empty", async () => {
+    jest.mocked(require("ai").ToolLoopAgent).mockImplementationOnce(
+      makeToolLoopAgentMock([{ toolCallId: "c1" }], {
+        text: Promise.resolve(""),
+      })
+    )
+
+    const result = await run({
+      inputs: { agentId: "agent-id", prompt: "Complete the action" },
+      appId: "test",
+      context: {},
+      emitter: {} as any,
+    })
+
+    expect(addActionMock).toHaveBeenCalledTimes(1)
+    expect(require("ai").ToolLoopAgent).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({
+      success: false,
+      response: "Agent completed without producing a response.",
+    })
+  })
+
+  it("returns an explicit stream error", async () => {
+    jest.mocked(require("ai").ToolLoopAgent).mockImplementationOnce(
+      makeToolLoopAgentMock([], {
+        text: Promise.resolve(""),
+        streamingError: new Error("Provider stream failed"),
+      })
+    )
+
+    const result = await run({
+      inputs: { agentId: "agent-id", prompt: "Evaluate data" },
+      appId: "test",
+      context: {},
+      emitter: {} as any,
+    })
+
+    expect(result).toMatchObject({
+      success: false,
+      response: "Provider stream failed",
+    })
   })
 
   it("returns a controlled failure when response metadata has no generated output", async () => {


### PR DESCRIPTION
## Description

- stacked on the compatibility fix in [#19458](https://github.com/Budibase/budibase/pull/19458)
- stops before the main agent call when any configured tool is absent from the available tool set
- keeps deliberately tool-free operations valid and returns an actionable re-selection error for partial or complete resolution failures
- records configured, resolved, unresolved, and total tool counts on agent spans without recording tool names
- treats empty or whitespace-only automation text as a failed empty response when no structured output exists
- keeps empty text valid when structured output exists and does not retry after possible tool side effects
- validated with:
  - `yarn build`
  - 97 focused tool-resolution, agent-runtime, automation, and chat tests
  - the server type check

## Addresses

- hardens the compatibility repair in [#19458](https://github.com/Budibase/budibase/pull/19458)
- follows up on the query tool-name change in [#19425](https://github.com/Budibase/budibase/pull/19425)

## App Export

- no app export included; the failure modes are covered by focused runtime fixtures

## Screenshots

- not applicable; there are no ui changes

## Launchcontrol

- agents now fail clearly when configured tools are unavailable or a run completes without producing a usable response