### PR TITLE
point to the correct route for apps

### DIFF
--- a/packages/builder/src/pages/builder/apps/index.svelte
+++ b/packages/builder/src/pages/builder/apps/index.svelte
@@ -138,7 +138,7 @@
                 {menuLabels.password}
               </MenuItem>
               {#if sdk.users.hasBuilderPermissions($auth.user)}
-                <MenuItem icon="code" on:click={() => $goto("/builder")}>
+                <MenuItem icon="code" on:click={() => $goto("/builder/apps")}>
                   {menuLabels.portal}
                 </MenuItem>
               {/if}


### PR DESCRIPTION
## Description
Change the open developer portal route to the correct URL: /builder/apps instead of builder/workspaces.

## Addresses
- Internal bug report, not logged.

## Launchcontrol
Fixes a wrong link that directed users to a black screen.