### PR TITLE
[19484] Fix REST query HTTP verb dropdown overlap

### DIFF
--- a/packages/builder/src/components/integration/APIEndpointViewer.svelte
+++ b/packages/builder/src/components/integration/APIEndpointViewer.svelte
@@ -1669,7 +1669,7 @@
     position: relative;
   }
   .request-top {
-    z-index: 2;
+    z-index: 101;
   }
   .request-bottom {
     z-index: 1;


### PR DESCRIPTION
## Description
Fixes the REST query HTTP verb dropdown overlapping the query tabs when selecting DELETE or other verbs. The request header now stacks above the tabs so the dropdown remains visible and usable.

## Addresses
- https://github.com/Budibase/budibase/issues/19484

## Screenshots
<img width="570" height="351" alt="overlap" src="https://github.com/user-attachments/assets/5cf7eaee-8b64-40ba-b144-0cc27ec913b7" />

## Launchcontrol
Keeps the REST query HTTP verb menu visible above the query tabs.