### PR TITLE
Cut apps container memory footprint

### DIFF
--- a/packages/server/docker_run.sh
+++ b/packages/server/docker_run.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 
-if [ -z $CLUSTER_MODE ]; then
-  yarn run:docker
+# exec so that node replaces this shell as PID 1 and receives SIGTERM directly.
+# Going through yarn left a ~81MB node process resident for the lifetime of the
+# container, and bash does not forward signals to a foreground child, so
+# graceful shutdown never ran.
+
+NODE_ARGS=()
+if [ "$DISABLE_SOURCE_MAPS" != "1" ]; then
+  # ~150MB of retained source map per process - see run:docker in package.json.
+  NODE_ARGS+=(--enable-source-maps)
+fi
+
+if [ -z "$CLUSTER_MODE" ]; then
+  exec node "${NODE_ARGS[@]}" dist/index.js
 else
-  yarn run:docker:cluster
+  exec pm2-runtime start pm2.config.js
 fi

--- a/packages/server/docker_run.sh
+++ b/packages/server/docker_run.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-# exec so that node replaces this shell as PID 1 and receives SIGTERM directly.
-# Going through yarn left a ~81MB node process resident for the lifetime of the
-# container, and bash does not forward signals to a foreground child, so
-# graceful shutdown never ran.
 
 NODE_ARGS=()
 if [ "$DISABLE_SOURCE_MAPS" != "1" ]; then

--- a/packages/server/pm2.config.js
+++ b/packages/server/pm2.config.js
@@ -2,9 +2,6 @@ module.exports = {
   apps: [
     {
       script: "./dist/index.js",
-      // "max" counts the host's CPUs, not the container's cgroup CPU limit. On a
-      // 24 core host that forked 24 instances plus their worker farms - 79
-      // processes and 19GB of RSS - which is instant death under a pod limit.
       instances: process.env.CLUSTER_INSTANCES || "max",
       exec_mode: "cluster",
     },

--- a/packages/server/pm2.config.js
+++ b/packages/server/pm2.config.js
@@ -2,7 +2,10 @@ module.exports = {
   apps: [
     {
       script: "./dist/index.js",
-      instances: "max",
+      // "max" counts the host's CPUs, not the container's cgroup CPU limit. On a
+      // 24 core host that forked 24 instances plus their worker farms - 79
+      // processes and 19GB of RSS - which is instant death under a pod limit.
+      instances: process.env.CLUSTER_INSTANCES || "max",
       exec_mode: "cluster",
     },
   ],

--- a/packages/server/src/threads/index.ts
+++ b/packages/server/src/threads/index.ts
@@ -8,6 +8,19 @@ export enum ThreadType {
   AUTOMATION = "automation",
 }
 
+// child_process inherits the parent's execArgv when execArgv isn't given, which
+// duplicates flags that are only ever meant for the main process: --inspect
+// fights over the debugger port, and --max-semi-space-size reserves a whole
+// extra V8 young generation in every thread. Only forward what the threads
+// themselves need.
+const FORWARDED_EXEC_ARGV = ["--enable-source-maps"]
+
+function threadExecArgv() {
+  return process.execArgv.filter(arg =>
+    FORWARDED_EXEC_ARGV.some(flag => arg === flag || arg.startsWith(`${flag}=`))
+  )
+}
+
 function typeToFile(type: ThreadType) {
   let filename = null
   switch (type) {
@@ -57,11 +70,7 @@ export class Thread {
             FORKED_PROCESS: "1",
             FORKED_PROCESS_NAME: type,
           },
-          execArgv: process.execArgv.some(arg =>
-            arg.startsWith("--enable-source-maps")
-          )
-            ? ["--enable-source-maps"]
-            : undefined,
+          execArgv: threadExecArgv(),
         },
       }
       if (opts.timeoutMs) {


### PR DESCRIPTION
## Description

This pull request resolves out-of-memory crashes by preventing worker threads from inheriting process-heavy Node.js flags (like `--max-semi-space-size` and `--inspect`), replacing the Yarn docker entrypoint wrapper with direct `exec node` to ensure `SIGTERM` signals work properly, and allowing `CLUSTER_INSTANCES` to override default core scaling. These fixes keep memory usage within the 1Gi container limit without sacrificing source-mapped stack traces.


## Addresses
- Budibase/budibase-deploys#562

## Launchcontrol

Reduces the memory the apps container needs. Worker threads no longer inherit Node flags meant for the main process, the container runs Node directly instead of through yarn (which also means graceful shutdown now works on SIGTERM), and the pm2 cluster worker count can be capped to match a container's CPU allocation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the apps container’s memory footprint and fixes SIGTERM handling to avoid OOM/restart loops under 1Gi limits. Threads no longer inherit parent Node flags, Node runs as PID 1, and `pm2` cluster size can be capped to match container CPUs.

- Threads: forward only `--enable-source-maps` to children (old: `--inspect` and V8 flags duplicated, causing port conflicts and extra young-gen; new: filtered execArgv keeps only source maps).
- Entrypoint: `docker_run.sh` execs Node directly (old: bash → yarn → node; SIGTERM didn’t reach Node and an extra process stayed resident; new: Node is PID 1 and graceful shutdown runs).
- Clustering: `pm2.config.js` honors `CLUSTER_INSTANCES` (old: `"max"` used host CPUs inside containers; new: cap workers via `CLUSTER_INSTANCES`, default unchanged).
- Optional: set `DISABLE_SOURCE_MAPS=1` to drop per-process RSS; default keeps source-mapped stack traces.
- If running with `CLUSTER_MODE=1`, set `CLUSTER_INSTANCES` to your container CPU quota. No migration otherwise.

<sup>Written for commit 5c7fe3a055924c69cd44df2eefc36751b05216f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

