### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Employees ask questions, request approvals, and report issues every day. Budibas
 
 ### Agents that take action
 
-Budibase agents don’t just answer questions. They run workflows across your business - creating records, routing approvals, updating apps, and notifying teams automatically.
+Budibase agents don't just answer questions. They run workflows across your business - creating records, routing approvals, updating apps, and notifying teams automatically.
 
 <p align="center">
   <img alt="Budibase agent actions" src="https://res.cloudinary.com/daog6scxm/image/upload/v1775572270/github/Agent_Actions.jpg">
@@ -124,6 +124,7 @@ Deploy Budibase using Docker, Kubernetes, and Digital Ocean on your existing inf
 - [Kubernetes](https://docs.budibase.com/docs/kubernetes-k8s)
 - [Digital Ocean](https://docs.budibase.com/docs/digitalocean)
 - [Portainer](https://docs.budibase.com/docs/portainer)
+- [RepoCloud](https://repocloud.io/details/Budibase/)
 
 ### [Get started with Budibase Cloud](https://budibase.com)
 


### PR DESCRIPTION
## Description
Adds [RepoCloud](https://repocloud.io/details/Budibase/) as a one-click deployment option in the self-hosting section of the README, alongside the existing Docker, Docker Compose, Kubernetes, Digital Ocean, and Portainer options.

RepoCloud provides managed open-source app hosting with free credits for new users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a RepoCloud one-click deploy link to the self-hosting section of the README so users can deploy Budibase via RepoCloud alongside Docker, Kubernetes, Digital Ocean, and Portainer. Also normalizes the apostrophe in the “Agents that take action” copy.

<sup>Written for commit 467955844253a5da189ed5db1e938a130db99d76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

