### PR TITLE
fix: mirror EditWorkspaceRoleModal pattern in add workspace modal

### DIFF
--- a/packages/builder/src/settings/pages/people/groups/_components/WorkspaceAddModal.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/WorkspaceAddModal.svelte
@@ -9,10 +9,11 @@
     notifications,
   } from "@budibase/bbui"
   import GlobalRoleSelect from "@/components/common/GlobalRoleSelect.svelte"
-  import { roles } from "@/stores/builder"
+  import { API } from "@/api"
   import { workspacesStore } from "@/stores/portal/workspaces"
   import { groups } from "@/stores/portal/groups"
   import { Constants } from "@budibase/frontend-core"
+  import type { Role } from "@budibase/types"
   import GroupIcon from "./GroupIcon.svelte"
 
   export let groupId: string
@@ -27,19 +28,40 @@
       option.value === Constants.BudibaseRoles.Creator ||
       option.value === Constants.BudibaseRoles.AppUser
   )
+  const excludedRoleIds = [
+    Constants.Roles.BASIC,
+    Constants.Roles.ADMIN,
+    Constants.Roles.PUBLIC,
+    Constants.Roles.CREATOR,
+    Constants.Roles.GROUP,
+  ]
 
   let selectedWorkspaceIds: string[] = []
   let selectedRole = Constants.BudibaseRoles.AppUser
   let selectedEndUserRole = Constants.Roles.BASIC
   let workspaceSearchTerm = ""
+  let workspaceRoles: Role[] = []
+  let roleRequestId = 0
 
   $: group = $groups.find(x => x._id === groupId)
-  $: roleColorLookup = ($roles || []).reduce<
+  $: namedWorkspaceRoles = workspaceRoles.filter(
+    (role): role is Role & { _id: string } => !!role._id
+  )
+  $: roleColorLookup = namedWorkspaceRoles.reduce<
     Record<string, string | undefined>
   >((acc, role) => {
     acc[role._id] = role.uiMetadata?.color
     return acc
   }, {})
+  $: customEndUserRoleOptions = namedWorkspaceRoles
+    .filter(role => !excludedRoleIds.includes(role._id))
+    .map(role => ({
+      label: role.uiMetadata?.displayName || role.name || "Custom role",
+      value: role._id,
+      color:
+        role.uiMetadata?.color ||
+        "var(--spectrum-global-color-static-magenta-400)",
+    }))
   $: endUserRoleOptions = [
     {
       label: "Basic user",
@@ -51,6 +73,7 @@
       value: Constants.Roles.ADMIN,
       color: roleColorLookup[Constants.Roles.ADMIN],
     },
+    ...customEndUserRoleOptions,
   ]
   $: assignedWorkspaceIds = group ? groups.getGroupAppIds(group) : []
   $: workspaceOptions = Object.values(
@@ -84,12 +107,41 @@
   $: confirmDisabled =
     !selectedWorkspaceIdsForSubmit.length ||
     (selectedRole === Constants.BudibaseRoles.AppUser && !selectedEndUserRole)
+  $: singleWorkspaceId =
+    selectedWorkspaceIdsForSubmit.length === 1
+      ? selectedWorkspaceIdsForSubmit[0]
+      : null
+  $: if (singleWorkspaceId) {
+    fetchWorkspaceRoles(singleWorkspaceId)
+  } else {
+    workspaceRoles = []
+  }
+  $: if (
+    !endUserRoleOptions.find(option => option.value === selectedEndUserRole)
+  ) {
+    selectedEndUserRole = Constants.Roles.BASIC
+  }
+
+  async function fetchWorkspaceRoles(appId: string) {
+    const requestId = ++roleRequestId
+    try {
+      const response = await API.getRolesForApp(appId)
+      if (requestId === roleRequestId) {
+        workspaceRoles = response?.roles || []
+      }
+    } catch (error) {
+      if (requestId === roleRequestId) {
+        workspaceRoles = []
+      }
+    }
+  }
 
   export function reset() {
     selectedWorkspaceIds = []
     selectedRole = Constants.BudibaseRoles.AppUser
     selectedEndUserRole = Constants.Roles.BASIC
     workspaceSearchTerm = ""
+    workspaceRoles = []
   }
 
   const getWorkspaceRole = () => {

--- a/packages/builder/src/settings/pages/people/groups/_components/WorkspaceAddModal.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/WorkspaceAddModal.svelte
@@ -111,19 +111,22 @@
     selectedWorkspaceIdsForSubmit.length === 1
       ? selectedWorkspaceIdsForSubmit[0]
       : null
-  $: if (singleWorkspaceId) {
-    fetchWorkspaceRoles(singleWorkspaceId)
-  } else {
-    workspaceRoles = []
-  }
+  $: handleWorkspaceSelectionChange(singleWorkspaceId)
   $: if (
     !endUserRoleOptions.find(option => option.value === selectedEndUserRole)
   ) {
     selectedEndUserRole = Constants.Roles.BASIC
   }
 
-  async function fetchWorkspaceRoles(appId: string) {
+  function handleWorkspaceSelectionChange(workspaceId: string | null) {
     const requestId = ++roleRequestId
+    workspaceRoles = []
+    if (workspaceId) {
+      fetchWorkspaceRoles(workspaceId, requestId)
+    }
+  }
+
+  async function fetchWorkspaceRoles(appId: string, requestId: number) {
     try {
       const response = await API.getRolesForApp(appId)
       if (requestId === roleRequestId) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables assigning custom workspace roles to user groups from the Add Workspace modal by mirroring the EditWorkspaceRoleModal flow. Previously the modal only showed built-in roles from the global store; now it fetches per‑workspace roles and includes custom roles, fixing 19531.

- Fetches roles with `API.getRolesForApp` when exactly one workspace is selected; multi-select clears custom role options.
- Appends custom roles to end‑user role options and excludes built-ins (Basic, Admin, Public, Creator, Group).
- Preserves stable UX: maps role colors, resets fetched roles on modal reset and workspace change, and falls back to Basic if the selected role is no longer available.
- Prevents stale updates by tagging requests and ignoring out‑of‑order responses.

<sup>Written for commit c8e8b3554ffba5faa8c955a65c6111b8318e484d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

