### PR TITLE
Require verified emails for SSO invite reconciliation

### DIFF
--- a/packages/backend-core/src/middleware/passport/sso/sso.ts
+++ b/packages/backend-core/src/middleware/passport/sso/sso.ts
@@ -69,9 +69,11 @@ export async function authenticate(
   }
 
   let pendingInvite: InviteWithCode | undefined
-  if (!dbUser) {
+  if (!dbUser && (details.emailVerified || allowUnverifiedEmailLinking)) {
     const invites = await cache.invite.getExistingInvites([details.email])
-    pendingInvite = invites[0]
+    pendingInvite = invites.find(
+      invite => details.emailVerified || !invite.info.admin?.global
+    )
   }
 
   const emailLookupWasSkipped =

--- a/packages/backend-core/src/middleware/passport/sso/sso.ts
+++ b/packages/backend-core/src/middleware/passport/sso/sso.ts
@@ -69,10 +69,24 @@ export async function authenticate(
   }
 
   let pendingInvite: InviteWithCode | undefined
-  if (!dbUser && (details.emailVerified || allowUnverifiedEmailLinking)) {
+  let blockedInvite: InviteWithCode | undefined
+  if (!dbUser) {
     const invites = await cache.invite.getExistingInvites([details.email])
-    pendingInvite = invites.find(
-      invite => details.emailVerified || !invite.info.admin?.global
+    const matchingInvite = invites[0]
+    const canClaimInvite =
+      details.emailVerified ||
+      (allowUnverifiedEmailLinking && !matchingInvite?.info.admin?.global)
+    if (canClaimInvite) {
+      pendingInvite = matchingInvite
+    } else {
+      blockedInvite = matchingInvite
+    }
+  }
+
+  if (blockedInvite) {
+    return authError(
+      done,
+      "Email verification is required to accept this invite."
     )
   }
 

--- a/packages/backend-core/src/middleware/passport/sso/sso.ts
+++ b/packages/backend-core/src/middleware/passport/sso/sso.ts
@@ -72,14 +72,13 @@ export async function authenticate(
   let blockedInvite: InviteWithCode | undefined
   if (!dbUser) {
     const invites = await cache.invite.getExistingInvites([details.email])
-    const matchingInvite = invites[0]
-    const canClaimInvite =
-      details.emailVerified ||
-      (allowUnverifiedEmailLinking && !matchingInvite?.info.admin?.global)
-    if (canClaimInvite) {
-      pendingInvite = matchingInvite
-    } else {
-      blockedInvite = matchingInvite
+    if (details.emailVerified) {
+      pendingInvite = invites[0]
+    } else if (allowUnverifiedEmailLinking) {
+      pendingInvite = invites.find(invite => !invite.info.admin?.global)
+    }
+    if (!pendingInvite) {
+      blockedInvite = invites[0]
     }
   }
 

--- a/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
@@ -512,6 +512,36 @@ describe("sso", () => {
         expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
       })
 
+      it("reconciles an eligible invite when an admin invite for the same email appears first", async () => {
+        const adminInvite: InviteWithCode = {
+          code: structures.uuid(),
+          email: details.email!,
+          info: {
+            tenantId: context.getTenantId(),
+            admin: { global: true },
+          },
+        }
+        mockInvite.getExistingInvites.mockReset()
+        mockInvite.getExistingInvites.mockResolvedValueOnce([
+          adminInvite,
+          invite,
+        ])
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, true, mockDone, mockSaveUser, true)
+
+        expect(mockInvite.getCode).toHaveBeenCalledWith(
+          invite.code,
+          invite.info.tenantId
+        )
+        expect(mockInvite.deleteCode).toHaveBeenCalledWith(
+          invite.code,
+          invite.info.tenantId
+        )
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+
       it("rejects an unverified login for an admin invite even when unverified email linking is allowed", async () => {
         invite.info.admin = { global: true }
 

--- a/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
@@ -51,7 +51,7 @@ const getErrorMessage = () => {
 describe("sso", () => {
   describe("authenticate", () => {
     beforeEach(() => {
-      jest.clearAllMocks()
+      jest.resetAllMocks()
       testEnv.singleTenant()
       nock.cleanAll()
       mockInvite.getExistingInvites.mockResolvedValue([])
@@ -466,15 +466,15 @@ describe("sso", () => {
         mockInvite.deleteCode.mockResolvedValueOnce(undefined)
       })
 
-      it("does not reconcile the invite without a verified email", async () => {
-        await sso.authenticate(details, true, mockDone, mockSaveUser)
+      it("rejects the login rather than creating an account when the email is unverified", async () => {
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
 
-        expect(mockInvite.getExistingInvites).not.toHaveBeenCalled()
         expect(mockSaveUser).not.toHaveBeenCalled()
         expect(mockInvite.deleteCode).not.toHaveBeenCalled()
         expect(events.user.inviteAccepted).not.toHaveBeenCalled()
+        expect(mockDone.mock.calls.length).toBe(1)
         expect(getErrorMessage()).toContain(
-          "Email does not yet exist. You must set up your local budibase account first."
+          "Email verification is required to accept this invite."
         )
       })
 
@@ -512,16 +512,17 @@ describe("sso", () => {
         expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
       })
 
-      it("does not reconcile an admin invite from an unverified email", async () => {
+      it("rejects an unverified login for an admin invite even when unverified email linking is allowed", async () => {
         invite.info.admin = { global: true }
 
-        await sso.authenticate(details, true, mockDone, mockSaveUser, true)
+        await sso.authenticate(details, false, mockDone, mockSaveUser, true)
 
         expect(mockSaveUser).not.toHaveBeenCalled()
         expect(mockInvite.deleteCode).not.toHaveBeenCalled()
         expect(events.user.inviteAccepted).not.toHaveBeenCalled()
+        expect(mockDone.mock.calls.length).toBe(1)
         expect(getErrorMessage()).toContain(
-          "Email does not yet exist. You must set up your local budibase account first."
+          "Email verification is required to accept this invite."
         )
       })
 
@@ -548,8 +549,6 @@ describe("sso", () => {
 
         await sso.authenticate(details, false, mockDone, mockSaveUser)
 
-        // reused via the deterministic id, never by email match
-        expect(users.getGlobalUserByEmail).not.toHaveBeenCalled()
         // the winner's account is reused - no second document is created
         expect(mockSaveUser).toHaveBeenCalledWith(
           expect.objectContaining({ _id: existingUser._id }),
@@ -573,7 +572,6 @@ describe("sso", () => {
 
         await sso.authenticate(details, false, mockDone, mockSaveUser)
 
-        expect(users.getGlobalUserByEmail).not.toHaveBeenCalled()
         expect(mockSaveUser).not.toHaveBeenCalled()
         expect(mockInvite.deleteCode).not.toHaveBeenCalled()
         expect(events.user.inviteAccepted).not.toHaveBeenCalled()

--- a/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
@@ -466,14 +466,24 @@ describe("sso", () => {
         mockInvite.deleteCode.mockResolvedValueOnce(undefined)
       })
 
-      it("reconciles the invite without requiring a verified email, deletes it, and fires the accepted event", async () => {
+      it("does not reconcile the invite without a verified email", async () => {
+        await sso.authenticate(details, true, mockDone, mockSaveUser)
+
+        expect(mockInvite.getExistingInvites).not.toHaveBeenCalled()
+        expect(mockSaveUser).not.toHaveBeenCalled()
+        expect(mockInvite.deleteCode).not.toHaveBeenCalled()
+        expect(events.user.inviteAccepted).not.toHaveBeenCalled()
+        expect(getErrorMessage()).toContain(
+          "Email does not yet exist. You must set up your local budibase account first."
+        )
+      })
+
+      it("reconciles the invite when the email is verified, deletes it, and fires the accepted event", async () => {
+        details.emailVerified = true
         const ssoUser = structures.users.ssoUser({ details })
         mockSaveUser.mockReturnValueOnce(ssoUser)
 
         await sso.authenticate(details, false, mockDone, mockSaveUser)
-
-        // the invite is matched purely on email - no account-linking lookup happens
-        expect(users.getGlobalUserByEmail).not.toHaveBeenCalled()
 
         expect(mockSaveUser).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -493,16 +503,30 @@ describe("sso", () => {
         expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
       })
 
-      it("reconciles the invite even when a local account would otherwise be required", async () => {
+      it("reconciles a non-admin invite when unverified email linking is explicitly allowed", async () => {
         const ssoUser = structures.users.ssoUser({ details })
         mockSaveUser.mockReturnValueOnce(ssoUser)
 
-        await sso.authenticate(details, true, mockDone, mockSaveUser)
+        await sso.authenticate(details, true, mockDone, mockSaveUser, true)
 
         expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
       })
 
+      it("does not reconcile an admin invite from an unverified email", async () => {
+        invite.info.admin = { global: true }
+
+        await sso.authenticate(details, true, mockDone, mockSaveUser, true)
+
+        expect(mockSaveUser).not.toHaveBeenCalled()
+        expect(mockInvite.deleteCode).not.toHaveBeenCalled()
+        expect(events.user.inviteAccepted).not.toHaveBeenCalled()
+        expect(getErrorMessage()).toContain(
+          "Email does not yet exist. You must set up your local budibase account first."
+        )
+      })
+
       it("reuses the account when the same identity's own concurrent login already claimed the invite", async () => {
+        details.emailVerified = true
         // simulates a second, racing request for this exact identity
         // (e.g. a double-submitted login) losing the lock race: the
         // winner already consumed the invite and saved the account for
@@ -537,6 +561,7 @@ describe("sso", () => {
       })
 
       it("fails closed when the invite can no longer be validated and no concurrent claim for this identity can be confirmed", async () => {
+        details.emailVerified = true
         // covers expired/revoked invites and failed reads alike - none of
         // these are a positively identified concurrent claim, so this must
         // not fall back to linking by email or creating a fresh account

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -407,7 +407,7 @@ describe("/api/global/users", () => {
       expect(user?.builder?.apps).toEqual([workspaceId])
     })
 
-    it("reconciles an OIDC login with a pending invite for the same email, regardless of casing or email verification", async () => {
+    it("reconciles a verified OIDC login with a pending invite regardless of email casing", async () => {
       const email = structures.users.newEmail()
       const workspaceId = "app_oidc_invite_workspace"
       const request = [
@@ -421,7 +421,7 @@ describe("/api/global/users", () => {
 
       await config.api.users.sendMultiUserInvite(request)
 
-      // different casing, no email_verified claim
+      // different casing with a verified email claim
       const uppercaseEmail = email.toUpperCase()
       const ssoUserId = `oidc-test-${randomUUID()}`
       const verify: any = middleware.oidc.buildVerifyFn(userSdk.db.save, false)
@@ -431,7 +431,10 @@ describe("/api/global/users", () => {
           new Promise<{ err: any; user: any }>(resolve => {
             verify(
               "https://issuer.example.com",
-              { id: ssoUserId, _json: { email: uppercaseEmail } } as any,
+              {
+                id: ssoUserId,
+                _json: { email: uppercaseEmail, email_verified: true },
+              } as any,
               { id: ssoUserId, emails: [] } as any,
               {} as any,
               "id-token",


### PR DESCRIPTION
## Summary

- Restrict SSO invite reconciliation to verified email addresses by default
- Allow explicitly enabled unverified linking only for non-admin invites
- Prevent unverified email addresses from accepting global admin invites

## Addresses
- https://github.com/Budibase/vulns/issues/159

## Testing

- Added and updated unit tests covering verified, unverified, explicitly allowed, and admin invite scenarios


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
SSO invite reconciliation now requires a verified email by default; previously, unverified emails could accept pending invites. Unverified linking remains available only when explicitly enabled for non-global-admin invites, while blocked attempts return an email-verification error.

- Verified emails continue to reconcile pending invites.
- Unverified emails cannot accept global admin invites, even when linking is enabled.
- Tests cover verified, unverified, mixed admin, and concurrent invite scenarios.

<sup>Written for commit ac9ca1e5e54242d9ae5ba505fc160717ffff5d26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



