### PR TITLE
Reject zip entries marked as symlinks in PWA upload mechanism

### DIFF
--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -82,6 +82,10 @@ const MAX_PWA_ZIP_FILE_COUNT = 100
 const MAX_PWA_ZIP_ENTRY_SIZE = 10 * 1024 * 1024 // 10MB per file
 const MAX_PWA_ZIP_TOTAL_SIZE = 50 * 1024 * 1024 // 50MB uncompressed total
 const MAX_PWA_ZIP_DEPTH = 10
+// used in attribute checks for security remediation, see
+// https://github.com/Budibase/budibase/pull/19564
+const ZIP_FILE_TYPE_MASK = 0o170000
+const ZIP_SYMLINK_FILE_TYPE = 0o120000
 
 const validatePWAZipEntries = () => {
   let fileCount = 0
@@ -97,7 +101,8 @@ const validatePWAZipEntries = () => {
       return
     }
 
-    if (((entry.externalFileAttributes >>> 16) & 0o170000) === 0o120000) {
+    const fileType = (entry.externalFileAttributes >>> 16) & ZIP_FILE_TYPE_MASK
+    if (fileType === ZIP_SYMLINK_FILE_TYPE) {
       throw new BadRequestError(
         `Invalid zip`
       )

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -99,7 +99,7 @@ const validatePWAZipEntries = () => {
 
     if (((entry.externalFileAttributes >>> 16) & 0o170000) === 0o120000) {
       throw new BadRequestError(
-        `Invalid zip - "${entry.fileName}" is a symlink, which is not allowed`
+        `Invalid zip`
       )
     }
 

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -87,10 +87,20 @@ const validatePWAZipEntries = () => {
   let fileCount = 0
   let totalUncompressedSize = 0
 
-  return (entry: { fileName: string; uncompressedSize: number }) => {
+  return (entry: {
+    fileName: string
+    uncompressedSize: number
+    externalFileAttributes: number
+  }) => {
     // extract-zip skips these itself, so don't count them against the limits.
     if (entry.fileName.startsWith("__MACOSX/")) {
       return
+    }
+
+    if (((entry.externalFileAttributes >>> 16) & 0o170000) === 0o120000) {
+      throw new BadRequestError(
+        `Invalid zip - "${entry.fileName}" is a symlink, which is not allowed`
+      )
     }
 
     const depth =

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -623,6 +623,33 @@ describe("/static", () => {
           await fsp.rm(sensitiveDir, { recursive: true, force: true })
         }
       })
+
+      it("rejects a zip entry that is a symlink", async () => {
+        const symlinkExternalAttr = (0o120777 << 16) >>> 0
+
+        mockedExtract.mockImplementation(
+          async (_zipPath: string, opts: any) => {
+            await fsp.mkdir(opts.dir, { recursive: true })
+            opts.onEntry?.(
+              {
+                fileName: "payload.txt",
+                uncompressedSize: 10,
+                externalFileAttributes: symlinkExternalAttr,
+              },
+              {}
+            )
+          }
+        )
+
+        const res = await request
+          .post("/api/pwa/process-zip")
+          .attach("file", Buffer.from("fake-zip"), "icons.zip")
+          .set(config.defaultHeaders())
+
+        expect(res.status).toEqual(400)
+        expect(res.body.message).toEqual("Invalid zip")
+        expect(mockedUpload).not.toHaveBeenCalled()
+      })
     })
 
     describe("resource limits", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rejects zip entries marked as symlinks in the PWA upload mechanism, closing an arbitrary file write vulnerability. Uploads with such entries now fail with an "Invalid zip" error.

<sup>Written for commit ae0bad2110ba2dcd26094c318d400cd83fbe6bd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

