### PR TITLE
Hotfix - #19515

### DIFF
--- a/packages/backend-core/src/cache/tests/user.spec.ts
+++ b/packages/backend-core/src/cache/tests/user.spec.ts
@@ -1,7 +1,7 @@
 import { User } from "@budibase/types"
 import { generator, structures } from "../../../tests"
 import { DBTestConfiguration } from "../../../tests/extra"
-import { getUsers } from "../user"
+import { getUser, getUsers } from "../user"
 import { getGlobalDB } from "../../context"
 import _ from "lodash"
 
@@ -11,6 +11,9 @@ import * as redis from "../../redis/init"
 import { UserDB } from "../../users"
 
 const config = new DBTestConfiguration()
+
+const withAccountPortal = <T>(f: () => Promise<T>) =>
+  withEnv({ SELF_HOSTED: false, DISABLE_ACCOUNT_PORTAL: "" }, f)
 
 describe("user cache", () => {
   describe("getUsers", () => {
@@ -121,9 +124,6 @@ describe("user cache", () => {
     })
 
     describe("account portal", () => {
-      const withAccountPortal = <T>(f: () => Promise<T>) =>
-        withEnv({ SELF_HOSTED: false, DISABLE_ACCOUNT_PORTAL: "" }, f)
-
       afterEach(() => {
         jest.restoreAllMocks()
       })
@@ -225,6 +225,61 @@ describe("user cache", () => {
         ),
         notFoundIds: expect.arrayContaining(missingIds),
       })
+    })
+  })
+
+  describe("getUser", () => {
+    let user: User
+
+    beforeAll(async () => {
+      await config.doInTenant(async () => {
+        user = structures.users.user({ _id: generator.guid() })
+        await getGlobalDB().put(user)
+      })
+    })
+
+    beforeEach(async () => {
+      jest.restoreAllMocks()
+
+      const redisClient = await redis.getUserClient()
+      await redisClient.clear()
+    })
+
+    it("a failing account lookup does not fail the lookup", async () => {
+      jest
+        .spyOn(accounts, "getAccount")
+        .mockRejectedValue(new Error("account portal is down"))
+
+      const result = await withAccountPortal(() =>
+        config.doInTenant(() => getUser({ userId: user._id! }))
+      )
+
+      expect(result).toEqual({
+        ...user,
+        budibaseAccess: true,
+        _rev: expect.any(String),
+      })
+    })
+
+    it("a user with a failed account lookup is not cached", async () => {
+      const account = structures.accounts.cloudAccount()
+      const getAccountSpy = jest
+        .spyOn(accounts, "getAccount")
+        .mockRejectedValue(new Error("account portal is down"))
+
+      await withAccountPortal(() =>
+        config.doInTenant(() => getUser({ userId: user._id! }))
+      )
+
+      getAccountSpy.mockResolvedValue(account)
+
+      const result = await withAccountPortal(() =>
+        config.doInTenant(() => getUser({ userId: user._id! }))
+      )
+
+      expect(result).toEqual(
+        expect.objectContaining({ account, accountPortalAccess: true })
+      )
     })
   })
 })

--- a/packages/backend-core/src/cache/tests/user.spec.ts
+++ b/packages/backend-core/src/cache/tests/user.spec.ts
@@ -5,6 +5,8 @@ import { getUsers } from "../user"
 import { getGlobalDB } from "../../context"
 import _ from "lodash"
 
+import * as accounts from "../../accounts"
+import { withEnv } from "../../environment"
 import * as redis from "../../redis/init"
 import { UserDB } from "../../users"
 
@@ -116,6 +118,89 @@ describe("user cache", () => {
         userIdsToRequest[2],
         userIdsToRequest[4],
       ])
+    })
+
+    describe("account portal", () => {
+      const withAccountPortal = <T>(f: () => Promise<T>) =>
+        withEnv({ SELF_HOSTED: false, DISABLE_ACCOUNT_PORTAL: "" }, f)
+
+      afterEach(() => {
+        jest.restoreAllMocks()
+      })
+
+      it("a single failing account lookup does not fail the whole batch", async () => {
+        const usersToRequest = _.sampleSize(users, 3)
+        const userIdsToRequest = usersToRequest.map(x => x._id!)
+        const failingUser = usersToRequest[1]
+        const account = structures.accounts.cloudAccount()
+
+        jest
+          .spyOn(accounts, "getAccount")
+          .mockImplementation(async (email: string) => {
+            if (email === failingUser.email) {
+              throw new Error(`Error getting account by email ${email}`)
+            }
+            return account
+          })
+
+        const results = await withAccountPortal(() =>
+          config.doInTenant(() => getUsers(userIdsToRequest))
+        )
+
+        expect(results.users).toHaveLength(3)
+        expect(_.sortBy(results.users, "_id")).toEqual(
+          _.sortBy(
+            usersToRequest.map(u => ({
+              ...u,
+              budibaseAccess: true,
+              _rev: expect.any(String),
+              ...(u._id === failingUser._id
+                ? {}
+                : { account, accountPortalAccess: true }),
+            })),
+            "_id"
+          )
+        )
+      })
+
+      it("a user with a failed account lookup is not cached", async () => {
+        const usersToRequest = _.sampleSize(users, 3)
+        const userIdsToRequest = usersToRequest.map(x => x._id!)
+        const failingUser = usersToRequest[1]
+        const account = structures.accounts.cloudAccount()
+
+        const getAccountSpy = jest
+          .spyOn(accounts, "getAccount")
+          .mockImplementation(async (email: string) => {
+            if (email === failingUser.email) {
+              throw new Error(`Error getting account by email ${email}`)
+            }
+            return account
+          })
+
+        await withAccountPortal(() =>
+          config.doInTenant(() => getUsers(userIdsToRequest))
+        )
+
+        getAccountSpy.mockResolvedValue(account)
+        jest.spyOn(UserDB, "bulkGet")
+
+        const results = await withAccountPortal(() =>
+          config.doInTenant(() => getUsers(userIdsToRequest))
+        )
+
+        expect(UserDB.bulkGet).toHaveBeenCalledTimes(1)
+        expect(UserDB.bulkGet).toHaveBeenCalledWith([failingUser._id])
+        expect(results.users).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              _id: failingUser._id,
+              account,
+              accountPortalAccess: true,
+            }),
+          ])
+        )
+      })
     })
 
     it("requesting existing and unexisting ids will return found ones", async () => {

--- a/packages/backend-core/src/cache/user.ts
+++ b/packages/backend-core/src/cache/user.ts
@@ -6,7 +6,7 @@ import env from "../environment"
 import * as accounts from "../accounts"
 import { UserDB } from "../users"
 import { sdk } from "@budibase/shared-core"
-import { User, SSOUser, UserMetadata } from "@budibase/types"
+import { ContextUser, User, SSOUser, UserMetadata } from "@budibase/types"
 
 const EXPIRY_SECONDS = 3600
 
@@ -26,7 +26,7 @@ async function populateFromDB(
 
 // returns false when the account portal lookup failed - the user is still
 // usable, but must not be cached so that the next lookup can retry
-async function populateAccountInfo(user: User): Promise<boolean> {
+async function populateAccountInfo(user: ContextUser): Promise<boolean> {
   if (env.SELF_HOSTED || env.DISABLE_ACCOUNT_PORTAL) {
     return true
   }

--- a/packages/backend-core/src/cache/user.ts
+++ b/packages/backend-core/src/cache/user.ts
@@ -28,9 +28,28 @@ async function populateFromDB(userId: string, tenantId: string) {
   return user
 }
 
-async function populateUsersFromDB(
-  userIds: string[]
-): Promise<{ users: User[]; notFoundIds?: string[] }> {
+async function populateAccountInfo(user: User): Promise<boolean> {
+  if (env.SELF_HOSTED || env.DISABLE_ACCOUNT_PORTAL) {
+    return true
+  }
+  try {
+    const account = await accounts.getAccount(user.email)
+    if (account) {
+      user.account = account
+      user.accountPortalAccess = true
+    }
+    return true
+  } catch (err) {
+    console.error(`Failed to retrieve account for user ${user._id}`, err)
+    return false
+  }
+}
+
+async function populateUsersFromDB(userIds: string[]): Promise<{
+  users: User[]
+  notFoundIds?: string[]
+  accountLookupFailedIds: string[]
+}> {
   const getUsersResponse = await UserDB.bulkGet(userIds)
 
   // Handle missed user ids
@@ -38,23 +57,20 @@ async function populateUsersFromDB(
 
   const users = getUsersResponse.filter(x => x)
 
+  const accountLookupFailedIds: string[] = []
   await Promise.all(
     users.map(async (user: any) => {
       user.budibaseAccess = true
-      if (!env.SELF_HOSTED && !env.DISABLE_ACCOUNT_PORTAL) {
-        const account = await accounts.getAccount(user.email)
-        if (account) {
-          user.account = account
-          user.accountPortalAccess = true
-        }
+      if (!(await populateAccountInfo(user))) {
+        accountLookupFailedIds.push(user._id)
       }
     })
   )
 
   if (notFoundIds.length) {
-    return { users, notFoundIds }
+    return { users, notFoundIds, accountLookupFailedIds }
   }
-  return { users }
+  return { users, accountLookupFailedIds }
 }
 
 /**
@@ -140,7 +156,11 @@ export async function getUsers(
     const usersFromDb = await populateUsersFromDB(missingUsersFromCache)
 
     notFoundIds = usersFromDb.notFoundIds
+    const accountLookupFailedIds = new Set(usersFromDb.accountLookupFailedIds)
     for (const userToCache of usersFromDb.users) {
+      if (accountLookupFailedIds.has(userToCache._id!)) {
+        continue
+      }
       await client.store(userToCache._id!, userToCache, EXPIRY_SECONDS)
     }
     users.push(...usersFromDb.users)

--- a/packages/backend-core/src/cache/user.ts
+++ b/packages/backend-core/src/cache/user.ts
@@ -13,21 +13,19 @@ const EXPIRY_SECONDS = 3600
 /**
  * The default populate user function
  */
-async function populateFromDB(userId: string, tenantId: string) {
+async function populateFromDB(
+  userId: string,
+  tenantId: string
+): Promise<{ user: UserMetadata; accountLookupFailed: boolean }> {
   const db = tenancy.getTenantDB(tenantId)
   const user = await db.get<UserMetadata>(userId)
   user.budibaseAccess = true
-  if (!env.SELF_HOSTED && !env.DISABLE_ACCOUNT_PORTAL) {
-    const account = await accounts.getAccount(user.email)
-    if (account) {
-      user.account = account
-      user.accountPortalAccess = true
-    }
-  }
-
-  return user
+  const populated = await populateAccountInfo(user)
+  return { user, accountLookupFailed: !populated }
 }
 
+// returns false when the account portal lookup failed - the user is still
+// usable, but must not be cached so that the next lookup can retry
 async function populateAccountInfo(user: User): Promise<boolean> {
   if (env.SELF_HOSTED || env.DISABLE_ACCOUNT_PORTAL) {
     return true
@@ -98,9 +96,6 @@ export async function getUser({
     email?: string
   ) => Promise<User>
 }) {
-  if (!populateUser) {
-    populateUser = populateFromDB
-  }
   if (!tenantId) {
     try {
       tenantId = context.getTenantId()
@@ -112,8 +107,16 @@ export async function getUser({
   // try cache
   let user: User | SSOUser = await client.get(userId)
   if (!user) {
-    user = await populateUser(userId, tenantId, email)
-    await client.store(userId, user, EXPIRY_SECONDS)
+    const populated = populateUser
+      ? {
+          user: await populateUser(userId, tenantId, email),
+          accountLookupFailed: false,
+        }
+      : await populateFromDB(userId, tenantId)
+    user = populated.user
+    if (!populated.accountLookupFailed) {
+      await client.store(userId, user, EXPIRY_SECONDS)
+    }
   }
   if (user && !user.tenantId && tenantId) {
     // make sure the tenant ID is always correct/set


### PR DESCRIPTION
## Description
Hotfix for https://github.com/Budibase/budibase/pull/19515

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents account-portal outages from breaking user cache lookups. Previously, `getUsers`/`getUser` propagated `getAccount` errors and could fail; now they return users without account fields, skip caching those users, and retry population on subsequent requests.

- Batch: a single failed account lookup no longer fails `getUsers`; other users are returned, `notFoundIds` is preserved, and only users with failed lookups are not cached.
- Single: `getUser` returns the user with `budibaseAccess` set when the account lookup fails; that user is not cached until a successful retry populates account fields.
- Scope: behavior applies only when the account portal is enabled (not `SELF_HOSTED` and not `DISABLE_ACCOUNT_PORTAL`); adds error logging for failed account lookups.
- Implementation/tests: introduces `populateAccountInfo` and tracks `accountLookupFailed` to gate cache writes; updates bulk and single paths accordingly; adds tests covering failure tolerance and cache retry.

<sup>Written for commit 50214ea71ace2225c8ae33855c28a0d3f3b78628. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

