### PR TITLE
fix: prevent form fields from collapsing to <50px in row flex containers (Fixes #19479)

### DIFF
--- a/packages/client/src/components/app/container/FlexContainer.svelte
+++ b/packages/client/src/components/app/container/FlexContainer.svelte
@@ -57,6 +57,7 @@
   /* The nested selector for data-type is the wrapper around all components */
   .direction-row :global(> .component > .size-grow) {
     width: 0;
+    flex: 1 1 auto;
   }
 
   .size-shrink {
@@ -64,6 +65,16 @@
   }
   .size-grow {
     flex: 1 1 auto;
+  }
+
+  /* Form fields (e.g. User Fields, text fields, etc.) inside a row flex
+     container should grow to fill available space equally, instead of
+     collapsing to their intrinsic content width (which can be <50px due
+     to picker-label width: 0 ellipsis tricks). Two User Fields side by
+     side in a row each take 50% of the container width. */
+  .direction-row :global(> .component > .spectrum-Form-item) {
+    flex: 1 1 0;
+    min-width: 0;
   }
 
   .direction-row.hAlign-left,


### PR DESCRIPTION
## Description

When two or more **User Fields** are placed inside a **Container** and the container is switched to `row` direction (to display them side-by-side), the fields collapse to **<50px wide** instead of sharing the available width (expected: 50% each).

### Root cause

Inside a row flex container, the field root element (`.spectrum-Form-item`) has no `flex` property and defaults to `flex: 0 1 auto`, which sizes it to its **intrinsic content width**. The `Picker`'s label uses a `width: 0` ellipsis trick, so the intrinsic width of the field is tiny (~40–50px). In column mode this is invisible because the column container stretches children to full width, but in row mode it collapses.

### Fix

Apply two CSS changes in `FlexContainer.svelte`:

1. **`flex: 1 1 auto`** added to the existing `.direction-row > .component > .size-grow` rule — it was setting `width: 0` without the actual flex property that makes the container grow.
2. **New rule** targeting `.spectrum-Form-item` inside a row flex container:

```css
.direction-row :global(> .component > .spectrum-Form-item) {
  flex: 1 1 0;
  min-width: 0;
}
```

This makes form fields (User Fields, text fields, etc.) share the available row width equally — two fields side by side each take 50% of the container, matching the expected behavior described in the issue.

### Testing

- N/A for automated tests — this is a pure CSS layout fix. Manual reproduction steps from the issue:
  1. Add a container to a screen (flex)
  2. Add two user fields to the container
  3. Switch container to "row" (from column)
  4. ✅ Fields now sit side-by-side occupying equal width

Fixes #19479


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents form fields from collapsing to under 50px in row flex containers; fields now share available width (two side-by-side take ~50% each). Previously `.spectrum-Form-item` used intrinsic content width; now row containers apply flex growth with `min-width: 0`.

**Review notes**
- Changes are limited to CSS in `packages/client/src/components/app/container/FlexContainer.svelte`.
- Adds `flex: 1 1 auto` to `.direction-row > .component > .size-grow` to actually grow with `width: 0`.
- Adds `.direction-row > .component > .spectrum-Form-item { flex: 1 1 0; min-width: 0; }` so form fields distribute width evenly.
- Applies only when container `direction=row`; column layout is unchanged.
- No migration required; existing screens with User Fields in row containers will render correctly.

<sup>Written for commit 546db39f9f6cb3d6b7446c02351d33cc23b2a91f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

