### PR TITLE
Batch user cache lookups in row output processing

### DIFF
--- a/packages/server/src/api/routes/tests/searchUserBatching.spec.ts
+++ b/packages/server/src/api/routes/tests/searchUserBatching.spec.ts
@@ -3,6 +3,7 @@ import {
   BBReferenceFieldSubType,
   FieldType,
   Table,
+  TableSchema,
   User,
 } from "@budibase/types"
 import TestConfiguration from "../../../tests/utilities/TestConfiguration"
@@ -11,17 +12,17 @@ import { basicTable } from "../../../tests/utilities/structures"
 const ROW_COUNT = 20
 const USER_COUNT = 5
 
-const userColumns = {
+const userColumns: TableSchema = {
   single_user: {
     name: "single_user",
-    type: FieldType.BB_REFERENCE_SINGLE as const,
+    type: FieldType.BB_REFERENCE_SINGLE,
     subtype: BBReferenceFieldSubType.USER,
   },
   multi_user: {
     name: "multi_user",
-    type: FieldType.BB_REFERENCE as const,
+    type: FieldType.BB_REFERENCE,
     subtype: BBReferenceFieldSubType.USER,
-    constraints: { type: "array" as const },
+    constraints: { type: "array" },
   },
 }
 

--- a/packages/server/src/api/routes/tests/searchUserBatching.spec.ts
+++ b/packages/server/src/api/routes/tests/searchUserBatching.spec.ts
@@ -1,0 +1,260 @@
+import { cache, context, RedisClient, utils } from "@budibase/backend-core"
+import {
+  BBReferenceFieldSubType,
+  FieldType,
+  Table,
+  User,
+} from "@budibase/types"
+import TestConfiguration from "../../../tests/utilities/TestConfiguration"
+import { basicTable } from "../../../tests/utilities/structures"
+
+const ROW_COUNT = 20
+const USER_COUNT = 5
+
+const userColumns = {
+  single_user: {
+    name: "single_user",
+    type: FieldType.BB_REFERENCE_SINGLE as const,
+    subtype: BBReferenceFieldSubType.USER,
+  },
+  multi_user: {
+    name: "multi_user",
+    type: FieldType.BB_REFERENCE as const,
+    subtype: BBReferenceFieldSubType.USER,
+    constraints: { type: "array" as const },
+  },
+}
+
+describe("search - user column redis usage", () => {
+  const config = new TestConfiguration()
+
+  let users: User[]
+  let table: Table
+
+  beforeAll(async () => {
+    await config.init()
+
+    users = []
+    for (let i = 0; i < USER_COUNT; i++) {
+      users.push(await config.createUser({ _id: `us_${utils.newid()}` }))
+    }
+
+    table = await config.api.table.save(
+      basicTable(undefined, { schema: userColumns })
+    )
+
+    for (let i = 0; i < ROW_COUNT; i++) {
+      await config.api.row.save(table._id!, {
+        name: `row ${i}`,
+        single_user: users[i % USER_COUNT],
+        multi_user: [users[i % USER_COUNT], users[(i + 1) % USER_COUNT]],
+      })
+    }
+  })
+
+  afterAll(() => {
+    config.end()
+  })
+
+  const isUserKey = (key: string) => key.startsWith("us_")
+
+  async function trackUserLookups<T>(task: () => Promise<T>) {
+    const gets = jest.spyOn(RedisClient.prototype, "get")
+    const bulkGets = jest.spyOn(RedisClient.prototype, "bulkGet")
+
+    try {
+      const result = await task()
+      const bulkGetCalls = bulkGets.mock.calls.filter(([keys]) =>
+        keys.some(isUserKey)
+      )
+
+      return {
+        result,
+        gets: gets.mock.calls.filter(([key]) => isUserKey(key)).length,
+        bulkGets: bulkGetCalls.length,
+        keysFetched: bulkGetCalls.reduce((acc, [keys]) => acc + keys.length, 0),
+      }
+    } finally {
+      gets.mockRestore()
+      bulkGets.mockRestore()
+    }
+  }
+
+  async function countUserLookups(limit: number) {
+    const { result, gets, bulkGets } = await trackUserLookups(() =>
+      config.api.row.search(table._id!, { query: {}, limit })
+    )
+    expect(result.rows).toHaveLength(limit)
+    return { gets, bulkGets }
+  }
+
+  it("fetches referenced users in one round trip, whatever the page size", async () => {
+    const smallPage = await countUserLookups(5)
+    const largePage = await countUserLookups(ROW_COUNT)
+
+    // the remaining single-key gets authenticate the caller, they don't scale
+    // with the rows being returned
+    expect(largePage).toEqual(smallPage)
+    expect(largePage.bulkGets).toBe(1)
+  })
+
+  it("returns fully enriched user columns", async () => {
+    const { rows } = await config.api.row.search(table._id!, { query: {} })
+    const row = rows.find(r => r.name === "row 0")!
+
+    expect(row.single_user).toEqual({
+      _id: users[0]._id,
+      primaryDisplay: users[0].email,
+      email: users[0].email,
+      firstName: users[0].firstName,
+      lastName: users[0].lastName,
+      fullName: expect.anything(),
+    })
+    expect(row.multi_user).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ _id: users[0]._id, email: users[0].email }),
+        expect.objectContaining({ _id: users[1]._id, email: users[1].email }),
+      ])
+    )
+  })
+
+  it("deduplicates repeated references into one batch", async () => {
+    const { keysFetched, bulkGets } = await trackUserLookups(() =>
+      config.api.row.search(table._id!, { query: {}, limit: ROW_COUNT })
+    )
+
+    // 20 rows reference the same 5 users across two columns - 40 references
+    expect(bulkGets).toBe(1)
+    expect(keysFetched).toBe(USER_COUNT)
+  })
+
+  it("preserves the stored order of a multi user column", async () => {
+    const ordered = await config.api.row.save(table._id!, {
+      name: "ordered",
+      multi_user: [users[3], users[1], users[4]],
+    })
+
+    const { rows } = await config.api.row.search(table._id!, {
+      query: { equal: { _id: ordered._id } },
+    })
+
+    expect(rows[0].multi_user.map((u: User) => u._id)).toEqual([
+      users[3]._id,
+      users[1]._id,
+      users[4]._id,
+    ])
+  })
+
+  it("keeps that order when the cache is only partially warm", async () => {
+    const ordered = await config.api.row.save(table._id!, {
+      name: "partially cached",
+      multi_user: [users[3], users[1], users[4]],
+    })
+
+    await config.doInContext(undefined, () =>
+      cache.user.invalidateUser(users[1]._id!)
+    )
+
+    const { rows } = await config.api.row.search(table._id!, {
+      query: { equal: { _id: ordered._id } },
+    })
+
+    expect(rows[0].multi_user.map((u: User) => u._id)).toEqual([
+      users[3]._id,
+      users[1]._id,
+      users[4]._id,
+    ])
+  })
+
+  describe("empty values", () => {
+    let emptyTable: Table
+
+    beforeAll(async () => {
+      emptyTable = await config.api.table.save(
+        basicTable(undefined, { schema: userColumns })
+      )
+      await config.api.row.save(emptyTable._id!, { name: "no users" })
+      await config.api.row.save(emptyTable._id!, {
+        name: "explicitly empty",
+        single_user: null,
+        multi_user: [],
+      })
+    })
+
+    it("does not hit redis when no rows reference a user", async () => {
+      const { result, gets, bulkGets } = await trackUserLookups(() =>
+        config.api.row.search(emptyTable._id!, { query: {} })
+      )
+
+      expect(result.rows).toHaveLength(2)
+      expect(bulkGets).toBe(0)
+      expect(gets).toBe(3) // caller authentication only
+      for (const row of result.rows) {
+        expect(row.single_user).toBeUndefined()
+        expect(row.multi_user).toBeUndefined()
+      }
+    })
+  })
+
+  describe("dangling references", () => {
+    let danglingTable: Table
+    let deleted: User
+
+    beforeAll(async () => {
+      deleted = await config.createUser({ _id: `us_${utils.newid()}` })
+      danglingTable = await config.api.table.save(
+        basicTable(undefined, { schema: userColumns })
+      )
+
+      await config.api.row.save(danglingTable._id!, {
+        name: "dangling single",
+        single_user: deleted,
+        multi_user: [deleted, users[0]],
+      })
+      await config.api.row.save(danglingTable._id!, {
+        name: "all dangling",
+        multi_user: [deleted],
+      })
+
+      await config.doInContext(undefined, async () => {
+        const db = context.getGlobalDB()
+        const user = await db.get<User>(deleted._id!)
+        await db.remove(user._id!, user._rev!)
+        await cache.user.invalidateUser(deleted._id!)
+      })
+    })
+
+    it("drops references to users that no longer exist", async () => {
+      const { rows } = await config.api.row.search(danglingTable._id!, {
+        query: {},
+      })
+
+      const single = rows.find(r => r.name === "dangling single")!
+      expect(single.single_user).toBeUndefined()
+      expect(single.multi_user).toEqual([
+        expect.objectContaining({ _id: users[0]._id }),
+      ])
+
+      const allDangling = rows.find(r => r.name === "all dangling")!
+      expect(allDangling.multi_user).toBeUndefined()
+    })
+  })
+
+  describe("tables without user columns", () => {
+    let plainTable: Table
+
+    beforeAll(async () => {
+      plainTable = await config.api.table.save(basicTable())
+      await config.api.row.save(plainTable._id!, { name: "plain" })
+    })
+
+    it("makes no user lookups at all", async () => {
+      const { result, bulkGets } = await trackUserLookups(() =>
+        config.api.row.search(plainTable._id!, { query: {} })
+      )
+
+      expect(result.rows).toHaveLength(1)
+      expect(bulkGets).toBe(0)
+    })
+  })
+})

--- a/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
+++ b/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
@@ -4,6 +4,7 @@ import {
   BBReferenceFieldSubType,
   DocumentType,
   SEPARATOR,
+  User,
 } from "@budibase/types"
 import { getUserFullName } from "../users"
 import { InvalidBBRefError } from "./errors"
@@ -117,70 +118,80 @@ interface UserReferenceInfo {
   fullName?: string
 }
 
-export async function processOutputBBReference(
+export type UserReferenceMap = Record<string, UserReferenceInfo>
+
+function toUserReference(user: User): UserReferenceInfo {
+  return {
+    _id: user._id!,
+    primaryDisplay: user.email,
+    email: user.email,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    fullName: getUserFullName(user),
+  }
+}
+
+export function getBBReferenceIds(
+  value: string | string[] | null | undefined
+): string[] {
+  if (!value) {
+    return []
+  }
+  const ids = typeof value === "string" ? value.split(",") : value
+  return ids.filter(id => !!id)
+}
+
+export async function fetchUserReferences(
+  ids: string[]
+): Promise<UserReferenceMap> {
+  const uniqueIds = Array.from(new Set(ids.filter(id => !!id)))
+  if (!uniqueIds.length) {
+    return {}
+  }
+
+  const { users } = await cache.user.getUsers(uniqueIds)
+  return users.reduce((acc: UserReferenceMap, user) => {
+    acc[user._id!] = toUserReference(user)
+    return acc
+  }, {})
+}
+
+export function processOutputBBReference(
   value: string | null | undefined,
-  subtype: BBReferenceFieldSubType.USER
-): Promise<UserReferenceInfo | undefined> {
+  subtype: BBReferenceFieldSubType.USER,
+  users: UserReferenceMap
+): UserReferenceInfo | undefined {
   if (!value) {
     return undefined
   }
 
   switch (subtype) {
-    case BBReferenceFieldSubType.USER: {
-      let user
-      try {
-        user = await cache.user.getUser({
-          userId: value as string,
-        })
-      } catch (err: any) {
-        if (err.statusCode !== 404) {
-          throw err
-        }
-      }
-      if (!user) {
-        return undefined
-      }
-
-      return {
-        _id: user._id!,
-        primaryDisplay: user.email,
-        email: user.email,
-        firstName: user.firstName,
-        lastName: user.lastName,
-        fullName: getUserFullName(user),
-      }
-    }
+    case BBReferenceFieldSubType.USER:
+      return users[value]
     default:
       throw utils.unreachable(subtype)
   }
 }
 
-export async function processOutputBBReferences(
+export function processOutputBBReferences(
   value: string | string[] | null | undefined,
-  subtype: BBReferenceFieldSubType
-): Promise<UserReferenceInfo[] | undefined> {
+  subtype: BBReferenceFieldSubType,
+  users: UserReferenceMap
+): UserReferenceInfo[] | undefined {
   if (!value || (Array.isArray(value) && value.length === 0)) {
     return undefined
   }
-  const ids =
-    typeof value === "string" ? value.split(",").filter(id => !!id) : value
+  const ids = getBBReferenceIds(value)
 
   switch (subtype) {
     case BBReferenceFieldSubType.USER:
     case BBReferenceFieldSubType.USERS: {
-      const { users } = await cache.user.getUsers(ids)
-      if (!users.length) {
+      const found = ids.map(id => users[id]).filter(user => !!user)
+      if (!found.length) {
         return undefined
       }
 
-      return users.map(u => ({
-        _id: u._id!,
-        primaryDisplay: u.email,
-        email: u.email,
-        firstName: u.firstName,
-        lastName: u.lastName,
-        fullName: getUserFullName(u),
-      }))
+      return found
     }
     default:
       throw utils.unreachable(subtype)

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -33,10 +33,13 @@ import { InternalTables } from "../../db/utils"
 import { isExternalTableID } from "../../integrations/utils"
 import sdk from "../../sdk"
 import {
+  fetchUserReferences,
+  getBBReferenceIds,
   processInputBBReference,
   processInputBBReferences,
   processOutputBBReference,
   processOutputBBReferences,
+  UserReferenceMap,
 } from "./bbReferenceProcessor"
 import { allocateAutoColumnValues } from "./autoColumnState"
 import { TYPE_TRANSFORM_MAP } from "./map"
@@ -373,6 +376,23 @@ export async function coreOutputProcessing(
     table = source
   }
 
+  let userReferences: UserReferenceMap = {}
+  if (!opts.skipBBReferences) {
+    const referencedIds: string[] = []
+    for (const [property, column] of Object.entries(table.schema)) {
+      if (
+        column.type !== FieldType.BB_REFERENCE &&
+        column.type !== FieldType.BB_REFERENCE_SINGLE
+      ) {
+        continue
+      }
+      for (const row of rows) {
+        referencedIds.push(...getBBReferenceIds(row[property]))
+      }
+    }
+    userReferences = await fetchUserReferences(referencedIds)
+  }
+
   // process complex types: attachments, bb references...
   for (const [property, column] of Object.entries(table.schema)) {
     if (
@@ -408,9 +428,10 @@ export async function coreOutputProcessing(
       column.type == FieldType.BB_REFERENCE
     ) {
       for (const row of rows) {
-        row[property] = await processOutputBBReferences(
+        row[property] = processOutputBBReferences(
           row[property],
-          column.subtype
+          column.subtype,
+          userReferences
         )
       }
     } else if (
@@ -418,9 +439,10 @@ export async function coreOutputProcessing(
       column.type == FieldType.BB_REFERENCE_SINGLE
     ) {
       for (const row of rows) {
-        row[property] = await processOutputBBReference(
+        row[property] = processOutputBBReference(
           row[property],
-          column.subtype
+          column.subtype,
+          userReferences
         )
       }
     } else if (column.type === FieldType.DATETIME && column.timeOnly) {

--- a/packages/server/src/utilities/rowProcessor/tests/bbReferenceProcessor.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/bbReferenceProcessor.spec.ts
@@ -2,6 +2,8 @@ import _ from "lodash"
 import * as backendCore from "@budibase/backend-core"
 import { BBReferenceFieldSubType, User } from "@budibase/types"
 import {
+  fetchUserReferences,
+  getBBReferenceIds,
   processInputBBReference,
   processInputBBReferences,
   processOutputBBReference,
@@ -234,14 +236,43 @@ describe("bbReferenceProcessor", () => {
     })
   })
 
+  describe("fetchUserReferences", () => {
+    it("fetches all referenced users in a single cache call", async () => {
+      const [user1, user2] = _.sampleSize(users, 2)
+      const userId1 = user1._id!
+      const userId2 = user2._id!
+
+      const result = await config.doInTenant(() =>
+        fetchUserReferences([userId1, userId2, userId1])
+      )
+
+      expect(Object.keys(result)).toEqual(
+        expect.arrayContaining([userId1, userId2])
+      )
+      expect(cacheGetUsersSpy).toHaveBeenCalledTimes(1)
+      expect(cacheGetUsersSpy).toHaveBeenCalledWith([userId1, userId2])
+    })
+
+    it("does not hit the cache when there is nothing to fetch", async () => {
+      const result = await config.doInTenant(() => fetchUserReferences([]))
+
+      expect(result).toEqual({})
+      expect(cacheGetUsersSpy).not.toHaveBeenCalled()
+    })
+  })
+
   describe("processOutputBBReference", () => {
     describe("subtype user", () => {
       it("fetches user given a valid string id", async () => {
         const user = _.sample(users)!
         const userId = user._id!
 
-        const result = await config.doInTenant(() =>
-          processOutputBBReference(userId, BBReferenceFieldSubType.USER)
+        const result = await config.doInTenant(async () =>
+          processOutputBBReference(
+            userId,
+            BBReferenceFieldSubType.USER,
+            await fetchUserReferences([userId])
+          )
         )
 
         expect(result).toEqual({
@@ -252,24 +283,24 @@ describe("bbReferenceProcessor", () => {
           lastName: user.lastName,
           fullName: `${user.firstName} ${user.lastName}`,
         })
-        expect(cacheGetUserSpy).toHaveBeenCalledTimes(1)
-        expect(cacheGetUserSpy).toHaveBeenCalledWith({
-          userId,
-        })
+        expect(cacheGetUsersSpy).toHaveBeenCalledTimes(1)
+        expect(cacheGetUsersSpy).toHaveBeenCalledWith([userId])
       })
 
       it("returns undefined given an unexisting user", async () => {
         const userId = generator.guid()
 
-        const result = await config.doInTenant(() =>
-          processOutputBBReference(userId, BBReferenceFieldSubType.USER)
+        const result = await config.doInTenant(async () =>
+          processOutputBBReference(
+            userId,
+            BBReferenceFieldSubType.USER,
+            await fetchUserReferences([userId])
+          )
         )
 
         expect(result).toBeUndefined()
-        expect(cacheGetUserSpy).toHaveBeenCalledTimes(1)
-        expect(cacheGetUserSpy).toHaveBeenCalledWith({
-          userId,
-        })
+        expect(cacheGetUsersSpy).toHaveBeenCalledTimes(1)
+        expect(cacheGetUsersSpy).toHaveBeenCalledWith([userId])
       })
     })
   })
@@ -280,8 +311,12 @@ describe("bbReferenceProcessor", () => {
         const user = _.sample(users)!
         const userId = user._id!
 
-        const result = await config.doInTenant(() =>
-          processOutputBBReferences(userId, BBReferenceFieldSubType.USER)
+        const result = await config.doInTenant(async () =>
+          processOutputBBReferences(
+            userId,
+            BBReferenceFieldSubType.USER,
+            await fetchUserReferences([userId])
+          )
         )
 
         expect(result).toEqual([
@@ -302,11 +337,13 @@ describe("bbReferenceProcessor", () => {
         const [user1, user2] = _.sampleSize(users, 2)
         const userId1 = user1._id!
         const userId2 = user2._id!
+        const input = [userId1, userId2].join(",")
 
-        const result = await config.doInTenant(() =>
+        const result = await config.doInTenant(async () =>
           processOutputBBReferences(
-            [userId1, userId2].join(","),
-            BBReferenceFieldSubType.USER
+            input,
+            BBReferenceFieldSubType.USER,
+            await fetchUserReferences(getBBReferenceIds(input))
           )
         )
 
@@ -342,8 +379,12 @@ describe("bbReferenceProcessor", () => {
           userId2,
         ].join(",")
 
-        const result = await config.doInTenant(() =>
-          processOutputBBReferences(input, BBReferenceFieldSubType.USER)
+        const result = await config.doInTenant(async () =>
+          processOutputBBReferences(
+            input,
+            BBReferenceFieldSubType.USER,
+            await fetchUserReferences(getBBReferenceIds(input))
+          )
         )
 
         expect(result).toHaveLength(2)

--- a/packages/server/src/utilities/rowProcessor/tests/inputProcessing.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/inputProcessing.spec.ts
@@ -14,6 +14,8 @@ jest.mock("../bbReferenceProcessor", (): typeof bbReferenceProcessor => ({
   processInputBBReferences: jest.fn(),
   processOutputBBReference: jest.fn(),
   processOutputBBReferences: jest.fn(),
+  getBBReferenceIds: jest.fn(),
+  fetchUserReferences: jest.fn(),
 }))
 
 describe("rowProcessor - inputProcessing", () => {

--- a/packages/server/src/utilities/rowProcessor/tests/outputProcessing.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/outputProcessing.spec.ts
@@ -17,6 +17,8 @@ jest.mock("../bbReferenceProcessor", (): typeof bbReferenceProcessor => ({
   processInputBBReferences: jest.fn(),
   processOutputBBReference: jest.fn(),
   processOutputBBReferences: jest.fn(),
+  getBBReferenceIds: jest.fn(),
+  fetchUserReferences: jest.fn(),
 }))
 
 describe("rowProcessor - outputProcessing", () => {
@@ -30,14 +32,20 @@ describe("rowProcessor - outputProcessing", () => {
     config.end()
   })
 
-  beforeEach(() => {
-    jest.resetAllMocks()
-  })
-
   const processOutputBBReferenceMock =
     bbReferenceProcessor.processOutputBBReference as jest.Mock
   const processOutputBBReferencesMock =
     bbReferenceProcessor.processOutputBBReferences as jest.Mock
+  const getBBReferenceIdsMock =
+    bbReferenceProcessor.getBBReferenceIds as jest.Mock
+  const fetchUserReferencesMock =
+    bbReferenceProcessor.fetchUserReferences as jest.Mock
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    getBBReferenceIdsMock.mockReturnValue([])
+    fetchUserReferencesMock.mockResolvedValue({})
+  })
 
   it("fetches single user references given a populated field", async () => {
     await config.doInContext(config.getDevWorkspaceId(), async () => {
@@ -74,7 +82,7 @@ describe("rowProcessor - outputProcessing", () => {
       }
 
       const user = structures.users.user()
-      processOutputBBReferenceMock.mockResolvedValue(user)
+      processOutputBBReferenceMock.mockReturnValue(user)
 
       const result = await outputProcessing(table, row, { squash: false })
 
@@ -85,7 +93,7 @@ describe("rowProcessor - outputProcessing", () => {
       ).toHaveBeenCalledTimes(1)
       expect(
         bbReferenceProcessor.processOutputBBReference
-      ).toHaveBeenCalledWith("123", BBReferenceFieldSubType.USER)
+      ).toHaveBeenCalledWith("123", BBReferenceFieldSubType.USER, {})
     })
   })
 
@@ -124,7 +132,7 @@ describe("rowProcessor - outputProcessing", () => {
       }
 
       const users = [structures.users.user()]
-      processOutputBBReferencesMock.mockResolvedValue(users)
+      processOutputBBReferencesMock.mockReturnValue(users)
 
       const result = await outputProcessing(table, row, { squash: false })
 
@@ -135,7 +143,7 @@ describe("rowProcessor - outputProcessing", () => {
       ).toHaveBeenCalledTimes(1)
       expect(
         bbReferenceProcessor.processOutputBBReferences
-      ).toHaveBeenCalledWith("123", BBReferenceFieldSubType.USER)
+      ).toHaveBeenCalledWith("123", BBReferenceFieldSubType.USER, {})
     })
   })
 


### PR DESCRIPTION
This came straight from a Datadog suggestion that resource:search is way slower than it should, having O(N) complexity (performing roundtrips for getting user references). Given different page sizes:

10 -> 23 round trips
25 -> 53
50 -> 103
100 -> 203

So it falls under a 2N + 3.

This implements 1 MGET to reduce the complexity to O(1).

10 -> 4
25 -> 4
50 -> 4
100 -> 4

Latency remains stable regardless of how the page size increases. 

 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch user reference lookups during row output into a single Redis bulk get, reducing per-page latency from O(N) to O(1). Previously each row hit `cache.user` per reference; now we collect all user IDs across returned rows, bulk-fetch once via `cache.user.getUsers`, and enrich from a pre-fetched map.

- Add `getBBReferenceIds`, `fetchUserReferences`, and `UserReferenceMap`; `coreOutputProcessing` deduplicates IDs across BB reference columns and performs one lookup, skipping when no BB reference columns exist.
- Make `processOutputBBReference` and `processOutputBBReferences` synchronous and map-based; they no longer perform cache calls.
- Preserve multi-user column order, deduplicate repeated IDs, and drop nonexistent users; behavior is unchanged when no user values are present.
- Tests: add `packages/server/src/api/routes/tests/searchUserBatching.spec.ts` to validate a single bulk fetch regardless of page size and proper enrichment/order; update row processor tests to mock the new helpers and sync processors.

<sup>Written for commit 14961fdedc83e2ebb73b35c1c24b1cc1b3b02d85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

