### PR TITLE
fix: recognize custom plugin form contexts in filter/link property editors

### DIFF
--- a/packages/builder/src/components/design/settings/controls/RelationshipFilterEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/RelationshipFilterEditor.svelte
@@ -3,6 +3,7 @@
     findClosestMatchingComponent,
     findComponent,
   } from "@/helpers/components"
+  import { hasFormContext } from "@/helpers/formFields"
   import {
     getDatasourceForProvider,
     getSchemaForDatasource,
@@ -19,7 +20,7 @@
   $: form = findClosestMatchingComponent(
     $selectedScreen.props,
     componentInstance._id,
-    component => component._component.endsWith("/form")
+    hasFormContext
   )
 
   const resolveDatasource = (selectedScreen, componentInstance, form) => {

--- a/packages/builder/src/components/design/settings/controls/ResetFieldsButton.svelte
+++ b/packages/builder/src/components/design/settings/controls/ResetFieldsButton.svelte
@@ -2,6 +2,7 @@
   import { ActionButton, notifications } from "@budibase/bbui"
   import { selectedScreen, componentStore } from "@/stores/builder"
   import { findClosestMatchingComponent } from "@/helpers/components"
+  import { hasFormContext } from "@/helpers/formFields"
   import { makeDatasourceFormComponents } from "@/templates/commonComponents"
   import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
 
@@ -13,7 +14,7 @@
     const form = findClosestMatchingComponent(
       $selectedScreen?.props,
       componentInstance._id,
-      component => component._component.endsWith("/form")
+      hasFormContext
     )
     const dataSource = form?.dataSource
     const fields = makeDatasourceFormComponents(dataSource)

--- a/packages/builder/src/components/design/settings/controls/ValidationEditor/ValidationDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ValidationEditor/ValidationDrawer.svelte
@@ -26,6 +26,7 @@
   import { SvelteSet } from "svelte/reactivity"
   import { selectedScreen, selectedComponent } from "@/stores/builder"
   import { findClosestMatchingComponent } from "@/helpers/components"
+  import { hasFormContext } from "@/helpers/formFields"
   import {
     getSchemaForDatasource,
     getDatasourceForProvider,
@@ -138,9 +139,8 @@
     const formParent = findClosestMatchingComponent(
       asset.props,
       component._id,
-      (component: Component) =>
-        component._component.endsWith("/form") ||
-        component._component.endsWith("/formblock") ||
+      component =>
+        hasFormContext(component) ||
         component._component.endsWith("/tableblock")
     )
     const dataSource = resolveDatasource(asset, component, formParent)

--- a/packages/builder/src/helpers/bindings.ts
+++ b/packages/builder/src/helpers/bindings.ts
@@ -1,5 +1,6 @@
 import { makePropSafe } from "@budibase/string-templates"
 import { UIBinding } from "@budibase/types"
+import { hasFormContext } from "@/helpers/formFields"
 
 export function extractRelationships(bindings: UIBinding[]) {
   return (
@@ -7,7 +8,7 @@ export function extractRelationships(bindings: UIBinding[]) {
       // Get only link bindings
       .filter(x => x.fieldSchema?.type === "link")
       // Filter out bindings provided by forms
-      .filter(x => !x.component?.endsWith("/form"))
+      .filter(x => !hasFormContext(x.component ?? ""))
       .map(binding => {
         const { providerId, readableBinding, fieldSchema } = binding || {}
         const { name, tableId } = fieldSchema || {}

--- a/packages/builder/src/helpers/formFields.ts
+++ b/packages/builder/src/helpers/formFields.ts
@@ -5,8 +5,10 @@ import {
 } from "@/helpers/components"
 import type { Component, Screen } from "@budibase/types"
 
-const hasFormContext = (component: Component) => {
-  const contexts = getComponentContexts(component._component)
+export const hasFormContext = (component: Component | string) => {
+  const componentType =
+    typeof component === "string" ? component : component._component
+  const contexts = getComponentContexts(componentType)
   return contexts.some(context => context.type === "form")
 }
 

--- a/packages/builder/src/stores/builder/components.ts
+++ b/packages/builder/src/stores/builder/components.ts
@@ -15,7 +15,7 @@ import {
   makeComponentUnique,
   findComponentType,
 } from "@/helpers/components"
-import { getComponentFieldOptions } from "@/helpers/formFields"
+import { getComponentFieldOptions, hasFormContext } from "@/helpers/formFields"
 import { selectedScreen } from "./screens"
 import {
   screenStore,
@@ -489,7 +489,7 @@ export class ComponentStore extends BudiStore<ComponentState> {
       const parentForm = findClosestMatchingComponent(
         screen.props,
         get(selectedComponent)?._id,
-        (component: Component) => component._component.endsWith("/form")
+        (component: Component) => hasFormContext(component)
       )
       const formSteps = findAllMatchingComponents(
         parentForm,


### PR DESCRIPTION
## Description
The builder determines whether a component is a form using hardcoded component name checks (`component._component.endsWith("/form")`). This only matches the built-in form component, so **custom plugin components that export a `form` context** are not recognized as forms. That breaks form-datasource resolution in several property editors and the binding relationship filter for any such plugin.

This change exports a `hasFormContext` helper from `helpers/formFields.ts`, which checks the component definition for a `form` context (by `_component` type string or component instance), and replaces the hardcoded `endsWith("/form")` checks with it in:

- `RelationshipFilterEditor.svelte`
- `ResetFieldsButton.svelte`
- `ValidationEditor/ValidationDrawer.svelte`
- `helpers/bindings.ts` (`extractRelationships`)
- `stores/builder/components.ts` (parent-form lookup)

The deprecated `/tableblock` special case is kept separate since it does not expose a form context.

## Addresses
- https://github.com/Budibase/budibase/issues/19528

Closes #19528

## App Export
- N/A (builder behaviour change; no app export attached).

## Screenshots
- N/A (no UI-facing layout change; the builder now recognizes custom plugin form contexts).

## Launchcontrol
Custom plugin components that export a form context are now recognized as forms by the builder's filter, link, validation, and reset-fields editors, instead of only the built-in form component.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognizes custom plugin components that export a `form` context as forms in the builder. Previously only components with names ending in "/form" were treated as forms, which broke datasource resolution and link filtering; now any component with a `form` context is handled, restoring expected behavior in property editors.

- Introduces `hasFormContext` in `helpers/formFields.ts` (accepts `Component | string`) and replaces `endsWith('/form')` checks in the relationship filter editor, reset fields button, validation drawer, bindings extraction, and parent-form lookup.
- Keeps the `/tableblock` special case separate since it does not expose a form context.
- No migration required; plugin components that already export a `form` context now work in filter/link editors, validation, and reset-fields.

<sup>Written for commit 78cace2bccd8ac3368f3c922beffa89ae8c10c48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

