### PR TITLE
Client app svelte file to Typescript

### DIFF
--- a/packages/client/src/assets.d.ts
+++ b/packages/client/src/assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg?raw" {
+  const value: string
+  export default value
+}

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -1,5 +1,5 @@
-<script>
-  import { writable, get } from "svelte/store"
+<script lang="ts">
+  import { writable, get, derived } from "svelte/store"
   import { setContext, onMount } from "svelte"
   import { Layout, Heading, Body } from "@budibase/bbui"
   import ErrorSVG from "@budibase/frontend-core/assets/error.svg?raw"
@@ -7,7 +7,6 @@
     redirectToLoginWithReturnUrl,
     invalidationMessage,
     popNumSessionsInvalidated,
-    derivedMemo,
   } from "@budibase/frontend-core"
   import { getThemeClassNames } from "@budibase/shared-core"
   import Component from "./Component.svelte"
@@ -174,23 +173,26 @@
         embedded: !!$appStore.embedded,
       })
     }
+  })
+
+  onMount(() => {
     const handleHashChange = () => {
       const { open: sidePanelOpen } = $sidePanelStore
       // only close if the sidepanel is open and theres no onload side panel actions on the screen.
       if (
         sidePanelOpen &&
-        !$screenStore.activeScreen.onLoad?.some(
+        !$screenStore.activeScreen?.onLoad?.some(
           item => item["##eventHandlerType"] === "Open Side Panel"
         )
       ) {
         sidePanelStore.actions.close()
       }
 
-      const { open: modalOpen } = $modalStore
+      const modalOpen = $modalStore.contentId != null
       // only close if the modal is open and theres onload modals actions on the screen.
       if (
         modalOpen &&
-        !$screenStore.activeScreen.onLoad?.some(
+        !$screenStore.activeScreen?.onLoad?.some(
           item => item["##eventHandlerType"] === "Open Modal"
         )
       ) {
@@ -209,7 +211,7 @@
     }
   }
 
-  const builderActiveScreenId = derivedMemo(
+  const builderActiveScreenId = derived(
     [builderStore, screenStore],
     ([$builderStore, $screenStore]) =>
       $builderStore.inBuilder ? $screenStore.activeScreen?._id : undefined

--- a/packages/client/src/stores/routes.ts
+++ b/packages/client/src/stores/routes.ts
@@ -84,8 +84,8 @@ const createRouteStore = () => {
   }
   const navigate = (
     url: string,
-    peek: boolean,
-    externalNewTab: boolean,
+    peek = false,
+    externalNewTab = false,
     screenNewTab = false
   ) => {
     if (get(builderStore).inBuilder) {


### PR DESCRIPTION
## Description
Client app svelte file to Typescript

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts `ClientApp.svelte` to TypeScript and tightens route and UI state handling. Improves type safety for raw SVG imports and reduces edge-case errors when no screen is active.

- Adds `packages/client/src/assets.d.ts` to type `*.svg?raw` imports as `string`.
- Replaces `derivedMemo` from `@budibase/frontend-core` with Svelte `derived` for `builderActiveScreenId`.
- Registers the hashchange handler in `onMount`; close checks now:
  - Safely read `$screenStore.activeScreen?.onLoad` (was non-null access).
  - Treat a modal as open when `$modalStore.contentId != null` (was `$modalStore.open`).
- Sets default params in `routes.navigate(url, peek = false, externalNewTab = false, screenNewTab = false)` so callers can omit booleans; previously `peek` and `externalNewTab` had to be passed explicitly.

<sup>Written for commit f50beee39081f0b2302cf6d4abc33d6859665045. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

