### PR TITLE
Support slack threads

### DIFF
--- a/packages/server/__mocks__/chat.ts
+++ b/packages/server/__mocks__/chat.ts
@@ -29,6 +29,7 @@ const mockWebhookState: Record<MockProvider, MockPostEphemeralResult> = {
   teams: defaultPostEphemeralResult(),
 }
 const mockChatOptions: ChatOptions[] = []
+const subscribedThreads = new Set<string>()
 
 const toMessageText = (value: unknown) =>
   typeof value === "string" ? value : JSON.stringify(value)
@@ -165,6 +166,7 @@ export const resetMockChatState = () => {
   mockWebhookState.slack = defaultPostEphemeralResult()
   mockWebhookState.teams = defaultPostEphemeralResult()
   mockChatOptions.length = 0
+  subscribedThreads.clear()
 }
 
 export const setMockPostEphemeralResult = (
@@ -322,7 +324,9 @@ export class Chat {
           id: `slack:${channelId}:${threadTs}`,
           channelId,
           ...createMessageCollector("slack", messages),
-          subscribe: async () => {},
+          subscribe: async () => {
+            subscribedThreads.add(`slack:${channelId}:${threadTs}`)
+          },
           channel,
         }
         const isMention = isSlackMentionMessage(event)
@@ -342,7 +346,10 @@ export class Chat {
         } else {
           if (isMention) {
             await invokeHandlers(this.mentionHandlers, thread, message)
-          } else if (event.thread_ts) {
+          } else if (
+            event.thread_ts &&
+            subscribedThreads.has(`slack:${channelId}:${threadTs}`)
+          ) {
             await invokeHandlers(this.subscribedHandlers, thread, message)
           }
           await invokeHandlers(this.newMessageHandlers, thread, message)

--- a/packages/server/__mocks__/chat.ts
+++ b/packages/server/__mocks__/chat.ts
@@ -30,6 +30,7 @@ const mockWebhookState: Record<MockProvider, MockPostEphemeralResult> = {
 }
 const mockChatOptions: ChatOptions[] = []
 const subscribedThreads = new Set<string>()
+let subscribeError: Error | undefined
 
 const toMessageText = (value: unknown) =>
   typeof value === "string" ? value : JSON.stringify(value)
@@ -167,6 +168,11 @@ export const resetMockChatState = () => {
   mockWebhookState.teams = defaultPostEphemeralResult()
   mockChatOptions.length = 0
   subscribedThreads.clear()
+  subscribeError = undefined
+}
+
+export const setMockSubscribeError = (error?: Error) => {
+  subscribeError = error
 }
 
 export const setMockPostEphemeralResult = (
@@ -325,6 +331,9 @@ export class Chat {
           channelId,
           ...createMessageCollector("slack", messages),
           subscribe: async () => {
+            if (subscribeError) {
+              throw subscribeError
+            }
             subscribedThreads.add(`slack:${channelId}:${threadTs}`)
           },
           channel,

--- a/packages/server/src/api/controllers/webhook/slack.ts
+++ b/packages/server/src/api/controllers/webhook/slack.ts
@@ -196,6 +196,7 @@ type SlackInput = {
   isDirectMessage: boolean
   teamId?: string
   threadId?: string
+  subscribe?: () => Promise<void>
 }
 
 const createSlackInputHandler = ({
@@ -222,6 +223,7 @@ const createSlackInputHandler = ({
     isDirectMessage,
     teamId,
     threadId,
+    subscribe,
   }: SlackInput) => {
     const displayName = author.fullName || author.userName || externalUserId
 
@@ -242,6 +244,7 @@ const createSlackInputHandler = ({
     }
 
     try {
+      await subscribe?.()
       await handleChatMessage({
         reply: async text => {
           await target.post(text)
@@ -306,8 +309,6 @@ const createSlackMessageHandler = (
       return
     }
 
-    await thread.subscribe()
-
     await handleSlackInput({
       target: thread as SlackReplyTarget,
       privateTarget: thread.channel as SlackReplyTarget,
@@ -319,6 +320,7 @@ const createSlackMessageHandler = (
       externalUserId: message.author.userId,
       isDirectMessage: isSlackDirectMessage(raw),
       teamId: raw?.team_id || raw?.team,
+      subscribe: () => thread.subscribe(),
     })
   }
 }

--- a/packages/server/src/api/controllers/webhook/slack.ts
+++ b/packages/server/src/api/controllers/webhook/slack.ts
@@ -306,6 +306,8 @@ const createSlackMessageHandler = (
       return
     }
 
+    await thread.subscribe()
+
     await handleSlackInput({
       target: thread as SlackReplyTarget,
       privateTarget: thread.channel as SlackReplyTarget,

--- a/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
@@ -11,6 +11,7 @@ interface ChatMockModule {
     provider: "slack" | "teams",
     result: { usedFallback: boolean }
   ) => void
+  setMockSubscribeError: (error?: Error) => void
 }
 
 interface SlackManifest {
@@ -128,9 +129,11 @@ import { setupDefaultCompletionsAIConfig } from "../../../../tests/utilities/aiC
 import { webhookChat } from "../../../controllers/ai/chatConversations"
 
 const SECRET_ENCODING_PREFIX = "bbai_enc::"
-const { resetMockChatState, setMockPostEphemeralResult } = jest.requireActual(
-  "chat"
-) as ChatMockModule
+const {
+  resetMockChatState,
+  setMockPostEphemeralResult,
+  setMockSubscribeError,
+} = jest.requireActual("chat") as ChatMockModule
 
 const mockedWebhookChat = webhookChat as jest.MockedFunction<typeof webhookChat>
 const mockedGetFileUrlForAgent = jest.mocked(sdk.ai.rag.getFileUrlForAgent)
@@ -1066,6 +1069,33 @@ describe("agent slack integration provisioning", () => {
         `/${ChatCommands.LINK}`
       )
       expect(extractLinkUrl(response.body.messages)).toBeTruthy()
+    })
+
+    it("posts a fallback error when thread subscribe fails", async () => {
+      const { agent } = await setupProvisionedSlackAgent()
+      const path = `/api/webhooks/slack/${config.getProdWorkspaceId()}/${agent._id}`
+      setMockSubscribeError(new Error("missing conversations:write"))
+
+      const response = await postSlackMessage({
+        path,
+        body: {
+          type: "event_callback",
+          event: {
+            type: "message",
+            text: "hello slack",
+            user: "user-1",
+            channel: "D123",
+            channel_type: "im",
+            ts: "1700000000.100",
+            team_id: "T123",
+          },
+        },
+      })
+
+      expect(mockedWebhookChat).not.toHaveBeenCalled()
+      expect(response.body.messages).toContain(
+        "Sorry, something went wrong while processing your request."
+      )
     })
 
     it("allows optional-link unlinked users and reuses their synthetic conversation", async () => {

--- a/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
@@ -1358,6 +1358,51 @@ describe("agent slack integration provisioning", () => {
       expect(mockedGetFileUrlForAgent).not.toHaveBeenCalled()
     })
 
+    it("handles replies in a channel thread without another mention", async () => {
+      const { agent, linkExternalUser } = await setupProvisionedSlackAgent()
+      const path = `/api/webhooks/slack/${config.getProdWorkspaceId()}/${agent._id}`
+      await linkExternalUser("user-1")
+
+      await postSlackMessage({
+        path,
+        body: {
+          type: "event_callback",
+          event: {
+            type: "message",
+            text: "<@U123> first question",
+            user: "user-1",
+            channel: "C123",
+            channel_type: "channel",
+            ts: "1700000000.100",
+            team_id: "T123",
+          },
+        },
+      })
+
+      const response = await postSlackMessage({
+        path,
+        body: {
+          type: "event_callback",
+          event: {
+            type: "message",
+            text: "follow-up question",
+            user: "user-1",
+            channel: "C123",
+            channel_type: "channel",
+            ts: "1700000000.200",
+            thread_ts: "1700000000.100",
+            team_id: "T123",
+          },
+        },
+      })
+
+      expect(response.body.messages).toContain("Mock assistant response")
+      expect(mockedWebhookChat).toHaveBeenCalledTimes(2)
+      const conversations = await fetchConversations()
+      expect(conversations).toHaveLength(1)
+      expect(conversations[0]?.messages).toHaveLength(4)
+    })
+
     it("does not append RAG source links when downloads are disabled", async () => {
       mockedWebhookChat.mockResolvedValueOnce({
         messages: [


### PR DESCRIPTION
## Description
Support Slack threads without retagging

## Screenshots
### Before

https://github.com/user-attachments/assets/054ca335-6b48-4a06-b3d5-7f292f8dddaa



### After
https://github.com/user-attachments/assets/84f8fa99-e7c3-422f-b1b4-e1282ced7907

## Launchcontrol
Support Slack threads

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slack thread handling so follow-up replies in a thread get responses without requiring another mention.

- Subscribes to a thread when the initial message is handled, and surfaces a fallback error if subscription fails.
- Adds `subscribedThreads` tracking and a `subscribe` failure test to the mock chat provider.

<sup>Written for commit 897a4b02b7b168854056f29ca1a7940a3fab61bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

