### PR TITLE
Fix escalation resume status race

### DIFF
--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -558,6 +558,7 @@ export async function resumeOperation({
     }
   } catch (error) {
     await toolCallChain
+    await needsInputUpdate
     await markEscalationRequestResolved({
       status: "failed",
       error: error instanceof Error ? error.message : String(error),

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -441,6 +441,7 @@ export async function resumeOperation({
   // (preserving completion order) and flush the tail (await toolCallChain
   // below) before writing the terminal status.
   let toolCallChain = Promise.resolve()
+  let needsInputUpdate = Promise.resolve()
 
   try {
     const result = await run.stream({
@@ -449,14 +450,16 @@ export async function resumeOperation({
       onToolCalls: toolNames => {
         const requestId = doc.requestId
         if (requestId && toolNames.includes(ESCALATE_TOOL_NAME)) {
-          sdk.ai.agentRequests
-            .updateRequestStatus({ requestId, status: "needs_input" })
-            .catch(error => {
-              console.error(
-                "Failed to update agent request status to needs_input",
-                { escalationId, agentId: ctx.agentId, error }
-              )
-            })
+          needsInputUpdate = needsInputUpdate.then(() =>
+            sdk.ai.agentRequests
+              .updateRequestStatus({ requestId, status: "needs_input" })
+              .catch(error => {
+                console.error(
+                  "Failed to update agent request status to needs_input",
+                  { escalationId, agentId: ctx.agentId, error }
+                )
+              })
+          )
         }
       },
       onToolCallCompleted: ({ toolName, status, input, output }) => {
@@ -537,6 +540,7 @@ export async function resumeOperation({
     const toolCallsIncomplete =
       pendingToolCalls.size > 0 || finishReason === "tool-calls"
     await toolCallChain
+    await needsInputUpdate
 
     if (doc.requestId) {
       const judged = await sdk.ai.agentRequests.resolveFinalRequestOutcome({


### PR DESCRIPTION
## Description
Fixes a race where a resumed operation started the agent request's needs_input update without waiting for it. The operation could return while the request still appeared active, causing the escalation regression test to fail intermittently in CI.

Fixes this flaky test:

```
Expected: "needs_input"
Received: "active"
    at toEqual (src/escalation/queue.spec.ts:379:30)
    at Object.<anonymous> (src/escalation/queue.spec.ts:277:5)
Summary of all failing tests
FAIL src/escalation/queue.spec.ts (18.352 s)
  ● resumeOperation › raises and tracks a second, genuinely new escalation created during the resumed run

    expect(received).toEqual(expected) // deep equality

    Expected: "needs_input"
    Received: "active"

      377 |
      378 |       // The new escalation is still pending, so the request must not close.
    > 379 |       expect(request.status).toEqual("needs_input")
          |                              ^
      380 |     })
      381 |   })
      382 | })

      at toEqual (src/escalation/queue.spec.ts:379:30)
      at Object.<anonymous> (src/escalation/queue.spec.ts:277:5)


Test Suites: 1 failed, 15 passed, 16 of 89 total
Tests:       1 failed, 1 skipped, 444 passed, 446 total
```

## Launchcontrol
Ensures resumed escalations consistently remain waiting for human input when a new escalation is raised during the resumed run.