### PR TITLE
[19480] Allow relationship filters in non-trigger automation steps

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -139,7 +139,7 @@
   $: schemaFields = search.getFields(
     $tables.list,
     Object.values(schema || {}),
-    { allowLinks: false }
+    { allowLinks: !isTrigger }
   )
   $: queryLimit = tableId?.includes("datasource") ? "∞" : "1000"
   $: isTrigger = $memoBlock?.type === AutomationStepType.TRIGGER

--- a/packages/builder/src/components/automation/SetupPanel/FilterSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/FilterSelector.svelte
@@ -11,7 +11,7 @@
     BaseIOStructure,
     UISearchFilter,
   } from "@budibase/types"
-  import { AutomationCustomIOType } from "@budibase/types"
+  import { AutomationCustomIOType, AutomationStepType } from "@budibase/types"
   import { utils } from "@budibase/shared-core"
   import { QueryUtils, Utils, search } from "@budibase/frontend-core"
   import { cloneDeep } from "lodash"
@@ -50,7 +50,7 @@
   $: schemaFields = search.getFields(
     $tables.list,
     Object.values(schema || {}),
-    { allowLinks: false }
+    { allowLinks: block?.type !== AutomationStepType.TRIGGER }
   )
 
   const lookForFilters = (


### PR DESCRIPTION
## Description
Relationship fields were hidden from the automation filter builder, which prevented the Query Rows step from using relationship filters.

This is scoped to non-trigger automation steps. Query Rows and other action steps execute filters through the server-side row search, which supports relationship fields. Trigger filters remain restricted because row-created and row-updated triggers evaluate filters in memory against the event row rather than joining related records.

This distinction preserves the mitigation from issue #14883. That issue documented relationship trigger filters failing to fire, and the closing decision was to remove relationship fields from automation filter options. The current change avoids reintroducing that trigger regression while allowing the supported Query Rows use case from issue #19480.

Tested both InternalDB (sqs) and PostgreSQL with relationships.

## Addresses
- https://github.com/Budibase/budibase/issues/19480
- https://github.com/Budibase/budibase/issues/14883

## Screenshots
<img width="822" height="698" alt="trigger filter" src="https://github.com/user-attachments/assets/826f3914-0d2b-4fd1-a63e-dd1d3c67ee14" />

**Relationship filtering is not allowed for triggers, e.g. Row created**

<img width="1210" height="698" alt="query_rows_filter" src="https://github.com/user-attachments/assets/5f87c4e2-a32a-40b3-ace4-d113dfc1e8ba" />

**Relationship filtering has been re-enabled for non-triggers, e.g. Query rows**

## Launchcontrol
Allow relationship fields to be used when filtering rows in non-trigger automation steps, while keeping them unavailable for trigger filters where they are not supported.