### PR TITLE
perf: index enriched rows in static formula updates

### DIFF
--- a/packages/server/src/api/controllers/row/staticFormula.ts
+++ b/packages/server/src/api/controllers/row/staticFormula.ts
@@ -108,12 +108,17 @@ export async function updateAllFormulasInTable(table: Table) {
   let enrichedRows = await outputProcessing(table, cloneDeep(rows), {
     squash: false,
   })
+  const enrichedRowsById = new Map<Row["_id"], Row>()
+  for (const enrichedRow of enrichedRows) {
+    const enrichedId = enrichedRow._id
+    if (!enrichedRowsById.has(enrichedId)) {
+      enrichedRowsById.set(enrichedId, enrichedRow)
+    }
+  }
   const updatedRows = []
   for (let row of rows) {
     // find the enriched row, if found process the formulas
-    const enrichedRow = enrichedRows.find(
-      (enriched: Row) => enriched._id === row._id
-    )
+    const enrichedRow = enrichedRowsById.get(row._id)
     if (enrichedRow) {
       let processed = await processFormulas(table, cloneDeep(row), {
         dynamic: false,

--- a/packages/server/src/api/controllers/row/tests/staticFormula.spec.ts
+++ b/packages/server/src/api/controllers/row/tests/staticFormula.spec.ts
@@ -1,0 +1,79 @@
+jest.mock("@budibase/backend-core", () => ({
+  context: {
+    getWorkspaceDB: jest.fn(),
+  },
+}))
+
+jest.mock("../../../../db/linkedRows", () => ({
+  squashLinks: jest.fn(),
+}))
+
+jest.mock("../../../../db/utils", () => ({
+  getRowParams: jest.fn(),
+}))
+
+jest.mock("../../../../sdk", () => ({
+  __esModule: true,
+  default: {
+    views: {
+      getTable: jest.fn(),
+      isView: jest.fn(),
+    },
+  },
+}))
+
+jest.mock("../../../../utilities/rowProcessor", () => ({
+  outputProcessing: jest.fn(),
+  processAIColumns: jest.fn(),
+  processFormulas: jest.fn(),
+}))
+
+import { context } from "@budibase/backend-core"
+import { Row, Table } from "@budibase/types"
+import {
+  outputProcessing,
+  processFormulas,
+} from "../../../../utilities/rowProcessor"
+import { updateAllFormulasInTable } from "../staticFormula"
+
+describe("updateAllFormulasInTable", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("indexes enriched rows before matching formula contexts", async () => {
+    const rowCount = 100
+    let enrichedIdReads = 0
+    const rows = Array.from({ length: rowCount }, (_, index) => ({
+      _id: `row-${index}`,
+    }))
+    const enrichedRows = rows.map(row => {
+      const enrichedRow: Row = {}
+      Object.defineProperty(enrichedRow, "_id", {
+        enumerable: true,
+        get() {
+          enrichedIdReads += 1
+          return row._id
+        },
+      })
+      return enrichedRow
+    })
+    const bulkDocs = jest.fn()
+    ;(context.getWorkspaceDB as jest.Mock).mockReturnValue({
+      allDocs: jest.fn().mockResolvedValue({
+        rows: rows.map(doc => ({ doc })),
+      }),
+      bulkDocs,
+    })
+    ;(outputProcessing as jest.Mock).mockResolvedValue(enrichedRows)
+    ;(processFormulas as jest.Mock).mockImplementation(
+      async (_table, row) => row
+    )
+
+    await updateAllFormulasInTable({ _id: "table-1" } as Table)
+
+    expect(enrichedIdReads).toBe(rowCount)
+    expect(processFormulas).toHaveBeenCalledTimes(rowCount)
+    expect(bulkDocs).toHaveBeenCalledWith([])
+  })
+})


### PR DESCRIPTION
## Description

`updateAllFormulasInTable()` recalculates static formulas for every row in a table. It currently scans the full `enrichedRows` array with `.find()` for each raw row, making the matching step O(rows²).

This builds a first-match ID index once and uses O(1) lookups while processing each row. The first-match behavior of the existing `.find()` is preserved, and formula processing order and output are unchanged.

## Addresses

#19556

## Verification

Added a regression test that counts enriched-row ID reads for 100 rows:

- before: 5,050 reads (test fails; expected 100)
- after: 100 reads (test passes)

Also verified:

- targeted Jest test passes
- changed-file formatting passes
- changed-file ESLint passes
- `@budibase/server` typecheck passes