### PR TITLE
Prune losing SQS definition branches

### DIFF
--- a/packages/backend-core/src/db/couch/DatabaseImpl.ts
+++ b/packages/backend-core/src/db/couch/DatabaseImpl.ts
@@ -210,6 +210,13 @@ export class DatabaseImpl implements Database {
     })
   }
 
+  async getConflicts(id: string): Promise<string[]> {
+    const doc = await this.performCall(db => {
+      return () => db.get(id, { conflicts: true })
+    })
+    return (doc as Document & { _conflicts?: string[] })._conflicts || []
+  }
+
   async tryGet<T extends Document>(id?: string): Promise<T | undefined> {
     try {
       return await this.get<T>(id)

--- a/packages/backend-core/src/db/instrumentation.ts
+++ b/packages/backend-core/src/db/instrumentation.ts
@@ -42,6 +42,13 @@ export class DDInstrumentedDatabase implements Database {
     })
   }
 
+  getConflicts(id: string): Promise<string[]> {
+    return tracer.trace("db.getConflicts", span => {
+      span.addTags({ db_name: this.name, doc_id: id })
+      return this.db.getConflicts(id)
+    })
+  }
+
   tryGet<T extends Document>(id?: string | undefined): Promise<T | undefined> {
     return tracer.trace("db.tryGet", async span => {
       span.addTags({ db_name: this.name, doc_id: id })

--- a/packages/server/src/sdk/workspace/tables/internal/sqs.ts
+++ b/packages/server/src/sdk/workspace/tables/internal/sqs.ts
@@ -141,12 +141,6 @@ async function buildBaseDefinition(): Promise<PreSaveSQLiteDefinition> {
   return definition
 }
 
-// The definition is replicated from development to production on publish, while
-// both databases can also write it locally - a search that hits a missing table
-// or column resyncs it in whichever workspace the query ran. That leaves CouchDB
-// holding unrelated revision branches for the same document, and every losing
-// branch is a full copy of the projection that has to be retained and reconciled
-// on each read. Drop them once the winning definition is in place.
 async function pruneConflicts(db: Database) {
   const conflicts = await db.getConflicts(SQLITE_DESIGN_DOC_ID)
   if (!conflicts.length) {

--- a/packages/server/src/sdk/workspace/tables/internal/sqs.ts
+++ b/packages/server/src/sdk/workspace/tables/internal/sqs.ts
@@ -141,15 +141,20 @@ async function buildBaseDefinition(): Promise<PreSaveSQLiteDefinition> {
   return definition
 }
 
+// best effort - the definition is already written, the next sync retries
 async function pruneConflicts(db: Database) {
-  const conflicts = await db.getConflicts(SQLITE_DESIGN_DOC_ID)
-  if (!conflicts.length) {
-    return
+  try {
+    const conflicts = await db.getConflicts(SQLITE_DESIGN_DOC_ID)
+    if (!conflicts.length) {
+      return
+    }
+    await db.bulkRemove(
+      conflicts.map(rev => ({ _id: SQLITE_DESIGN_DOC_ID, _rev: rev })),
+      { silenceErrors: true }
+    )
+  } catch (err) {
+    console.warn("Unable to prune conflicting SQLite definitions", err)
   }
-  await db.bulkRemove(
-    conflicts.map(rev => ({ _id: SQLITE_DESIGN_DOC_ID, _rev: rev })),
-    { silenceErrors: true }
-  )
 }
 
 export async function syncDefinition(

--- a/packages/server/src/sdk/workspace/tables/internal/sqs.ts
+++ b/packages/server/src/sdk/workspace/tables/internal/sqs.ts
@@ -1,6 +1,7 @@
 import { context, sql, SQLITE_DESIGN_DOC_ID } from "@budibase/backend-core"
 import { helpers, PROTECTED_INTERNAL_COLUMNS } from "@budibase/shared-core"
 import {
+  Database,
   FieldType,
   PreSaveSQLiteDefinition,
   RelationshipFieldMetadata,
@@ -140,6 +141,23 @@ async function buildBaseDefinition(): Promise<PreSaveSQLiteDefinition> {
   return definition
 }
 
+// The definition is replicated from development to production on publish, while
+// both databases can also write it locally - a search that hits a missing table
+// or column resyncs it in whichever workspace the query ran. That leaves CouchDB
+// holding unrelated revision branches for the same document, and every losing
+// branch is a full copy of the projection that has to be retained and reconciled
+// on each read. Drop them once the winning definition is in place.
+async function pruneConflicts(db: Database) {
+  const conflicts = await db.getConflicts(SQLITE_DESIGN_DOC_ID)
+  if (!conflicts.length) {
+    return
+  }
+  await db.bulkRemove(
+    conflicts.map(rev => ({ _id: SQLITE_DESIGN_DOC_ID, _rev: rev })),
+    { silenceErrors: true }
+  )
+}
+
 export async function syncDefinition(
   db = context.getWorkspaceDB()
 ): Promise<void> {
@@ -159,6 +177,7 @@ export async function syncDefinition(
   if (!existing || !isEqual(existing.sql, definition.sql)) {
     await db.put(definition)
   }
+  await pruneConflicts(db)
 }
 
 export async function addTable(table: Table) {

--- a/packages/server/src/sdk/workspace/tables/internal/tests/sqs.spec.ts
+++ b/packages/server/src/sdk/workspace/tables/internal/tests/sqs.spec.ts
@@ -1,0 +1,48 @@
+import { db as dbCore, SQLITE_DESIGN_DOC_ID } from "@budibase/backend-core"
+import { SQLiteDefinition } from "@budibase/types"
+import * as setup from "../../../../../api/routes/tests/utilities"
+import sdk from "../../../../../sdk"
+import { basicTable } from "../../../../../tests/utilities/structures"
+
+const config = setup.getConfig()
+
+describe("sqs definition conflicts", () => {
+  beforeAll(async () => {
+    await config.init()
+  })
+
+  it("removes losing definition branches left behind by replication", async () => {
+    const table = await config.api.table.save(basicTable())
+    const devId = config.getDevWorkspaceId()
+    const prodId = config.getProdWorkspaceId()
+
+    // give production its own unrelated revision branch for the definition, the
+    // state a local resync leaves behind when it runs outside the dev workspace
+    const prodDb = dbCore.getDB(prodId)
+    await prodDb.put({
+      _id: SQLITE_DESIGN_DOC_ID,
+      language: "sqlite",
+      sql: { tables: {}, options: { table_name: "tableId" } },
+    })
+
+    const replication = new dbCore.Replication({
+      source: devId,
+      target: prodId,
+    })
+    try {
+      await replication.replicate(replication.appReplicateOpts())
+    } finally {
+      await replication.close()
+    }
+
+    expect(
+      (await prodDb.getConflicts(SQLITE_DESIGN_DOC_ID)).length
+    ).toBeGreaterThan(0)
+
+    await config.doInContext(prodId, () => sdk.tables.sqs.syncDefinition())
+
+    expect(await prodDb.getConflicts(SQLITE_DESIGN_DOC_ID)).toEqual([])
+    const definition = await prodDb.get<SQLiteDefinition>(SQLITE_DESIGN_DOC_ID)
+    expect(definition.sql.tables[table._id!]).toBeDefined()
+  })
+})

--- a/packages/server/src/sdk/workspace/tables/internal/tests/sqs.spec.ts
+++ b/packages/server/src/sdk/workspace/tables/internal/tests/sqs.spec.ts
@@ -45,4 +45,19 @@ describe("sqs definition conflicts", () => {
     const definition = await prodDb.get<SQLiteDefinition>(SQLITE_DESIGN_DOC_ID)
     expect(definition.sql.tables[table._id!]).toBeDefined()
   })
+
+  it("still writes the definition when pruning fails", async () => {
+    const table = await config.api.table.save(basicTable())
+    const db = dbCore.getDB(config.getDevWorkspaceId())
+    jest
+      .spyOn(db, "getConflicts")
+      .mockRejectedValue(new Error("couch unavailable"))
+
+    await config.doInContext(config.getDevWorkspaceId(), () =>
+      sdk.tables.sqs.syncDefinition(db)
+    )
+
+    const definition = await db.get<SQLiteDefinition>(SQLITE_DESIGN_DOC_ID)
+    expect(definition.sql.tables[table._id!]).toBeDefined()
+  })
 })

--- a/packages/types/src/sdk/db.ts
+++ b/packages/types/src/sdk/db.ts
@@ -127,6 +127,10 @@ export interface Database {
    */
   get<T extends Document>(id?: string): Promise<T>
   tryGet<T extends Document>(id?: string): Promise<T | undefined>
+  /**
+   * Returns the revisions of any losing conflict branches held for a document.
+   */
+  getConflicts(id: string): Promise<string[]>
   getMultiple<T extends Document>(
     ids?: string[],
     opts?: { allowMissing?: boolean; excludeDocs?: boolean }

--- a/packages/types/src/sdk/db.ts
+++ b/packages/types/src/sdk/db.ts
@@ -127,9 +127,7 @@ export interface Database {
    */
   get<T extends Document>(id?: string): Promise<T>
   tryGet<T extends Document>(id?: string): Promise<T | undefined>
-  /**
-   * Returns the revisions of any losing conflict branches held for a document.
-   */
+  // revisions of any losing conflict branches held for a document
   getConflicts(id: string): Promise<string[]>
   getMultiple<T extends Document>(
     ids?: string[],


### PR DESCRIPTION
## Description

Production workspaces accumulate conflicting revision branches of the SQLite
definition document (`_design/sqlite`), which degrades SQS until queries time
out at the gateway.
## Addresses

- Raised from production investigation of a tenant whose
  `app-service` SQS queries were returning `504 Gateway Time-out`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes losing `_design/sqlite` conflict branches after syncing the SQS SQLite definition to stop buildup that slowed queries and caused timeouts. Previously we left conflict leaves from dev→prod publishes and local resyncs and pruning failures could abort the sync; now we delete non‑winning leaves after writing the winning definition and ignore pruning errors.

- Adds `Database.getConflicts(id)` in `@budibase/backend-core` (traced in `DDInstrumentedDatabase`) and updates `Database` in `@budibase/types`.
- `syncDefinition()` does best‑effort pruning via `bulkRemove` with `{ silenceErrors: true }`, wrapped in try/catch so Couch/transport errors don’t fail the definition write.
- Tests cover pruning after replication and that the definition still writes if pruning fails.
- No config or migration; existing leaves drop on the next definition sync.

<sup>Written for commit 6e1b5159851a6ccd71980dbbf895ea171ec2b1c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



