### PR TITLE
Audit logs to Svelte 5

### DIFF
--- a/packages/backend-core/src/events/publishers/backup.ts
+++ b/packages/backend-core/src/events/publishers/backup.ts
@@ -16,7 +16,7 @@ async function workspaceBackupRestored(backup: WorkspaceBackup) {
     name: backup.name as string,
   }
 
-  await publishEvent(Event.APP_BACKUP_RESTORED, properties)
+  await publishEvent(Event.WORKSPACE_BACKUP_RESTORED, properties)
 }
 
 async function workspaceBackupTriggered(
@@ -33,7 +33,7 @@ async function workspaceBackupTriggered(
     trigger,
     name,
   }
-  await publishEvent(Event.APP_BACKUP_TRIGGERED, properties)
+  await publishEvent(Event.WORKSPACE_BACKUP_TRIGGERED, properties)
 }
 
 export default {

--- a/packages/builder/src/settings/pages/auditLogs/_components/TimeRenderer.svelte
+++ b/packages/builder/src/settings/pages/auditLogs/_components/TimeRenderer.svelte
@@ -1,10 +1,15 @@
-<script>
+<script lang="ts">
   import dayjs from "dayjs"
   import relativeTime from "dayjs/plugin/relativeTime"
+  import type { AuditLogEnriched } from "@budibase/types"
 
   dayjs.extend(relativeTime)
 
-  export let row
+  interface Props {
+    row: AuditLogEnriched
+  }
+
+  let { row }: Props = $props()
 </script>
 
 <div>

--- a/packages/builder/src/settings/pages/auditLogs/_components/UserRenderer.svelte
+++ b/packages/builder/src/settings/pages/auditLogs/_components/UserRenderer.svelte
@@ -1,9 +1,15 @@
-<script>
+<script lang="ts">
   import { UserAvatar } from "@budibase/frontend-core"
+  import type { AuditLogEnriched } from "@budibase/types"
 
-  export let row
+  interface Props {
+    row: AuditLogEnriched
+  }
+
+  let { row }: Props = $props()
+  const user = $derived(row.user)
 </script>
 
-{#if row?.user?.email}
-  <UserAvatar user={row.user} />
+{#if user?.email}
+  <UserAvatar {user} />
 {/if}

--- a/packages/builder/src/settings/pages/auditLogs/_components/UserRenderer.svelte
+++ b/packages/builder/src/settings/pages/auditLogs/_components/UserRenderer.svelte
@@ -8,8 +8,9 @@
 
   let { row }: Props = $props()
   const user = $derived(row.user)
+  const displayUser = $derived(
+    user.email ? { ...user, email: user.email } : undefined
+  )
 </script>
 
-{#if user?.email}
-  <UserAvatar {user} />
-{/if}
+<UserAvatar user={displayUser} />

--- a/packages/builder/src/settings/pages/auditLogs/_components/ViewDetailsRenderer.svelte
+++ b/packages/builder/src/settings/pages/auditLogs/_components/ViewDetailsRenderer.svelte
@@ -1,10 +1,16 @@
-<script>
+<script lang="ts">
   import { ActionButton } from "@budibase/bbui"
   import { getContext } from "svelte"
+  import type { AuditLogEnriched } from "@budibase/types"
+  import { AUDIT_LOGS_CONTEXT, type AuditLogsContext } from "../auditLogContext"
 
-  export let row
-  const auditLogs = getContext("auditLogs")
-  const onClick = e => {
+  interface Props {
+    row: AuditLogEnriched
+  }
+
+  let { row }: Props = $props()
+  const auditLogs = getContext<AuditLogsContext>(AUDIT_LOGS_CONTEXT)
+  const onClick = (e: MouseEvent) => {
     e.stopPropagation()
     auditLogs.viewDetails(row)
   }

--- a/packages/builder/src/settings/pages/auditLogs/_components/WorkspaceColumnRenderer.svelte
+++ b/packages/builder/src/settings/pages/auditLogs/_components/WorkspaceColumnRenderer.svelte
@@ -1,5 +1,9 @@
-<script>
-  export let value
+<script lang="ts">
+  interface Props {
+    value?: { name?: string } | null
+  }
+
+  let { value }: Props = $props()
 </script>
 
 <div>{value?.name || ""}</div>

--- a/packages/builder/src/settings/pages/auditLogs/auditLogContext.ts
+++ b/packages/builder/src/settings/pages/auditLogs/auditLogContext.ts
@@ -1,0 +1,7 @@
+import type { AuditLogEnriched } from "@budibase/types"
+
+export const AUDIT_LOGS_CONTEXT = "auditLogs" as const
+
+export interface AuditLogsContext {
+  viewDetails: (detail: AuditLogEnriched) => void
+}

--- a/packages/builder/src/settings/pages/auditLogs/auditLogUtils.spec.ts
+++ b/packages/builder/src/settings/pages/auditLogs/auditLogUtils.spec.ts
@@ -2,6 +2,15 @@ import { describe, expect, it, vi } from "vitest"
 import { createLatestRequestQueue } from "./auditLogUtils"
 
 describe("createLatestRequestQueue", () => {
+  it("runs falsy query values", async () => {
+    const run = vi.fn<(query: string) => Promise<void>>().mockResolvedValue()
+    const queue = createLatestRequestQueue(run)
+
+    await queue("")
+
+    expect(run).toHaveBeenCalledWith("")
+  })
+
   it("runs the latest pending query after the active request", async () => {
     let finishFirst = () => {}
     const firstRequest = new Promise<void>(resolve => {

--- a/packages/builder/src/settings/pages/auditLogs/auditLogUtils.spec.ts
+++ b/packages/builder/src/settings/pages/auditLogs/auditLogUtils.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest"
+import { createLatestRequestQueue } from "./auditLogUtils"
+
+describe("createLatestRequestQueue", () => {
+  it("runs the latest pending query after the active request", async () => {
+    let finishFirst = () => {}
+    const firstRequest = new Promise<void>(resolve => {
+      finishFirst = resolve
+    })
+    const run = vi
+      .fn<(query: string) => Promise<void>>()
+      .mockReturnValueOnce(firstRequest)
+      .mockResolvedValue(undefined)
+    const queue = createLatestRequestQueue(run)
+
+    const activeRequest = queue("first")
+    await vi.waitFor(() => expect(run).toHaveBeenCalledWith("first"))
+    await queue("superseded")
+    await queue("latest")
+    finishFirst()
+    await activeRequest
+
+    expect(run).toHaveBeenCalledTimes(2)
+    expect(run).toHaveBeenLastCalledWith("latest")
+  })
+})

--- a/packages/builder/src/settings/pages/auditLogs/auditLogUtils.ts
+++ b/packages/builder/src/settings/pages/auditLogs/auditLogUtils.ts
@@ -1,0 +1,22 @@
+export const createLatestRequestQueue = <T>(
+  run: (query: T) => Promise<void>
+) => {
+  let pending: T | undefined
+  let running = false
+
+  return async (query: T) => {
+    pending = query
+    if (running) return
+
+    running = true
+    try {
+      while (pending) {
+        const next = pending
+        pending = undefined
+        await run(next)
+      }
+    } finally {
+      running = false
+    }
+  }
+}

--- a/packages/builder/src/settings/pages/auditLogs/auditLogUtils.ts
+++ b/packages/builder/src/settings/pages/auditLogs/auditLogUtils.ts
@@ -1,17 +1,17 @@
 export const createLatestRequestQueue = <T>(
   run: (query: T) => Promise<void>
 ) => {
-  let pending: T | undefined
+  let pending: { query: T } | undefined
   let running = false
 
   return async (query: T) => {
-    pending = query
+    pending = { query }
     if (running) return
 
     running = true
     try {
       while (pending) {
-        const next = pending
+        const next = pending.query
         pending = undefined
         await run(next)
       }

--- a/packages/builder/src/settings/pages/auditLogs/index.svelte
+++ b/packages/builder/src/settings/pages/auditLogs/index.svelte
@@ -219,7 +219,7 @@
     // with the key as the id and the value as the name
     if (obj) {
       return Object.entries(obj).map(([id, label]) => {
-        return { id: id as Event, label, selected: false }
+        return { id: id as Event, label: label.trim(), selected: false }
       })
     } else {
       return []
@@ -239,13 +239,13 @@
         selectedEvents,
         event => event.id
       ),
-      event => event.id
+      event => event.label.toLowerCase()
     )
   )
-  const sortedApps = $derived(
+  const sortedWorkspaces = $derived(
     sort(
       enrich($workspacesStore.apps, selectedApps, app => app.appId),
-      app => app.name
+      app => app.name.toLocaleLowerCase()
     )
   )
 
@@ -351,7 +351,7 @@
         label="Workspaces"
         getOptionValue={app => app.instance._id}
         getOptionLabel={app => app.name}
-        options={sortedApps}
+        options={sortedWorkspaces}
         bind:value={selectedApps}
       />
     </div>

--- a/packages/builder/src/settings/pages/auditLogs/index.svelte
+++ b/packages/builder/src/settings/pages/auditLogs/index.svelte
@@ -160,7 +160,7 @@
     try {
       logsPageInfo.loading()
       const response = await auditLogs.search({
-        bookmark: page || undefined,
+        bookmark: page ? Number(page) : undefined,
         startDate: dateRange[0]?.toISOString(),
         endDate: dateRange[1]?.toISOString(),
         fullSearch: search,

--- a/packages/builder/src/settings/pages/auditLogs/index.svelte
+++ b/packages/builder/src/settings/pages/auditLogs/index.svelte
@@ -95,7 +95,7 @@
   const logsPage = derived(logsPageInfo, value => value.page)
 
   let prevUserSearch = ""
-  let prevLogSearch = ""
+  let previousLogFilters: string | undefined
   let selectedUsers = $state<string[]>([])
   let selectedApps = $state<string[]>([])
   let selectedEvents = $state<Event[]>([])
@@ -151,12 +151,6 @@
     selectedApps,
     selectedEvents,
   }: LogSearchQuery) => {
-    // need to remove the page if they've started searching
-    if (search && !prevLogSearch) {
-      logsPageInfo.reset()
-      page = undefined
-    }
-    prevLogSearch = search
     try {
       logsPageInfo.loading()
       const response = await auditLogs.search({
@@ -256,8 +250,25 @@
   })
 
   $effect(() => {
+    const page = $logsPage
+    const filters = JSON.stringify({
+      search: logSearchTerm,
+      dateRange: dateRange.map(date => date?.toISOString()),
+      selectedUsers,
+      selectedApps,
+      selectedEvents,
+    })
+    const filtersChanged =
+      previousLogFilters !== undefined && previousLogFilters !== filters
+    previousLogFilters = filters
+
+    if (filtersChanged && page) {
+      untrack(() => logsPageInfo.reset())
+      return
+    }
+
     const query: LogSearchQuery = {
-      page: $logsPage,
+      page,
       search: logSearchTerm,
       dateRange: [...dateRange],
       selectedUsers: [...selectedUsers],

--- a/packages/builder/src/settings/pages/auditLogs/index.svelte
+++ b/packages/builder/src/settings/pages/auditLogs/index.svelte
@@ -2,7 +2,7 @@
      hot reload will stop working due to the use of window.location. You'll need to reload the pag
      to get it working again.
 -->
-<script>
+<script lang="ts">
   import {
     Layout,
     Table,
@@ -23,7 +23,8 @@
   import { auditLogs } from "@/stores/portal/auditLogs"
   import LockedFeature from "@/pages/builder/_components/LockedFeature.svelte"
   import { createPaginationStore } from "@/helpers/pagination"
-  import { onMount, setContext } from "svelte"
+  import { onDestroy, onMount, setContext, untrack } from "svelte"
+  import { derived } from "svelte/store"
   import ViewDetailsRenderer from "./_components/ViewDetailsRenderer.svelte"
   import UserRenderer from "./_components/UserRenderer.svelte"
   import TimeRenderer from "./_components/TimeRenderer.svelte"
@@ -31,6 +32,33 @@
   import { cloneDeep } from "lodash"
   import DateRangePicker from "@/components/common/DateRangePicker.svelte"
   import dayjs from "dayjs"
+  import type { Dayjs } from "dayjs"
+  import type { AuditLogEnriched, Event, StrippedUser } from "@budibase/types"
+  import { AUDIT_LOGS_CONTEXT, type AuditLogsContext } from "./auditLogContext"
+  import { createLatestRequestQueue } from "./auditLogUtils"
+
+  interface Selectable {
+    selected: boolean
+  }
+
+  interface EventOption extends Selectable {
+    id: Event
+    label: string
+  }
+
+  interface UserSearchQuery {
+    page?: string | null
+    search: string
+  }
+
+  interface LogSearchQuery {
+    page?: string | null
+    search: string
+    dateRange: Dayjs[]
+    selectedUsers: string[]
+    selectedApps: string[]
+    selectedEvents: Event[]
+  }
 
   const schema = {
     date: { width: "0.8fr" },
@@ -59,136 +87,123 @@
     },
   ]
 
-  let userSearchTerm = ""
-  let logSearchTerm = ""
-  let userPageInfo = createPaginationStore()
-  let logsPageInfo = createPaginationStore()
+  let userSearchTerm = $state("")
+  let logSearchTerm = $state("")
+  const userPageInfo = createPaginationStore()
+  const logsPageInfo = createPaginationStore()
+  const userPage = derived(userPageInfo, value => value.page)
+  const logsPage = derived(logsPageInfo, value => value.page)
 
-  let prevUserSearch = undefined
-  let prevLogSearch = undefined
-  let selectedUsers = []
-  let selectedApps = []
-  let selectedEvents = []
-  let selectedLog
-  let sidePanelVisible = false
-  let wideSidePanel = false
-  let timer
-  let dateRange = [dayjs().subtract(30, "days"), dayjs()]
+  let prevUserSearch = ""
+  let prevLogSearch = ""
+  let selectedUsers = $state<string[]>([])
+  let selectedApps = $state<string[]>([])
+  let selectedEvents = $state<Event[]>([])
+  let selectedLog = $state<AuditLogEnriched>()
+  let sidePanelVisible = $state(false)
+  let wideSidePanel = $state(false)
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let dateRange = $state([dayjs().subtract(30, "days"), dayjs()])
+  let usersObj = $state<Record<string, StrippedUser>>({})
 
-  $: fetchUsers(userPage, userSearchTerm)
-  $: fetchLogs({
-    logsPage,
-    logSearchTerm,
-    dateRange,
-    selectedUsers,
-    selectedApps,
-    selectedEvents,
-  })
-  $: userPage = $userPageInfo.page
-  $: logsPage = $logsPageInfo.page
-
-  let usersObj = {}
-  $: usersObj = {
-    ...usersObj,
-    ...$users.data?.reduce((accumulator, user) => {
-      accumulator[user._id] = user
-      return accumulator
-    }, {}),
-  }
-  $: sortedUsers = sort(
-    enrich(Object.values(usersObj), selectedUsers, "_id"),
-    "email"
-  )
-  $: sortedEvents = sort(
-    enrich(parseEventObject($auditLogs.events), selectedEvents, "id"),
-    "id"
-  )
-  $: sortedApps = sort(
-    enrich($workspacesStore.apps, selectedApps, "appId"),
-    "name"
-  )
-
-  const debounce = value => {
+  const debounce = (value: string) => {
     clearTimeout(timer)
     timer = setTimeout(() => {
       logSearchTerm = value
     }, 400)
   }
 
-  const fetchUsers = async (userPage, search) => {
-    if ($userPageInfo.loading) {
-      return
-    }
+  const fetchUsers = async ({ page, search }: UserSearchQuery) => {
     // need to remove the page if they've started searching
     if (search && !prevUserSearch) {
       userPageInfo.reset()
-      userPage = undefined
+      page = undefined
     }
     prevUserSearch = search
     try {
       userPageInfo.loading()
-      await users.search({
-        bookmark: userPage,
+      const response = await users.search({
+        bookmark: page || undefined,
         query: { string: { email: search } },
       })
-      userPageInfo.fetched($users.hasNextPage, $users.nextPage)
+      usersObj = {
+        ...usersObj,
+        ...response.data.reduce<Record<string, StrippedUser>>(
+          (accumulator, user) => {
+            if (user._id) accumulator[user._id] = user
+            return accumulator
+          },
+          {}
+        ),
+      }
+      userPageInfo.fetched(!!response.hasNextPage, response.nextPage || "")
     } catch (error) {
+      userPageInfo.loading(false)
       notifications.error("Error getting user list")
     }
   }
 
   const fetchLogs = async ({
-    logsPage,
-    logSearchTerm,
+    page,
+    search,
     dateRange,
     selectedUsers,
     selectedApps,
     selectedEvents,
-  }) => {
-    if ($logsPageInfo.loading) {
-      return
-    }
+  }: LogSearchQuery) => {
     // need to remove the page if they've started searching
-    if (logSearchTerm && !prevLogSearch) {
+    if (search && !prevLogSearch) {
       logsPageInfo.reset()
-      logsPage = undefined
+      page = undefined
     }
-    prevLogSearch = logSearchTerm
+    prevLogSearch = search
     try {
       logsPageInfo.loading()
-      await auditLogs.search({
-        bookmark: logsPage,
-        startDate: dateRange[0] || undefined,
-        endDate: dateRange[1] || undefined,
-        fullSearch: logSearchTerm,
+      const response = await auditLogs.search({
+        bookmark: page || undefined,
+        startDate: dateRange[0]?.toISOString(),
+        endDate: dateRange[1]?.toISOString(),
+        fullSearch: search,
         userIds: selectedUsers,
         appIds: selectedApps,
         events: selectedEvents,
       })
       logsPageInfo.fetched(
-        $auditLogs.logs?.hasNextPage,
-        $auditLogs.logs?.bookmark
+        !!response?.hasNextPage,
+        response?.bookmark?.toString() || ""
       )
     } catch (error) {
+      logsPageInfo.loading(false)
       notifications.error(`Error getting audit logs - ${error}`)
     }
   }
 
-  const enrich = (list, selected, key) => {
+  const queueUserSearch = createLatestRequestQueue(fetchUsers)
+  const queueLogSearch = createLatestRequestQueue(fetchLogs)
+
+  const enrich = <T extends object>(
+    list: T[],
+    selected: string[],
+    getValue: (item: T) => string | undefined
+  ): (T & Selectable)[] => {
     return list.map(item => {
+      const value = getValue(item)
       return {
         ...item,
         selected:
-          selected.find(x => x === item[key] || x.includes(item[key])) != null,
+          !!value && selected.some(x => x === value || x.includes(value)),
       }
     })
   }
 
-  const sort = (list, key) => {
-    let sortedList = list.slice()
-    sortedList?.sort((a, b) => {
+  const sort = <T extends Selectable>(
+    list: T[],
+    getValue: (item: T) => string
+  ): T[] => {
+    const sortedList = list.slice()
+    sortedList.sort((a, b) => {
       if (a.selected === b.selected) {
-        return a[key] < b[key] ? -1 : 1
+        return getValue(a) < getValue(b) ? -1 : 1
       } else if (a.selected) {
         return -1
       } else if (b.selected) {
@@ -199,65 +214,112 @@
     return sortedList
   }
 
-  const parseEventObject = obj => {
+  const parseEventObject = (obj?: Record<string, string>): EventOption[] => {
     // convert obj which is an object of key value pairs to an array of objects
     // with the key as the id and the value as the name
     if (obj) {
       return Object.entries(obj).map(([id, label]) => {
-        return { id, label }
+        return { id: id as Event, label, selected: false }
       })
     } else {
       return []
     }
   }
 
-  const viewDetails = detail => {
+  const sortedUsers = $derived(
+    sort(
+      enrich(Object.values(usersObj), selectedUsers, user => user._id),
+      user => user.email
+    )
+  )
+  const sortedEvents = $derived(
+    sort(
+      enrich(
+        parseEventObject($auditLogs.events),
+        selectedEvents,
+        event => event.id
+      ),
+      event => event.id
+    )
+  )
+  const sortedApps = $derived(
+    sort(
+      enrich($workspacesStore.apps, selectedApps, app => app.appId),
+      app => app.name
+    )
+  )
+
+  $effect(() => {
+    const page = $userPage
+    const search = userSearchTerm
+    untrack(() => queueUserSearch({ page, search }))
+  })
+
+  $effect(() => {
+    const query: LogSearchQuery = {
+      page: $logsPage,
+      search: logSearchTerm,
+      dateRange: [...dateRange],
+      selectedUsers: [...selectedUsers],
+      selectedApps: [...selectedApps],
+      selectedEvents: [...selectedEvents],
+    }
+    untrack(() => queueLogSearch(query))
+  })
+
+  const viewDetails = (detail: AuditLogEnriched) => {
     selectedLog = detail
     sidePanelVisible = true
   }
 
   const downloadLogs = async () => {
     try {
-      window.location = auditLogs.getDownloadUrl({
-        startDate: dateRange[0],
-        endDate: dateRange[1],
+      window.location.href = auditLogs.getDownloadUrl({
+        startDate: dateRange[0]?.toISOString(),
+        endDate: dateRange[1]?.toISOString(),
         fullSearch: logSearchTerm,
         userIds: selectedUsers,
         appIds: selectedApps,
         events: selectedEvents,
       })
     } catch (error) {
-      notifications.error(`Error downloading logs: ` + error.message)
+      notifications.error(
+        `Error downloading logs: ${error instanceof Error ? error.message : error}`
+      )
     }
   }
 
-  setContext("auditLogs", {
+  setContext<AuditLogsContext>(AUDIT_LOGS_CONTEXT, {
     viewDetails,
   })
 
-  const copyToClipboard = async value => {
+  const copyToClipboard = async (value: string) => {
     await Helpers.copyToClipboard(value)
     notifications.success("Copied")
   }
 
-  function cleanupMetadata(log) {
-    const cloned = cloneDeep(log)
-    cloned.userId = cloned.user._id
-    if (cloned.app) {
-      cloned.appId = cloned.app.appId
+  const copySelectedMetadata = () => {
+    if (selectedLog) {
+      return copyToClipboard(JSON.stringify(selectedLog.metadata))
     }
-    // remove props that are confused/not returned in download
-    delete cloned._id
-    delete cloned._rev
-    delete cloned.app
-    delete cloned.user
-    return cloned
+  }
+
+  function cleanupMetadata(log: AuditLogEnriched) {
+    const cloned = cloneDeep(log)
+    const { app, user, ...metadata } = cloned
+    return {
+      ...metadata,
+      userId: user._id,
+      ...(app ? { appId: app._id } : {}),
+    }
   }
 
   onMount(async () => {
     await auditLogs.getEventDefinitions()
     await licensing.init()
   })
+
+  onDestroy(() => clearTimeout(timer))
 </script>
 
 <LockedFeature
@@ -277,7 +339,7 @@
         label="Users"
         autocomplete
         bind:value={selectedUsers}
-        getOptionValue={user => user._id}
+        getOptionValue={user => user._id || ""}
         getOptionLabel={user => user.email}
         options={sortedUsers}
       />
@@ -382,10 +444,7 @@
     <Divider />
 
     <div class="side-panel-body">
-      <div
-        on:click={() => copyToClipboard(JSON.stringify(selectedLog.metadata))}
-        class="copy-icon"
-      >
+      <div on:click={copySelectedMetadata} class="copy-icon">
         <Icon name="copy" size="S" />
       </div>
       <CoreTextArea

--- a/packages/builder/src/settings/pages/auditLogs/index.svelte
+++ b/packages/builder/src/settings/pages/auditLogs/index.svelte
@@ -310,7 +310,7 @@
     return {
       ...metadata,
       userId: user._id,
-      ...(app ? { appId: app._id } : {}),
+      ...(app ? { appId: "appId" in app ? app.appId : app._id } : {}),
     }
   }
 

--- a/packages/builder/src/settings/pages/auditLogs/index.svelte
+++ b/packages/builder/src/settings/pages/auditLogs/index.svelte
@@ -64,7 +64,7 @@
     date: { width: "0.8fr" },
     user: { width: "0.5fr" },
     name: { width: "2fr", displayName: "Event" },
-    app: { width: "1.5fr" },
+    app: { width: "1.5fr", displayName: "Workspace" },
     view: { width: "0.1fr", borderLeft: true, displayName: "" },
   }
 

--- a/packages/frontend-core/src/components/UserAvatar.svelte
+++ b/packages/frontend-core/src/components/UserAvatar.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import { Avatar, AbsTooltip, TooltipPosition } from "@budibase/bbui"
   import { helpers } from "@budibase/shared-core"
-  import type { User } from "@budibase/types"
 
-  export let user: User | undefined
+  export let user: helpers.UserDisplayInfo | undefined
   export let size: "XS" | "S" | "M" = "S"
   export let tooltipPosition: TooltipPosition = TooltipPosition.Top
   export let showTooltip: boolean = true

--- a/packages/pro/src/db/auditLogs.ts
+++ b/packages/pro/src/db/auditLogs.ts
@@ -38,7 +38,7 @@ async function getAuditLogSqlQuery(
     tables: {},
     paginate: {
       limit: limit || GENERIC_PAGE_SIZE,
-      page: bookmark,
+      offset: (bookmark - 1) * GENERIC_PAGE_SIZE,
     },
     filters,
     resource: {
@@ -104,7 +104,7 @@ export async function searchSQL(
       await db.sql<AuditLogDoc>(mainQuery.sql, mainQuery.bindings)
     )
     let nextRow: AuditLogDoc | undefined
-    if (rows.length > limit) {
+    if (rows.length > GENERIC_PAGE_SIZE) {
       nextRow = rows.pop()
     }
     const response: SearchResponse<AuditLogDoc> = {

--- a/packages/types/src/api/web/global/auditLogs.ts
+++ b/packages/types/src/api/web/global/auditLogs.ts
@@ -9,14 +9,16 @@ export interface AuditLogSearchParams {
   startDate?: string
   endDate?: string
   fullSearch?: string
-  bookmark?: string
+  bookmark?: number
 }
 
 export interface DownloadAuditLogsRequest extends AuditLogSearchParams {}
 
 export interface SearchAuditLogsRequest
-  extends BasicPaginationRequest,
-    AuditLogSearchParams {}
+  extends Omit<BasicPaginationRequest, "bookmark">,
+    AuditLogSearchParams {
+  bookmark?: number
+}
 
 export enum AuditLogResourceStatus {
   DELETED = "deleted",

--- a/packages/types/src/sdk/events/event.ts
+++ b/packages/types/src/sdk/events/event.ts
@@ -194,8 +194,8 @@ export enum Event {
   PLUGIN_DELETED = "plugin:deleted",
 
   // BACKUP
-  APP_BACKUP_RESTORED = "app:backup:restored",
-  APP_BACKUP_TRIGGERED = "app:backup:triggered",
+  WORKSPACE_BACKUP_RESTORED = "app:backup:restored",
+  WORKSPACE_BACKUP_TRIGGERED = "app:backup:triggered",
 
   // ENVIRONMENT VARIABLE
   ENVIRONMENT_VARIABLE_CREATED = "environment_variable:created",
@@ -319,21 +319,21 @@ export const AuditedEventFriendlyName: Record<Event, string | undefined> = {
   [Event.ORG_LOGO_UPDATED]: `Organisation logo updated`,
   [Event.ORG_PLATFORM_URL_UPDATED]: `Organisation platform URL updated`,
 
-  // APP
-  [Event.WORKSPACE_CREATED]: `App "{{ name }}" created`,
-  [Event.WORKSPACE_UPDATED]: `App "{{ name }}" updated`,
-  [Event.WORKSPACE_DELETED]: `App "{{ name }}" deleted`,
-  [Event.WORKSPACE_DUPLICATED]: `App "{{ name }}" duplicated`,
-  [Event.WORKSPACE_PUBLISHED]: `App "{{ name }}" published`,
-  [Event.WORKSPACE_UNPUBLISHED]: `App "{{ name }}" unpublished`,
-  [Event.WORKSPACE_TEMPLATE_IMPORTED]: `App "{{ name }}" template imported`,
-  [Event.WORKSPACE_FILE_IMPORTED]: `App "{{ name }}" file imported`,
-  [Event.WORKSPACE_APP_VERSION_UPDATED]: `App "{{ name }}" version updated`,
-  [Event.WORKSPACE_APP_VERSION_REVERTED]: `App "{{ name }}" version reverted`,
-  [Event.WORKSPACE_REVERTED]: `App "{{ name }}" reverted`,
-  [Event.WORKSPACE_EXPORTED]: `App "{{ name }}" exported`,
-  [Event.APP_BACKUP_RESTORED]: `App backup "{{ name }}" restored`,
-  [Event.APP_BACKUP_TRIGGERED]: `App backup "{{ name }}" triggered`,
+  // WORKSPACE
+  [Event.WORKSPACE_CREATED]: `Workspace "{{ name }}" created`,
+  [Event.WORKSPACE_UPDATED]: `Workspace "{{ name }}" updated`,
+  [Event.WORKSPACE_DELETED]: `Workspace "{{ name }}" deleted`,
+  [Event.WORKSPACE_DUPLICATED]: `Workspace "{{ name }}" duplicated`,
+  [Event.WORKSPACE_PUBLISHED]: `Workspace "{{ name }}" published`,
+  [Event.WORKSPACE_UNPUBLISHED]: `Workspace "{{ name }}" unpublished`,
+  [Event.WORKSPACE_TEMPLATE_IMPORTED]: `Workspace "{{ name }}" template imported`,
+  [Event.WORKSPACE_FILE_IMPORTED]: `Workspace "{{ name }}" file imported`,
+  [Event.WORKSPACE_APP_VERSION_UPDATED]: `Workspace "{{ name }}" version updated`,
+  [Event.WORKSPACE_APP_VERSION_REVERTED]: `Workspace "{{ name }}" version reverted`,
+  [Event.WORKSPACE_REVERTED]: `Workspace "{{ name }}" reverted`,
+  [Event.WORKSPACE_EXPORTED]: `Workspace "{{ name }}" exported`,
+  [Event.WORKSPACE_BACKUP_RESTORED]: `Workspace backup "{{ name }}" restored`,
+  [Event.WORKSPACE_BACKUP_TRIGGERED]: `Workspace backup "{{ name }}" triggered`,
 
   // DATASOURCE
   [Event.DATASOURCE_CREATED]: `Datasource created`,


### PR DESCRIPTION
## Description
Converting audit log svelte files to ts and svelte 5. Along the way, renaming some wrong "app" to "workspaces", and fixing some sorting/filtering issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts the audit logs page to Svelte 5 runes and TypeScript and fixes sorting, filtering, selection, and pagination bugs.

- Renames `Event.APP_BACKUP_RESTORED` and `Event.APP_BACKUP_TRIGGERED` to `WORKSPACE_BACKUP_*`; event string values are unchanged, but code referencing the old members must update.
- Audit logs now display "Workspace" instead of "App" in the table column and event-friendly names.
- Event filters sort case-insensitively, and selected items stay at the top of all filter dropdowns.
- User and log searches use a latest-request queue that drops superseded queries so stale responses can't overwrite newer results, and changing any filter resets log pagination.
- Audit log pagination now uses a numeric bookmark converted to an SQL offset, with next-page detection based on the generic page size.
- `UserAvatar` now takes a `UserDisplayInfo` prop, and log metadata cleanup handles workspace IDs and omits fields not returned in downloads.

<sup>Written for commit 6ef3074387ade6b79767b956ea3e36e3c737f92f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

