### PR TITLE
Upgrade axios resolution to 1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "semver": "7.5.3",
     "http-cache-semantics": "4.1.1",
     "msgpackr": "1.10.1",
-    "axios": "1.15.2",
+    "axios": "1.19.0",
     "xml2js": "0.6.2",
     "passport": "0.6.0",
     "@azure/identity": "4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8965,13 +8965,14 @@ aws-cloudfront-sign@3.0.2:
   resolved "https://registry.yarnpkg.com/aws-cloudfront-sign/-/aws-cloudfront-sign-3.0.2.tgz#da5273b0301bcd70312c8c76293d5fec6d414f0a"
   integrity sha512-Z/yOGZ3Hd1rhYbY13mtRiLCbCDC1Xf/v+dQUyUwMLnyunD/nfDZd/2LMZ9MKxxOhVb2RzEmEwY0F9f+riPaSWQ==
 
-axios@1.15.2, axios@1.18.1, axios@^0.21.1, axios@^1.13.4, axios@^1.13.5, axios@^1.15.0, axios@^1.15.2, axios@^1.4.0, axios@^1.6.2:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.2.tgz#eb8fb6d30349abace6ade5b4cb4d9e8a0dc23e5b"
-  integrity sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==
+axios@1.15.2, axios@1.18.1, axios@1.19.0, axios@^0.21.1, axios@^1.13.4, axios@^1.13.5, axios@^1.15.0, axios@^1.15.2, axios@^1.4.0, axios@^1.6.2:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.19.0.tgz#ddf864d4c8233c0e6873746ab59361537d05ad39"
+  integrity sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==
   dependencies:
-    follow-redirects "^1.15.11"
-    form-data "^4.0.5"
+    follow-redirects "^1.16.0"
+    form-data "^4.0.6"
+    https-proxy-agent "^5.0.1"
     proxy-from-env "^2.1.0"
 
 axobject-query@^4.0.0, axobject-query@^4.1.0:
@@ -12917,7 +12918,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@1.16.0, follow-redirects@^1.15.11:
+follow-redirects@1.16.0, follow-redirects@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
@@ -12937,7 +12938,7 @@ foreground-child@^3.1.0, foreground-child@^3.3.1:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-form-data@4.0.6:
+form-data@4.0.6, form-data@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
   integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==


### PR DESCRIPTION
## Description
Upgrade the axios resolution to **1.19.0** (current latest)

## Addresses
- https://github.com/Budibase/budibase/security/dependabot/1410
- https://github.com/Budibase/budibase/security/dependabot/1491
- https://github.com/Budibase/budibase/security/dependabot/1416
- https://github.com/Budibase/budibase/security/dependabot/1525
- https://github.com/Budibase/budibase/security/dependabot/1415
- https://github.com/Budibase/budibase/security/dependabot/1418

## Launchcontrol
Patch axios to 1.19.0
