### PR TITLE
fix: resolve link datasources against their related table in field configuration

### DIFF
--- a/packages/builder/src/components/design/settings/controls/FieldConfiguration/FieldConfiguration.svelte
+++ b/packages/builder/src/components/design/settings/controls/FieldConfiguration/FieldConfiguration.svelte
@@ -63,7 +63,7 @@
       .filter(x => x != null)
   }
 
-  $: updateState(cachedValue, resourceId)
+  $: updateState(cachedValue, resourceId, datasource)
 
   // Builds unused ones only
   const buildUnconfiguredOptions = (schema, selected) => {

--- a/packages/builder/src/dataBinding.test.ts
+++ b/packages/builder/src/dataBinding.test.ts
@@ -1380,6 +1380,85 @@ describe("Builder dataBinding", () => {
       })
       expect(getSchemaForDatasourcePlus(undefined).schema).toEqual({})
     })
+
+    it("resolves link datasources to the related table schema", () => {
+      getTablesStore().set({
+        list: [
+          {
+            _id: "ta_source",
+            name: "Source",
+            sourceType: "internal",
+            schema: {
+              // The link field metadata carries the related table id
+              related: {
+                type: "link",
+                name: "related",
+                tableId: "ta_related",
+                fieldName: "source",
+                relationshipType: "one-to-many",
+              },
+              name: { type: "string", name: "name" },
+            },
+          },
+          {
+            _id: "ta_related",
+            name: "Related",
+            sourceType: "internal",
+            schema: {
+              title: { type: "string", name: "title" },
+              price: { type: "number", name: "price" },
+            },
+          },
+        ],
+      })
+
+      const { schema, table } = getSchemaForDatasource(null, {
+        type: "link",
+        tableId: "ta_source",
+        rowId: "{{ source._id }}",
+        rowTableId: "{{ source.tableId }}",
+        fieldName: "related",
+      })
+
+      expect(table).toMatchObject({ _id: "ta_related", name: "Related" })
+      expect(schema.title).toMatchObject({ type: "string", name: "title" })
+      expect(schema.price).toMatchObject({ type: "number", name: "price" })
+      // Fields from the source table must not leak through
+      expect(schema.name).toBeUndefined()
+      expect(schema.related).toBeUndefined()
+    })
+
+    it("returns an empty schema when a link field has no resolvable related table", () => {
+      getTablesStore().set({
+        list: [
+          {
+            _id: "ta_source",
+            name: "Source",
+            sourceType: "internal",
+            schema: {
+              // Link field with no matching related table in the store
+              related: {
+                type: "link",
+                name: "related",
+                tableId: "ta_missing",
+                fieldName: "source",
+                relationshipType: "one-to-many",
+              },
+            },
+          },
+        ],
+      })
+
+      const { schema } = getSchemaForDatasource(null, {
+        type: "link",
+        tableId: "ta_source",
+        rowId: "{{ source._id }}",
+        rowTableId: "{{ source.tableId }}",
+        fieldName: "related",
+      })
+
+      expect(schema).toEqual({})
+    })
   })
 
   describe("updateReferencesInObject", () => {

--- a/packages/builder/src/dataBinding.ts
+++ b/packages/builder/src/dataBinding.ts
@@ -31,7 +31,12 @@ import ActionDefinitions from "@/components/design/settings/controls/ButtonActio
 import { environment, licensing } from "@/stores/portal"
 import { convertOldFieldFormat } from "@/components/design/settings/controls/FieldConfiguration/utils"
 import { FIELDS, DB_TYPE_INTERNAL } from "@/constants/backend"
-import { CalculationType, FieldType, TableSourceType } from "@budibase/types"
+import {
+  CalculationType,
+  FieldType,
+  TableSourceType,
+  isRelationshipField,
+} from "@budibase/types"
 import type {
   Component,
   ComponentContext,
@@ -1440,6 +1445,22 @@ export const getSchemaForDatasource = (
       schema = asSchema(
         JSONUtils.getJSONArrayDatasourceSchema(schema, datasourceConfig)
       )
+    }
+
+    // "link" datasources are relationship datasources, scoped to the rows
+    // related to the parent row through a link field. Those rows belong to
+    // the related (target) table, not the source table the link field lives
+    // on, so the schema must come from the related table.
+    else if (type === "link") {
+      const sourceTable = tables.find(
+        table => table._id === datasourceConfig.tableId
+      )
+      const linkField = sourceTable?.schema?.[datasourceConfig.fieldName]
+      const relatedTableId =
+        linkField && isRelationshipField(linkField)
+          ? linkField.tableId
+          : undefined
+      table = tables.find(table => table._id === relatedTableId)
     }
 
     // Otherwise we assume we're targeting an internal table or a plus


### PR DESCRIPTION
## Description
The `fieldConfiguration` property editor lists the fields of a component's datasource. For relationship (`link`) datasources — e.g. the "Relationships" options in the datasource picker — it resolved the schema against the **source** table that hosts the link field, even though the rows of a link datasource belong to the **related (target)** table pointed to by the link field. This caused the editor to list the wrong fields for any component using a relationship datasource (for example custom plugin form blocks like SuperFormRepeatable, which had to work around this at runtime).

This change makes the builder resolve link datasources the same way the client runtime does: follow the link field metadata on the source table to its `tableId`, and derive the schema from that related table.

## Addresses
- https://github.com/Budibase/budibase/issues/19527

Closes #19527

## App Export
- N/A (builder behaviour change; no app export attached).

## Screenshots
- N/A (no UI-facing layout change; the builder now lists the correct fields).

## Launchcontrol
Relationship (link) data sources now show the fields of the related table in the field configuration editor, matching what the component actually renders at runtime.