### PR TITLE
Escape SQL rename identifiers for MySQL and SQL Server

### DIFF
--- a/packages/backend-core/src/sql/sqlTable.ts
+++ b/packages/backend-core/src/sql/sqlTable.ts
@@ -16,6 +16,18 @@ import { helpers, utils } from "@budibase/shared-core"
 import SchemaBuilder = Knex.SchemaBuilder
 import CreateTableBuilder = Knex.CreateTableBuilder
 
+const quoteMySqlIdentifier = (identifier: string) => {
+  return `\`${identifier.replace(/`/g, "``")}\``
+}
+
+const quoteSqlServerIdentifier = (identifier: string) => {
+  return `[${identifier.replace(/]/g, "]]")}]`
+}
+
+const quoteSqlServerString = (value: string) => {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
 function isIgnoredType(type: FieldType) {
   const ignored = [FieldType.LINK, FieldType.FORMULA, FieldType.AI]
   return ignored.indexOf(type) !== -1
@@ -272,10 +284,14 @@ class SqlTableQueryBuilder {
         if (this.sqlClient === SqlClient.MY_SQL && json.meta?.renamed) {
           const updatedColumn = json.meta.renamed.updated
           const tableName = json?.schema
-            ? `\`${json.schema}\`.\`${json.table.name}\``
-            : `\`${json.table.name}\``
+            ? `${quoteMySqlIdentifier(json.schema)}.${quoteMySqlIdentifier(
+                json.table.name
+              )}`
+            : quoteMySqlIdentifier(json.table.name)
           return {
-            sql: `alter table ${tableName} rename column \`${json.meta.renamed.old}\` to \`${updatedColumn}\`;`,
+            sql: `alter table ${tableName} rename column ${quoteMySqlIdentifier(
+              json.meta.renamed.old
+            )} to ${quoteMySqlIdentifier(updatedColumn)};`,
             bindings: [],
           }
         }
@@ -293,14 +309,20 @@ class SqlTableQueryBuilder {
         if (this.sqlClient === SqlClient.MS_SQL && json.meta?.renamed) {
           const oldColumn = json.meta.renamed.old
           const updatedColumn = json.meta.renamed.updated
-          const tableName = json?.schema
-            ? `${json.schema}.${json.table.name}`
-            : `${json.table.name}`
+          const oldColumnName = [
+            ...(json.schema ? [json.schema] : []),
+            json.table.name,
+            oldColumn,
+          ]
+            .map(quoteSqlServerIdentifier)
+            .join(".")
           const sql = getNativeSql(query)
           if (Array.isArray(sql)) {
             for (const query of sql) {
               if (query.sql.startsWith("exec sp_rename")) {
-                query.sql = `exec sp_rename '${tableName}.${oldColumn}', '${updatedColumn}', 'COLUMN'`
+                query.sql = `exec sp_rename ${quoteSqlServerString(
+                  oldColumnName
+                )}, ${quoteSqlServerString(updatedColumn)}, 'COLUMN'`
                 query.bindings = []
               }
             }

--- a/packages/backend-core/src/sql/sqlTable.ts
+++ b/packages/backend-core/src/sql/sqlTable.ts
@@ -24,8 +24,8 @@ const quoteSqlServerIdentifier = (identifier: string) => {
   return `[${identifier.replace(/]/g, "]]")}]`
 }
 
-const quoteSqlServerString = (value: string) => {
-  return `'${value.replace(/'/g, "''")}'`
+const quoteSqlServerUnicodeString = (value: string) => {
+  return `N'${value.replace(/'/g, "''")}'`
 }
 
 function isIgnoredType(type: FieldType) {
@@ -320,9 +320,11 @@ class SqlTableQueryBuilder {
           if (Array.isArray(sql)) {
             for (const query of sql) {
               if (query.sql.startsWith("exec sp_rename")) {
-                query.sql = `exec sp_rename ${quoteSqlServerString(
+                query.sql = `exec sp_rename ${quoteSqlServerUnicodeString(
                   oldColumnName
-                )}, ${quoteSqlServerString(updatedColumn)}, 'COLUMN'`
+                )}, ${quoteSqlServerUnicodeString(
+                  updatedColumn
+                )}, ${quoteSqlServerUnicodeString("COLUMN")}`
                 query.bindings = []
               }
             }

--- a/packages/backend-core/src/sql/tests/sqlTable.spec.ts
+++ b/packages/backend-core/src/sql/tests/sqlTable.spec.ts
@@ -75,10 +75,10 @@ describe("SQL table identifier escaping", () => {
 
   it("escapes SQL Server rename identifiers and string literals", () => {
     const query = buildRenameQuery({
-      schema: "schema]",
-      tableName: "table'",
-      oldColumn: "old]'; DROP TABLE users; --",
-      updatedColumn: "new'name",
+      schema: "schema漢]",
+      tableName: "table字'",
+      oldColumn: "old名]'; DROP TABLE users; --",
+      updatedColumn: "new列'name",
     })
 
     const result = new SqlTable(SqlClient.MS_SQL)._tableQuery(query)
@@ -88,7 +88,7 @@ describe("SQL table identifier escaping", () => {
     )
 
     expect(renameQuery).toEqual({
-      sql: "exec sp_rename '[schema]]].[table''].[old]]''; DROP TABLE users; --]', 'new''name', 'COLUMN'",
+      sql: "exec sp_rename N'[schema漢]]].[table字''].[old名]]''; DROP TABLE users; --]', N'new列''name', N'COLUMN'",
       bindings: [],
     })
   })

--- a/packages/backend-core/src/sql/tests/sqlTable.spec.ts
+++ b/packages/backend-core/src/sql/tests/sqlTable.spec.ts
@@ -1,0 +1,95 @@
+import SqlTable from "../sqlTable"
+import {
+  FieldType,
+  Operation,
+  SqlClient,
+  TableSourceType,
+} from "@budibase/types"
+import type { EnrichedQueryJson, SqlQuery, Table } from "@budibase/types"
+
+const buildTable = ({
+  name,
+  column,
+}: {
+  name: string
+  column: string
+}): Table => ({
+  _id: "tbl",
+  type: "table",
+  name,
+  sourceId: "datasource",
+  sourceType: TableSourceType.EXTERNAL,
+  schema: {
+    [column]: {
+      name: column,
+      type: FieldType.STRING,
+    },
+  },
+})
+
+const buildRenameQuery = ({
+  tableName,
+  oldColumn,
+  updatedColumn,
+  schema,
+}: {
+  tableName: string
+  oldColumn: string
+  updatedColumn: string
+  schema?: string
+}): EnrichedQueryJson => {
+  const oldTable = buildTable({ name: tableName, column: oldColumn })
+  const table = buildTable({ name: tableName, column: updatedColumn })
+
+  return {
+    operation: Operation.UPDATE_TABLE,
+    table,
+    tables: { [tableName]: table },
+    schema,
+    meta: {
+      oldTable,
+      renamed: {
+        old: oldColumn,
+        updated: updatedColumn,
+      },
+    },
+  }
+}
+
+describe("SQL table identifier escaping", () => {
+  it("escapes MySQL rename identifiers", () => {
+    const query = buildRenameQuery({
+      schema: "schema`; DROP TABLE audit; --",
+      tableName: "table`; DROP TABLE users; --",
+      oldColumn: "old`; SELECT SLEEP(10); --",
+      updatedColumn: "new`name",
+    })
+
+    const result = new SqlTable(SqlClient.MY_SQL)._tableQuery(query) as SqlQuery
+
+    expect(result).toEqual({
+      sql: "alter table `schema``; DROP TABLE audit; --`.`table``; DROP TABLE users; --` rename column `old``; SELECT SLEEP(10); --` to `new``name`;",
+      bindings: [],
+    })
+  })
+
+  it("escapes SQL Server rename identifiers and string literals", () => {
+    const query = buildRenameQuery({
+      schema: "schema]",
+      tableName: "table'",
+      oldColumn: "old]'; DROP TABLE users; --",
+      updatedColumn: "new'name",
+    })
+
+    const result = new SqlTable(SqlClient.MS_SQL)._tableQuery(query)
+    const queries = result as SqlQuery[]
+    const renameQuery = queries.find(query =>
+      query.sql.startsWith("exec sp_rename")
+    )
+
+    expect(renameQuery).toEqual({
+      sql: "exec sp_rename '[schema]]].[table''].[old]]''; DROP TABLE users; --]', 'new''name', 'COLUMN'",
+      bindings: [],
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Safely quote MySQL table and column identifiers during renames
- Escape SQL Server identifiers and `sp_rename` string literals
- Add unit tests covering injection-like identifier and literal values

## Addresses
- https://github.com/Budibase/vulns/issues/160

## Testing

- Added unit tests for MySQL and SQL Server rename escaping


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes table and column identifiers in rename SQL for MySQL and SQL Server so injection-like values can't break out of the query.

- MySQL identifiers use backticks with embedded backticks doubled; SQL Server uses brackets with `]` doubled and `sp_rename` string literals are escaped and prefixed with `N` for Unicode.
- Adds unit tests covering injection-like identifiers for both dialects.

<sup>Written for commit bc1d10288ad1278982495f34222bb8b9e430ecb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



