### PR TITLE
chore: reorganize workspace settings navigation

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/DeploymentChannels/SlackConfig.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/DeploymentChannels/SlackConfig.svelte
@@ -224,7 +224,7 @@
     <div class="guided-setup">
       <Body size="S">
         Slack app creation uses the access token managed in
-        <Link on:click={() => bb.settings("/connections/slack")}
+        <Link on:click={() => bb.settings("/channels/slack")}
           >workspace settings</Link
         >.
       </Body>

--- a/packages/builder/src/settings/pages/automations/automations.svelte
+++ b/packages/builder/src/settings/pages/automations/automations.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { Layout, Body, Heading, Toggle, notifications } from "@budibase/bbui"
   import { appStore } from "@/stores/builder"
   import { admin } from "@/stores/portal/admin"
@@ -6,7 +6,7 @@
   $: isCloud = $admin.cloud
   $: chainAutomations = $appStore.automations?.chainAutomations ?? !isCloud
 
-  async function save({ detail }) {
+  async function save({ detail }: CustomEvent<boolean>) {
     try {
       await appStore.updateApp({
         automations: {

--- a/packages/builder/src/settings/pages/automations/automations.svelte
+++ b/packages/builder/src/settings/pages/automations/automations.svelte
@@ -2,17 +2,13 @@
   import { Layout, Body, Heading, Toggle, notifications } from "@budibase/bbui"
   import { appStore } from "@/stores/builder"
   import { admin } from "@/stores/portal/admin"
-  import { workspacesStore } from "@/stores/portal/workspaces"
 
-  $: app = $workspacesStore.apps.find(app =>
-    $appStore.appId?.includes(app.appId)
-  )
   $: isCloud = $admin.cloud
-  $: chainAutomations = app?.automations?.chainAutomations ?? !isCloud
+  $: chainAutomations = $appStore.automations?.chainAutomations ?? !isCloud
 
   async function save({ detail }) {
     try {
-      await workspacesStore.save($appStore.appId, {
+      await appStore.updateApp({
         automations: {
           chainAutomations: detail,
         },

--- a/packages/builder/src/settings/pages/slackAppConfig.svelte
+++ b/packages/builder/src/settings/pages/slackAppConfig.svelte
@@ -82,9 +82,8 @@
 
 <Layout noPadding gap="M">
   <Body size="S">
-    Store the Slack app configuration access token used to create Slack apps
-    automatically in this workspace. Budibase rotates the token using the
-    matching Slack refresh token before it expires.
+    Configure Slack for this workspace so agents can connect to and communicate
+    with users in Slack.
   </Body>
 
   <div class="field">

--- a/packages/builder/src/settings/routes.ts
+++ b/packages/builder/src/settings/routes.ts
@@ -269,6 +269,11 @@ export const workspaceRoutes = (
           path: "oauth2",
           component: Pages.get("oauth2"),
         },
+        {
+          title: "Automations",
+          path: "automations",
+          component: Pages.get("automations"),
+        },
       ],
     },
     {
@@ -358,21 +363,20 @@ export const workspaceRoutes = (
             },
           ],
         },
+      ],
+    },
+    {
+      section: "Channels",
+      access: () => isCreator,
+      path: "channels",
+      icon: "chat-teardrop-text",
+      new: true,
+      showNav: true,
+      routes: [
         {
           path: "slack",
           title: "Slack",
           component: Pages.get("slack_app_config"),
-        },
-      ],
-    },
-    {
-      section: "Automations",
-      icon: "lightning-a",
-      path: "automations",
-      routes: [
-        {
-          path: "logs",
-          component: Pages.get("automations"),
         },
       ],
     },

--- a/packages/builder/src/settings/routes.ts
+++ b/packages/builder/src/settings/routes.ts
@@ -366,7 +366,7 @@ export const workspaceRoutes = (
       ],
     },
     {
-      section: "Channels",
+      section: "Agent channels",
       access: () => isCreator,
       path: "channels",
       icon: "chat-teardrop-text",

--- a/packages/builder/src/types/routing.ts
+++ b/packages/builder/src/types/routing.ts
@@ -46,6 +46,7 @@ export interface Route {
   group?: string
   color?: string // for highlighting
   skipNav?: boolean // Exclude from nav tabs but still process as navigable route
+  showNav?: boolean // Show nav tabs even when there is only one visible child route
   props?: Record<string, unknown> // Props to pass to the component
 
   nav?: Route[]
@@ -97,9 +98,10 @@ export const flatten = (
       // Exclude routes with skipNav: true
       const pageSiblings = entry.routes.filter(r => r.component && !r.skipNav)
 
-      // Build nav only if there is more than one sibling page
+      // Build nav when there are multiple sibling pages or the parent opts in
+      // to showing a tab for a single child page.
       nav =
-        pageSiblings.length > 1
+        pageSiblings.length > 1 || entry.showNav
           ? pageSiblings.map(r => ({
               path: `${currentPath}/${r.path}`,
               new: r.new,


### PR DESCRIPTION
## Description
Reorganizes workspace settings navigation:

- Moves Automations into the General tabs.
- Moves Slack into a new top-level Channels section with the chat-teardrop-text icon and New tag.
- Displays Slack as a tab under the Channels section.
- Updates automation chaining persistence to use the active workspace store.

**Note**: Also fixed a bug where the automations *Enable chaining* toggle setting was not actually saving. 

## Addresses
- Dean's feedback

## Screenshots
<img width="1173" height="747" alt="channels" src="https://github.com/user-attachments/assets/d29b9b77-2b73-4f20-aa1a-cef767422a1a" />

*Slack app settings moved from AI models to a dedicated Channels section*

<img width="1173" height="747" alt="automations" src="https://github.com/user-attachments/assets/06181d34-1319-4e0d-aadf-79460eda70b2" />

*Automations no longer has a dedicated top-level section, and has been moved into General instead*

## Launchcontrol
Workspace settings are now grouped more clearly, with communication channels separated from AI models and automation settings grouped under General.