### PR TITLE
Implement Teams service URL validation and enhance webhook handling

### DIFF
--- a/packages/server/src/api/controllers/webhook/ms-teams.ts
+++ b/packages/server/src/api/controllers/webhook/ms-teams.ts
@@ -1,4 +1,9 @@
-import { context, features, isHTTPError } from "@budibase/backend-core"
+import {
+  context,
+  features,
+  HTTPError,
+  isHTTPError,
+} from "@budibase/backend-core"
 import { ChatCommands, type SupportedChatCommand } from "@budibase/shared-core"
 import {
   AgentChannelProvider,
@@ -22,6 +27,7 @@ import {
 import { createTeamsAdapter } from "@chat-adapter/teams"
 import sdk from "../../../sdk"
 import { escalationProcessor } from "../../../escalation/processor"
+import { validateMSTeamsServiceUrl } from "../../../utilities/msTeams"
 import { handleChatMessage, NO_ASSISTANT_RESPONSE_MESSAGE } from "./chatHandler"
 import { getTeamsState } from "./chatState"
 import { postLinkPromptPrivately } from "./linkPrompt"
@@ -442,6 +448,17 @@ export async function MSTeamsWebhook(
   await runChatWebhook({
     ctx,
     providerName: "Teams",
+    validateBody: body => {
+      if (
+        !body ||
+        typeof body !== "object" ||
+        !("serviceUrl" in body) ||
+        typeof body.serviceUrl !== "string"
+      ) {
+        throw new HTTPError("Missing Microsoft Teams service URL", 400)
+      }
+      validateMSTeamsServiceUrl(body.serviceUrl)
+    },
     createWebhookHandler: async ({ workspaceId, agentId }) => {
       const {
         integration,

--- a/packages/server/src/api/controllers/webhook/runChatWebhook.ts
+++ b/packages/server/src/api/controllers/webhook/runChatWebhook.ts
@@ -1,12 +1,18 @@
 import { HTTPError } from "@budibase/backend-core"
 import type { Ctx } from "@budibase/types"
-import { rawBodyToRequest, readRawBody, responseToKoa } from "./koaToRequest"
+import {
+  rawBodyToRequest,
+  readRawBody,
+  responseToKoa,
+  tryParseJson,
+} from "./koaToRequest"
 import { ensureProdWorkspaceWebhookRoute } from "./utils"
 
 export const runChatWebhook = async ({
   ctx,
   providerName,
   createWebhookHandler,
+  validateBody,
 }: {
   ctx: Ctx<unknown, unknown, { instance: string; agentId: string }>
   providerName: string
@@ -14,6 +20,7 @@ export const runChatWebhook = async ({
     workspaceId: string
     agentId: string
   }) => Promise<(request: Request) => Promise<Response>>
+  validateBody?: (body: unknown) => void
 }): Promise<void> => {
   const prodWorkspaceId = ensureProdWorkspaceWebhookRoute({
     ctx,
@@ -40,6 +47,18 @@ export const runChatWebhook = async ({
   }
 
   const rawBody = await readRawBody(ctx.req)
+  try {
+    if (ctx.get("authorization")) {
+      validateBody?.(tryParseJson(rawBody))
+    }
+  } catch (error) {
+    if (error instanceof HTTPError) {
+      ctx.status = error.status
+      ctx.body = { error: error.message }
+      return
+    }
+    throw error
+  }
   const request = rawBodyToRequest(ctx, rawBody)
   const response = await handleWebhook(request)
   await responseToKoa(ctx, response)

--- a/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
@@ -81,6 +81,7 @@ import {
 import sdk from "../../../../sdk"
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
 import { setupDefaultCompletionsAIConfig } from "../../../../tests/utilities/aiConfig"
+import { DEFAULT_MSTEAMS_SERVICE_URL } from "../../../../utilities/msTeams"
 import { webhookChat } from "../../../controllers/ai/chatConversations"
 
 const { getMockChatOptions, resetMockChatState, setMockPostEphemeralResult } =
@@ -403,7 +404,7 @@ describe("agent teams integration provisioning", () => {
         .post(path)
         .set("Authorization", "Bearer valid-token")
         .send({
-          serviceUrl: "https://smba.trafficmanager.net/emea/",
+          serviceUrl: DEFAULT_MSTEAMS_SERVICE_URL,
           ...body,
         })
         .expect(200)

--- a/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
@@ -402,7 +402,10 @@ describe("agent teams integration provisioning", () => {
         .getRequest()!
         .post(path)
         .set("Authorization", "Bearer valid-token")
-        .send(body)
+        .send({
+          serviceUrl: "https://smba.trafficmanager.net/emea/",
+          ...body,
+        })
         .expect(200)
 
     const fetchConversations = async () =>
@@ -461,6 +464,24 @@ describe("agent teams integration provisioning", () => {
       }
       return { agent, linkExternalUser }
     }
+
+    it("rejects an activity with an untrusted service URL", async () => {
+      const { agent } = await setupProvisionedTeamsAgent()
+      const path = `/api/webhooks/ms-teams/${config.getProdWorkspaceId()}/${agent._id}`
+
+      const response = await config
+        .getRequest()!
+        .post(path)
+        .set("Authorization", "Bearer valid-token")
+        .send({
+          type: "message",
+          serviceUrl: "https://example.com/",
+        })
+        .expect(400)
+
+      expect(response.body.error).toEqual("Invalid Microsoft Teams service URL")
+      expect(mockedWebhookChat).not.toHaveBeenCalled()
+    })
 
     it(`returns a private link prompt for ${ChatCommands.LINK} and /${ChatCommands.LINK} commands`, async () => {
       const { agent } = await setupProvisionedTeamsAgent()

--- a/packages/server/src/escalation/notifications/ms-teams.spec.ts
+++ b/packages/server/src/escalation/notifications/ms-teams.spec.ts
@@ -168,4 +168,31 @@ describe("sendMSTeamsNotification", () => {
     const body = JSON.parse(conversationCall[1].body)
     expect(body.members).toEqual([{ id: USER_RIGHT }])
   })
+
+  it("does not send a bot token to a persisted untrusted service URL", async () => {
+    agent = await createAgent()
+    const { contextDoc, notifDoc, globalUserId } = buildDocs()
+    await config.doInTenant(async () => {
+      await sdk.ai.chatIdentityLinks.upsertChatIdentityLink({
+        provider: AgentChannelProvider.MSTEAMS,
+        externalUserId: USER_RIGHT,
+        providerTenantId: TENANT_RIGHT,
+        globalUserId,
+        linkedBy: globalUserId,
+        serviceUrl: "https://example.com/",
+      })
+    })
+
+    await expect(
+      config.doInContext(config.getDevWorkspaceId(), () =>
+        sendMSTeamsNotification({ notifDoc, contextDoc })
+      )
+    ).rejects.toThrow("Invalid Microsoft Teams service URL")
+
+    expect(
+      mockFetch.mock.calls.some(([url]: [string]) =>
+        String(url).startsWith("https://example.com/")
+      )
+    ).toBe(false)
+  })
 })

--- a/packages/server/src/escalation/notifications/ms-teams.ts
+++ b/packages/server/src/escalation/notifications/ms-teams.ts
@@ -9,14 +9,14 @@ import {
   EscalationNotificationChannel,
 } from "@budibase/types"
 import sdk from "../../sdk"
+import {
+  DEFAULT_MSTEAMS_SERVICE_URL,
+  validateMSTeamsServiceUrl,
+} from "../../utilities/msTeams"
 import { findIntegrationAgent, getEscalationText } from "./utils"
 
 export const MS_SCOPE_BOT = "https://api.botframework.com/.default"
 export const MS_SCOPE_GRAPH = "https://graph.microsoft.com/.default"
-
-// Commercial Teams service URL — region-specific installs can override via TEAMS_API_URL
-const DEFAULT_SERVICE_URL =
-  process.env.TEAMS_API_URL ?? "https://smba.trafficmanager.net/apis/"
 
 export const getMSTeamsIntegration = async (
   appId: string,
@@ -209,9 +209,11 @@ const teamsPost = async <T = void>(
   conversationId: string,
   body: object
 ): Promise<T> => {
-  const url = `${serviceUrl.replace(/\/$/, "")}/v3/conversations/${encodeURIComponent(conversationId)}/activities`
+  const safeServiceUrl = validateMSTeamsServiceUrl(serviceUrl)
+  const url = `${safeServiceUrl.replace(/\/$/, "")}/v3/conversations/${encodeURIComponent(conversationId)}/activities`
   const resp = await fetch(url, {
     method: "POST",
+    redirect: "error",
     headers: {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
@@ -256,7 +258,7 @@ export async function replyToConversation({
     integration.msTenantId,
     MS_SCOPE_BOT
   )
-  const serviceUrl = channel.serviceUrl || DEFAULT_SERVICE_URL
+  const serviceUrl = channel.serviceUrl || DEFAULT_MSTEAMS_SERVICE_URL
 
   const isChannel =
     !!channel.channelId && channel.conversationType !== "personal"
@@ -335,7 +337,12 @@ export async function sendMSTeamsNotification({
   }
 
   if (config.channelId && config.teamId) {
-    await teamsPost(DEFAULT_SERVICE_URL, token, config.channelId, message)
+    await teamsPost(
+      DEFAULT_MSTEAMS_SERVICE_URL,
+      token,
+      config.channelId,
+      message
+    )
     console.log("sendMSTeamsNotification: message sent to channel", {
       escalationId: notifDoc.escalationId,
       channelId: config.channelId,
@@ -387,7 +394,9 @@ export async function sendMSTeamsNotification({
     return
   }
 
-  const dmServiceUrl = linkServiceUrl || DEFAULT_SERVICE_URL
+  const dmServiceUrl = validateMSTeamsServiceUrl(
+    linkServiceUrl || DEFAULT_MSTEAMS_SERVICE_URL
+  )
   const msTenantId = providerTenantId || integration.msTenantId
   const createBody = {
     channelId: "msteams",
@@ -405,6 +414,7 @@ export async function sendMSTeamsNotification({
     `${dmServiceUrl.replace(/\/$/, "")}/v3/conversations`,
     {
       method: "POST",
+      redirect: "error",
       headers: {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
@@ -421,7 +431,9 @@ export async function sendMSTeamsNotification({
     id: string
     serviceUrl?: string
   }
-  const postServiceUrl = conversation.serviceUrl || DEFAULT_SERVICE_URL
+  const postServiceUrl = validateMSTeamsServiceUrl(
+    conversation.serviceUrl || DEFAULT_MSTEAMS_SERVICE_URL
+  )
   console.log("sendMSTeamsNotification: conversation created", {
     conversationId: conversation.id,
     serviceUrl: conversation.serviceUrl,

--- a/packages/server/src/utilities/msTeams.ts
+++ b/packages/server/src/utilities/msTeams.ts
@@ -3,6 +3,13 @@ import { HTTPError } from "@budibase/backend-core"
 // Commercial Teams service URL — region-specific installs can override via TEAMS_API_URL
 const COMMERCIAL_MSTEAMS_SERVICE_URL = "https://smba.trafficmanager.net/apis/"
 
+const isSafeMSTeamsServiceUrl = (url: URL): boolean =>
+  url.protocol === "https:" &&
+  !url.username &&
+  !url.password &&
+  !url.search &&
+  !url.hash
+
 export const resolveDefaultMSTeamsServiceUrl = (
   configuredServiceUrl = process.env.TEAMS_API_URL
 ): string => {
@@ -12,13 +19,7 @@ export const resolveDefaultMSTeamsServiceUrl = (
 
   try {
     const parsed = new URL(configuredServiceUrl)
-    if (
-      parsed.protocol !== "https:" ||
-      parsed.username ||
-      parsed.password ||
-      parsed.search ||
-      parsed.hash
-    ) {
+    if (!isSafeMSTeamsServiceUrl(parsed)) {
       return COMMERCIAL_MSTEAMS_SERVICE_URL
     }
     return parsed.toString()
@@ -40,12 +41,8 @@ export const validateMSTeamsServiceUrl = (serviceUrl: string): string => {
   }
 
   if (
-    parsed.protocol !== "https:" ||
-    parsed.origin !== configuredServiceOrigin ||
-    parsed.username ||
-    parsed.password ||
-    parsed.search ||
-    parsed.hash
+    !isSafeMSTeamsServiceUrl(parsed) ||
+    parsed.origin !== configuredServiceOrigin
   ) {
     throw new HTTPError("Invalid Microsoft Teams service URL", 400)
   }

--- a/packages/server/src/utilities/msTeams.ts
+++ b/packages/server/src/utilities/msTeams.ts
@@ -1,0 +1,27 @@
+import { HTTPError } from "@budibase/backend-core"
+
+// Commercial Teams service URL — region-specific installs can override via TEAMS_API_URL
+export const DEFAULT_MSTEAMS_SERVICE_URL =
+  process.env.TEAMS_API_URL ?? "https://smba.trafficmanager.net/apis/"
+
+const configuredServiceOrigin = new URL(DEFAULT_MSTEAMS_SERVICE_URL).origin
+
+export const validateMSTeamsServiceUrl = (serviceUrl: string): string => {
+  let parsed: URL
+  try {
+    parsed = new URL(serviceUrl)
+  } catch {
+    throw new HTTPError("Invalid Microsoft Teams service URL", 400)
+  }
+
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.origin !== configuredServiceOrigin ||
+    parsed.username ||
+    parsed.password
+  ) {
+    throw new HTTPError("Invalid Microsoft Teams service URL", 400)
+  }
+
+  return parsed.toString()
+}

--- a/packages/server/src/utilities/msTeams.ts
+++ b/packages/server/src/utilities/msTeams.ts
@@ -1,8 +1,33 @@
 import { HTTPError } from "@budibase/backend-core"
 
 // Commercial Teams service URL — region-specific installs can override via TEAMS_API_URL
-export const DEFAULT_MSTEAMS_SERVICE_URL =
-  process.env.TEAMS_API_URL ?? "https://smba.trafficmanager.net/apis/"
+const COMMERCIAL_MSTEAMS_SERVICE_URL = "https://smba.trafficmanager.net/apis/"
+
+export const resolveDefaultMSTeamsServiceUrl = (
+  configuredServiceUrl = process.env.TEAMS_API_URL
+): string => {
+  if (!configuredServiceUrl) {
+    return COMMERCIAL_MSTEAMS_SERVICE_URL
+  }
+
+  try {
+    const parsed = new URL(configuredServiceUrl)
+    if (
+      parsed.protocol !== "https:" ||
+      parsed.username ||
+      parsed.password ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      return COMMERCIAL_MSTEAMS_SERVICE_URL
+    }
+    return parsed.toString()
+  } catch {
+    return COMMERCIAL_MSTEAMS_SERVICE_URL
+  }
+}
+
+export const DEFAULT_MSTEAMS_SERVICE_URL = resolveDefaultMSTeamsServiceUrl()
 
 const configuredServiceOrigin = new URL(DEFAULT_MSTEAMS_SERVICE_URL).origin
 
@@ -18,7 +43,9 @@ export const validateMSTeamsServiceUrl = (serviceUrl: string): string => {
     parsed.protocol !== "https:" ||
     parsed.origin !== configuredServiceOrigin ||
     parsed.username ||
-    parsed.password
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
   ) {
     throw new HTTPError("Invalid Microsoft Teams service URL", 400)
   }

--- a/packages/server/src/utilities/tests/msTeams.spec.ts
+++ b/packages/server/src/utilities/tests/msTeams.spec.ts
@@ -1,0 +1,24 @@
+import {
+  DEFAULT_MSTEAMS_SERVICE_URL,
+  validateMSTeamsServiceUrl,
+} from "../msTeams"
+
+describe("validateMSTeamsServiceUrl", () => {
+  it("accepts paths on the configured Teams service origin", () => {
+    const origin = new URL(DEFAULT_MSTEAMS_SERVICE_URL).origin
+
+    expect(validateMSTeamsServiceUrl(`${origin}/emea/`)).toBe(`${origin}/emea/`)
+  })
+
+  it.each([
+    "http://smba.trafficmanager.net/apis/",
+    "https://example.com/",
+    "https://smba.trafficmanager.net.example.com/",
+    "https://user:password@smba.trafficmanager.net/",
+    "not-a-url",
+  ])("rejects an untrusted service URL: %s", serviceUrl => {
+    expect(() => validateMSTeamsServiceUrl(serviceUrl)).toThrow(
+      "Invalid Microsoft Teams service URL"
+    )
+  })
+})

--- a/packages/server/src/utilities/tests/msTeams.spec.ts
+++ b/packages/server/src/utilities/tests/msTeams.spec.ts
@@ -1,7 +1,25 @@
 import {
   DEFAULT_MSTEAMS_SERVICE_URL,
+  resolveDefaultMSTeamsServiceUrl,
   validateMSTeamsServiceUrl,
 } from "../msTeams"
+
+describe("resolveDefaultMSTeamsServiceUrl", () => {
+  it.each(["not-a-url", "smba.trafficmanager.net", "http://example.com/"])(
+    "falls back from an invalid override: %s",
+    configuredServiceUrl => {
+      expect(resolveDefaultMSTeamsServiceUrl(configuredServiceUrl)).toBe(
+        "https://smba.trafficmanager.net/apis/"
+      )
+    }
+  )
+
+  it("accepts a valid HTTPS override", () => {
+    expect(resolveDefaultMSTeamsServiceUrl("https://example.com/custom/")).toBe(
+      "https://example.com/custom/"
+    )
+  })
+})
 
 describe("validateMSTeamsServiceUrl", () => {
   it("accepts paths on the configured Teams service origin", () => {
@@ -21,4 +39,13 @@ describe("validateMSTeamsServiceUrl", () => {
       "Invalid Microsoft Teams service URL"
     )
   })
+
+  it.each(["?region=emea", "#emea"])(
+    "rejects a configured-origin URL with suffix: %s",
+    suffix => {
+      expect(() =>
+        validateMSTeamsServiceUrl(`${DEFAULT_MSTEAMS_SERVICE_URL}${suffix}`)
+      ).toThrow("Invalid Microsoft Teams service URL")
+    }
+  )
 })


### PR DESCRIPTION
## Description
Implement Teams service URL validation and enhance webhook handling

## Addresses
- https://github.com/Budibase/vulns/issues/158

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects untrusted Microsoft Teams service URLs in webhook requests and notification sends. Previously any supplied `serviceUrl` was used to send bot tokens and messages; now URLs must be HTTPS, carry no credentials, query, or hash, and match the configured Teams origin (defaults to commercial `smba.trafficmanager.net`, overridable via `TEAMS_API_URL`; invalid overrides fall back to the default). Invalid URLs return 400 from webhooks and abort notification sends, and outbound Teams calls no longer follow redirects.

**Behavior changes**
- Webhook requests with an authorization header now parse the body and return 400 if `serviceUrl` is missing, invalid, or not on the allowed origin, so the handler is never called.
- Persisted chat link service URLs are validated before direct messages, so untrusted links cause the send to fail.

<sup>Written for commit a52c5b272e7d24eafcd2a0c539a722a287cb0147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

