### PR TITLE
Add tool configuration modal improvements

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/operation/[operationId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/operation/[operationId]/index.svelte
@@ -76,6 +76,7 @@
   let removeToolDialog: ConfirmDialog | undefined = $state()
   let configureToolModal: ConfigureOperationToolModal | undefined = $state()
   let toolToRemove: AgentTool | undefined = $state()
+  let restoreToolConfiguration = $state(false)
   let toolToAdd: AgentTool | undefined = $state()
   let toolInsertPosition: { start: number; end: number } | undefined = $state()
 
@@ -408,8 +409,12 @@
     saveOperation()
   }
 
-  const confirmRemoveTool = (tool: AgentTool) => {
+  const confirmRemoveTool = (
+    tool: AgentTool,
+    returnToConfiguration = false
+  ) => {
     toolToRemove = tool
+    restoreToolConfiguration = returnToConfiguration
     removeToolDialog?.show()
   }
 
@@ -419,10 +424,17 @@
     }
     removeTool(toolToRemove)
     toolToRemove = undefined
+    restoreToolConfiguration = false
   }
 
-  const clearToolToRemove = () => {
+  const handleRemoveToolClose = () => {
+    const tool = toolToRemove
+    const shouldRestore = restoreToolConfiguration
     toolToRemove = undefined
+    restoreToolConfiguration = false
+    if (tool && shouldRestore) {
+      configureTool(tool)
+    }
   }
 
   const openToolMenu = (event: MouseEvent, tool: AgentTool) => {
@@ -440,15 +452,6 @@
       ],
       { x: event.clientX, y: event.clientY }
     )
-  }
-
-  const handleToolActions = (event: MouseEvent, tool: AgentTool) => {
-    event.stopPropagation()
-    if ($featureFlags[FeatureFlag.AI_AGENT_TOOL_SECURITY]) {
-      configureTool(tool)
-      return
-    }
-    openToolMenu(event, tool)
   }
 
   const configureTool = (tool: AgentTool) => {
@@ -663,13 +666,15 @@
                           </div>
                         </div>
                       {/if}
-                      <button
-                        class="tool-actions"
-                        aria-label={`Actions for ${tool.readableBinding}`}
-                        onclick={event => handleToolActions(event, tool)}
-                      >
-                        <Icon name="dots-three" size="XS" />
-                      </button>
+                      {#if !$featureFlags[FeatureFlag.AI_AGENT_TOOL_SECURITY]}
+                        <button
+                          class="tool-actions"
+                          aria-label={`Actions for ${tool.readableBinding}`}
+                          onclick={event => openToolMenu(event, tool)}
+                        >
+                          <Icon name="dots-three" size="XS" />
+                        </button>
+                      {/if}
                     </div>
                   </div>
                 {:else}
@@ -706,8 +711,7 @@
     okText="Remove"
     warning={true}
     onOk={handleRemoveToolConfirm}
-    onCancel={clearToolToRemove}
-    onClose={clearToolToRemove}
+    onClose={handleRemoveToolClose}
   >
     {#if toolToRemove?.readableBinding}
       Remove <b>{toolToRemove.readableBinding}</b> from this operation? Its binding
@@ -719,7 +723,7 @@
     <ConfigureOperationToolModal
       bind:this={configureToolModal}
       onSave={saveToolConfiguration}
-      onRemove={confirmRemoveTool}
+      onRemove={tool => confirmRemoveTool(tool, true)}
     />
   {/if}
 


### PR DESCRIPTION
## Description
Improvements for https://github.com/Budibase/budibase/pull/19502. That got merged before the comments were addressed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the tool configuration modal after canceling a removal started from it, and hides the actions menu when `FeatureFlag.AI_AGENT_TOOL_SECURITY` is enabled. Previously, canceling the remove confirmation closed the modal and left the operation view; now it returns to the configuration. The actions button used to show and route to either the menu or configuration based on the flag; now it shows only when the flag is off.

- Adds a restore path via `restoreToolConfiguration` so canceling the remove dialog re-opens the configuration modal; confirming removal proceeds without restoring.
- Consolidates dialog dismissal to `onClose` to avoid state drift; removes the separate cancel handler.
- Removes the intermediary `handleToolActions`; the three-dot menu button renders only when the security flag is off. No API or migration changes.

<sup>Written for commit f54f8212cac9313641976ff6f39f1224ba741d72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

