### PR TITLE
fix(sql): allow JSON column creation for Postgres datasources (#19512)

### DIFF
--- a/packages/backend-core/src/sql/sqlTable.ts
+++ b/packages/backend-core/src/sql/sqlTable.ts
@@ -25,6 +25,7 @@ function generateSchema(
   schema: CreateTableBuilder,
   table: Table,
   tables: Record<string, Table>,
+  sqlClient: SqlClient,
   oldTable?: Table,
   renamed?: RenameColumn
 ) {
@@ -154,8 +155,17 @@ function generateSchema(
       case FieldType.AI:
         // This is allowed, but nothing to do on the external datasource
         break
-      case FieldType.AUTO:
       case FieldType.JSON:
+        // native JSON columns are only proven safe for Postgres here - other
+        // dialects go through knex's generic .json() emulation (e.g. a
+        // NVARCHAR+CHECK column in SQL Server) which hasn't been verified
+        // against this codebase's expectations
+        if (sqlClient === SqlClient.POSTGRES) {
+          schema.json(key)
+          break
+        }
+        throw new Error(`${column.type} is not a valid SQL type`)
+      case FieldType.AUTO:
       case FieldType.INTERNAL:
         throw new Error(`${column.type} is not a valid SQL type`)
 
@@ -192,10 +202,11 @@ function generateSchema(
 function buildCreateTable(
   knex: SchemaBuilder,
   table: Table,
-  tables: Record<string, Table>
+  tables: Record<string, Table>,
+  sqlClient: SqlClient
 ): SchemaBuilder {
   return knex.createTable(table.name, schema => {
-    generateSchema(schema, table, tables)
+    generateSchema(schema, table, tables, sqlClient)
   })
 }
 
@@ -203,11 +214,12 @@ function buildUpdateTable(
   knex: SchemaBuilder,
   table: Table,
   tables: Record<string, Table>,
+  sqlClient: SqlClient,
   oldTable?: Table,
   renamed?: RenameColumn
 ): SchemaBuilder {
   return knex.alterTable(table.name, schema => {
-    generateSchema(schema, table, tables, oldTable, renamed)
+    generateSchema(schema, table, tables, sqlClient, oldTable, renamed)
   })
 }
 
@@ -262,7 +274,12 @@ class SqlTableQueryBuilder {
 
     switch (this._operation(json)) {
       case Operation.CREATE_TABLE:
-        query = buildCreateTable(client, json.table, json.tables)
+        query = buildCreateTable(
+          client,
+          json.table,
+          json.tables,
+          this.sqlClient
+        )
         break
       case Operation.UPDATE_TABLE:
         if (!json.table) {
@@ -284,6 +301,7 @@ class SqlTableQueryBuilder {
           client,
           json.table,
           json.tables,
+          this.sqlClient,
           json.meta?.oldTable,
           json.meta?.renamed
         )

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -624,6 +624,10 @@
         FIELDS.ATTACHMENT_SINGLE,
         FIELDS.ATTACHMENTS,
         FIELDS.SIGNATURE_SINGLE,
+        // only Postgres has a proven-safe native JSON column path in the
+        // backend DDL builder (sqlTable.ts) - other SQL dialects still reject
+        // it there
+        ...(datasource?.source === SourceName.POSTGRES ? [FIELDS.JSON] : []),
       ]
     } else if (isExternalTable && isGoogleSheet) {
       // google-sheets supports minimum set (no attachments or user references)


### PR DESCRIPTION
## Description
Fixes an issue where creating a new **JSON** column on an existing **Postgres** external table/datasource was impossible from the Data Table builder - the type simply wasn't offered in the "Create Column" type dropdown, even though a JSON/JSONB column that already existed in the database was read back and displayed correctly (a separate, working introspection code path in `packages/server/src/integrations/utils/utils.ts`).

Digging into why the frontend excluded it revealed this wasn't a UI oversight: `packages/backend-core/src/sql/sqlTable.ts` (the shared DDL generator used for `CREATE TABLE`/`ALTER TABLE` across every SQL dialect via knex) explicitly threw `"json is not a valid SQL type"` for `FieldType.JSON`. Simply adding the option to the dropdown without touching the backend would have replaced a disabled option with a hard 500 on save - so this PR fixes both layers together:

- `sqlTable.ts`: threads `sqlClient: SqlClient` through `generateSchema`/`buildCreateTable`/`buildUpdateTable`, and calls `schema.json(key)` - the same knex builder this file already uses for `FieldType.ARRAY`/`FieldType.ATTACHMENTS` on external Postgres tables - specifically when `sqlClient === SqlClient.POSTGRES`.
- `CreateEditColumn.svelte`: only adds `FIELDS.JSON` to the allowed column types for external SQL tables when `datasource.source === SourceName.POSTGRES`.

**Scope is deliberately limited to Postgres.** Every other SQL dialect (MySQL, SQL Server, Oracle) keeps throwing exactly as before. `knex`'s `.json()` builder is emulated differently per dialect (e.g. SQL Server has no native JSON column type - knex represents it as `NVARCHAR(MAX)` plus an `ISJSON()` check constraint), and I haven't verified that emulation holds up against this codebase's assumptions elsewhere (round-tripping through `generateColumnDefinition`'s introspection map, existing tests, etc.). Rather than guess, I kept the fix to the one dialect the linked issue actually reports and verified.

## Addresses
- https://github.com/Budibase/budibase/issues/19512

## App Export
- N/A - this is a schema/DDL-level fix (column type availability), not app-specific behavior, so there isn't a meaningful app export that would help reproduce it. The repro is simply: Postgres datasource → table → Create Column → JSON is absent from the type list.

## Screenshots
- I verified this through targeted `eslint`/`prettier`/`tsc --noEmit`/`svelte-check` runs against the two changed files rather than the full local dev stack (Docker/CouchDB/etc.), so I don't have a screenshot of the updated dropdown to attach. Happy to add one if a maintainer would like it before review.

## Launchcontrol
Postgres users can now create a JSON column directly from the Data Table builder's "Create Column" modal, instead of the option being silently unavailable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JSON column creation for Postgres external tables. The Create Column modal now offers the JSON type for Postgres datasources, and the backend DDL builder accepts it. All other SQL dialects keep their previous behavior.

- Adds `FIELDS.JSON` to the column type dropdown only when the datasource is Postgres.
- Threads `sqlClient` through the DDL builder and uses `schema.json()` only for Postgres; other dialects still throw.

<sup>Written for commit 8ea3f667040f85c3aeddf03c0157e8e4a4039856. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

