### PR TITLE
Fix broken lint

### DIFF
--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -103,9 +103,7 @@ const validatePWAZipEntries = () => {
 
     const fileType = (entry.externalFileAttributes >>> 16) & ZIP_FILE_TYPE_MASK
     if (fileType === ZIP_SYMLINK_FILE_TYPE) {
-      throw new BadRequestError(
-        `Invalid zip`
-      )
+      throw new BadRequestError(`Invalid zip`)
     }
 
     const depth =


### PR DESCRIPTION
## Description
Fix broken lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the lint error in `validatePWAZipEntries` by collapsing the `BadRequestError` construction to a single line. No behavior changes.

<sup>Written for commit 31dc0de58621d1921bd323c363e838cb56403d07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

