### PR TITLE
[18470] Fix static formula grouping

### DIFF
--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1865,7 +1865,7 @@ if (descriptions.length) {
                         type: FieldType.FORMULA,
                         formulaType: FormulaType.STATIC,
                         responseType: FieldType.STRING,
-                        formula: "{{ [label] }}",
+                        formula: '{{ "Group" }}',
                       },
                     },
                   })
@@ -1881,7 +1881,7 @@ if (descriptions.length) {
                       type: FieldType.FORMULA,
                       formulaType: FormulaType.STATIC,
                       responseType: FieldType.STRING,
-                      formula: "{{ [label] }}",
+                      formula: '{{ "Group" }}',
                     },
                   },
                 })
@@ -1911,16 +1911,82 @@ if (descriptions.length) {
                 })
 
                 const { rows } = await config.api.row.search(view.id)
-                expect(rows).toHaveLength(2)
+                expect(rows).toHaveLength(1)
                 expect(rows).toEqual(
                   expect.arrayContaining([
                     expect.objectContaining({
-                      staticFormula: "Group A",
-                      labelCount: 2,
+                      staticFormula: "Group",
+                      labelCount: 3,
                     }),
+                  ])
+                )
+              })
+
+            isInternal &&
+              it("can group by numeric static formula fields", async () => {
+                let table = await config.api.table.save(
+                  saveTableRequest({
+                    schema: {
+                      amount: {
+                        name: "amount",
+                        type: FieldType.NUMBER,
+                      },
+                      staticFormula: {
+                        name: "staticFormula",
+                        type: FieldType.FORMULA,
+                        formulaType: FormulaType.STATIC,
+                        responseType: FieldType.NUMBER,
+                        formula: "{{ 1 }}",
+                      },
+                    },
+                  })
+                )
+
+                table = await config.api.table.save({
+                  ...table,
+                  schema: {
+                    ...table.schema,
+                    staticFormula: {
+                      name: "staticFormula",
+                      type: FieldType.FORMULA,
+                      formulaType: FormulaType.STATIC,
+                      responseType: FieldType.NUMBER,
+                      formula: "{{ 1 }}",
+                    },
+                  },
+                })
+
+                await config.api.row.save(table._id!, { amount: 1 })
+                await config.api.row.save(table._id!, { amount: 1 })
+                await config.api.row.save(table._id!, { amount: 2 })
+
+                const view = await config.api.viewV2.create({
+                  tableId: table._id!,
+                  name: generator.guid(),
+                  type: ViewV2Type.CALCULATION,
+                  primaryDisplay: "staticFormula",
+                  schema: {
+                    amountCount: {
+                      visible: true,
+                      calculationType: CalculationType.COUNT,
+                      field: "amount",
+                    },
+                    amount: {
+                      visible: false,
+                    },
+                    staticFormula: {
+                      visible: true,
+                    },
+                  },
+                })
+
+                const { rows } = await config.api.row.search(view.id)
+                expect(rows).toHaveLength(1)
+                expect(rows).toEqual(
+                  expect.arrayContaining([
                     expect.objectContaining({
-                      staticFormula: "Group B",
-                      labelCount: 1,
+                      staticFormula: 1,
+                      amountCount: 3,
                     }),
                   ])
                 )

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1865,7 +1865,7 @@ if (descriptions.length) {
                         type: FieldType.FORMULA,
                         formulaType: FormulaType.STATIC,
                         responseType: FieldType.STRING,
-                        formula: '{{ "Group" }}',
+                        formula: "{{ [label] }}",
                       },
                     },
                   })
@@ -1881,7 +1881,7 @@ if (descriptions.length) {
                       type: FieldType.FORMULA,
                       formulaType: FormulaType.STATIC,
                       responseType: FieldType.STRING,
-                      formula: '{{ "Group" }}',
+                      formula: "{{ [label] }}",
                     },
                   },
                 })
@@ -1900,6 +1900,66 @@ if (descriptions.length) {
                       visible: true,
                       calculationType: CalculationType.COUNT,
                       field: "staticFormula",
+                    },
+                    label: {
+                      visible: false,
+                    },
+                    staticFormula: {
+                      visible: true,
+                    },
+                  },
+                })
+
+                const { rows } = await config.api.row.search(view.id)
+                expect(rows).toHaveLength(2)
+                expect(rows).toEqual(
+                  expect.arrayContaining([
+                    expect.objectContaining({
+                      staticFormula: "Group A",
+                      labelCount: 2,
+                    }),
+                    expect.objectContaining({
+                      staticFormula: "Group B",
+                      labelCount: 1,
+                    }),
+                  ])
+                )
+              })
+
+            isInternal &&
+              it("can group by constant text static formula fields", async () => {
+                const table = await config.api.table.save(
+                  saveTableRequest({
+                    schema: {
+                      label: {
+                        name: "label",
+                        type: FieldType.STRING,
+                      },
+                      staticFormula: {
+                        name: "staticFormula",
+                        type: FieldType.FORMULA,
+                        formulaType: FormulaType.STATIC,
+                        responseType: FieldType.STRING,
+                        formula: '{{ "Group" }}',
+                      },
+                    },
+                  })
+                )
+
+                await config.api.row.save(table._id!, { label: "Group A" })
+                await config.api.row.save(table._id!, { label: "Group A" })
+                await config.api.row.save(table._id!, { label: "Group B" })
+
+                const view = await config.api.viewV2.create({
+                  tableId: table._id!,
+                  name: generator.guid(),
+                  type: ViewV2Type.CALCULATION,
+                  primaryDisplay: "staticFormula",
+                  schema: {
+                    labelCount: {
+                      visible: true,
+                      calculationType: CalculationType.COUNT,
+                      field: "label",
                     },
                     label: {
                       visible: false,

--- a/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
+++ b/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
@@ -94,7 +94,7 @@ export async function buildInternalFieldList(
     const field = table.schema[f]
     return field != null && isDynamicFormula(field)
   })
-  // If are requesting for a formula field, we need to retrieve all fields
+  // Dynamic formulas need all source fields to be available for evaluation
   if (containsFormula) {
     schemaFields = Object.keys(table.schema)
   } else if (allowedFields) {

--- a/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
+++ b/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
@@ -90,12 +90,12 @@ export async function buildInternalFieldList(
     )
   }
 
-  const containsFormula = schemaFields.some(f => {
+  const containsDynamicFormula = schemaFields.some(f => {
     const field = table.schema[f]
     return field != null && isDynamicFormula(field)
   })
   // Dynamic formulas need all source fields to be available for evaluation
-  if (containsFormula) {
+  if (containsDynamicFormula) {
     schemaFields = Object.keys(table.schema)
   } else if (allowedFields) {
     schemaFields = schemaFields.filter(field => allowedFields.includes(field))
@@ -147,7 +147,7 @@ export async function buildInternalFieldList(
       // as part of the relationship to tell us which relationship column the junction is related to.
       const relatedFields = (
         await buildInternalFieldList(relatedTable, tables, {
-          includeHiddenFields: containsFormula,
+          includeHiddenFields: containsDynamicFormula,
         })
       ).concat(
         getJunctionFields(relatedTable, ["doc1.fieldName", "doc2.fieldName"])

--- a/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
+++ b/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
@@ -18,6 +18,7 @@ import {
   DocumentType,
   EnrichedQueryJson,
   FieldType,
+  isDynamicFormula,
   isLogicalSearchOperator,
   isStaticFormula,
   LockName,
@@ -89,9 +90,10 @@ export async function buildInternalFieldList(
     )
   }
 
-  const containsFormula = schemaFields.some(
-    f => table.schema[f]?.type === FieldType.FORMULA
-  )
+  const containsFormula = schemaFields.some(f => {
+    const field = table.schema[f]
+    return field != null && isDynamicFormula(field)
+  })
   // If are requesting for a formula field, we need to retrieve all fields
   if (containsFormula) {
     schemaFields = Object.keys(table.schema)

--- a/packages/types/src/documents/workspace/row.ts
+++ b/packages/types/src/documents/workspace/row.ts
@@ -183,6 +183,15 @@ export function isStaticFormula(
   )
 }
 
+export function isDynamicFormula(
+  schema: FieldSchema
+): schema is FormulaFieldMetadata {
+  return (
+    schema.type === FieldType.FORMULA &&
+    schema.formulaType === FormulaType.DYNAMIC
+  )
+}
+
 export function canGroupBySchema(schema: FieldSchema) {
   return canGroupBy(schema.type) || isStaticFormula(schema)
 }

--- a/packages/types/src/documents/workspace/row.ts
+++ b/packages/types/src/documents/workspace/row.ts
@@ -188,7 +188,7 @@ export function isDynamicFormula(
 ): schema is FormulaFieldMetadata {
   return (
     schema.type === FieldType.FORMULA &&
-    schema.formulaType === FormulaType.DYNAMIC
+    schema.formulaType !== FormulaType.STATIC
   )
 }
 


### PR DESCRIPTION
## Description
Static formulas used as calculation-view group-by fields were causing hidden source columns to be included in the SQL GROUP BY clause. This produced duplicate groups instead of grouping solely by the static formula value. The field expansion now applies only to dynamic formulas, and regression coverage includes numeric and text static formulas.

## Addresses
- https://github.com/Budibase/budibase/issues/18470

## Screenshots
<img width="534" height="296" alt="before" src="https://github.com/user-attachments/assets/b95c04ad-a87d-42c5-85fd-73ad7ef3d6fa" />

**before**

<img width="534" height="296" alt="after" src="https://github.com/user-attachments/assets/f2a8ebef-e541-45ad-91d8-38aec81c3131" />

**after**

## Launchcontrol
Fixes calculation tables grouped by static formula values so they return the expected aggregates.