### PR TITLE
[19475] Fix automation branch state bindings

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/BranchStepPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/BranchStepPanel.svelte
@@ -30,6 +30,10 @@
     isBranchStep,
   } from "@budibase/types"
   import { QueryUtils, Utils, memo } from "@budibase/frontend-core"
+  import {
+    readableToRuntimeBinding,
+    runtimeToReadableBinding,
+  } from "@/dataBinding"
   import { cloneDeep } from "lodash/fp"
 
   const [resizable, resizableHandle] = getVerticalResizeActions()
@@ -295,6 +299,8 @@
       schemaFields={branchSchemaFields}
       datasource={{ type: "custom" }}
       panel={AutomationBindingPanel}
+      toReadable={runtimeToReadableBinding}
+      toRuntime={readableToRuntimeBinding}
       on:change={e => {
         editableBranchConditionUI = e.detail
       }}

--- a/packages/builder/src/components/automation/AutomationBuilder/BranchStepPanel.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/BranchStepPanel.test.ts
@@ -72,7 +72,14 @@ Object.assign(mocks.automationStore, {
   actions: {
     buildEnvironmentBindings: () => [],
     buildSettingBindings: () => [],
-    buildStateBindings: () => [],
+    buildStateBindings: () => [
+      {
+        category: "State",
+        display: { name: "State.sanitized_output" },
+        readableBinding: "State.sanitized_output",
+        runtimeBinding: "state.sanitized_output",
+      },
+    ],
     buildUserBindings: () => [],
     deleteBranch: vi.fn(),
     generateDefaultConditions: () => {
@@ -92,6 +99,7 @@ Object.assign(mocks.automationStore, {
       {
         category: "Trigger",
         display: { name: "ID" },
+        readableBinding: "trigger.id",
         runtimeBinding: "trigger.id",
       },
     ],
@@ -192,5 +200,46 @@ describe("BranchStepPanel", () => {
       ],
     })
     expect(savedBranch.condition).not.toEqual({})
+  })
+
+  it("converts readable state bindings to runtime bindings", async () => {
+    render(BranchStepPanel)
+
+    await fireEvent.click(screen.getByText("Add condition"))
+    await fireEvent.click(screen.getByText("Add condition group"))
+    const fieldInput = document.querySelector(
+      ".field-wrap input"
+    ) as HTMLInputElement
+    await fireEvent.input(fieldInput, {
+      target: { value: "{{ State.sanitized_output }}" },
+    })
+    await fireEvent.input(screen.getByPlaceholderText("Value"), {
+      target: { value: "Partnership" },
+    })
+    await fireEvent.click(screen.getByText("Save"))
+
+    await waitFor(() => {
+      expect(mocks.save).toHaveBeenCalledOnce()
+    })
+
+    const savedAutomation = mocks.save.mock.calls[0][0] as Automation
+    const savedBranch = (savedAutomation.definition.steps[0] as any).inputs
+      .branches[0]
+
+    expect(savedBranch.condition).toMatchObject({
+      $and: {
+        conditions: [
+          {
+            $or: {
+              conditions: [
+                {
+                  equal: { "{{ state.sanitized_output }}": "Partnership" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    })
   })
 })


### PR DESCRIPTION
## Description
Branch conditions using State bindings were saved with readable paths such as `State.sanitized_output`, while automation runtime context uses `state.sanitized_output`. This caused the condition to evaluate as undefined and fall through to the next branch.

The branch condition editor now converts readable and runtime bindings consistently, with regression coverage.

## Addresses
- https://github.com/Budibase/budibase/issues/19475

## Screenshots
https://github.com/user-attachments/assets/2fcc17ab-3cf1-443c-9075-5d816eb4b2f1

## Launchcontrol
Fixes automation branches that use State bindings.