### PR TITLE
chore: exempt draft PRs from stale bot

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -19,4 +19,5 @@ jobs:
         days-before-pr-stale: 7
         days-before-pr-close: 14
         exempt-pr-labels: pinned,security,roadmap
+        exempt-draft-pr: true
         operations-per-run: 100


### PR DESCRIPTION
## Description
Configure the stale bot to ignore draft pull requests.

## Launchcontrol
Draft pull requests will no longer be marked stale or automatically closed.