### PR TITLE
Redact datasource secrets before broadcasting external table updates

### DIFF
--- a/packages/server/src/api/controllers/table/external.ts
+++ b/packages/server/src/api/controllers/table/external.ts
@@ -5,6 +5,7 @@ import { isRows, isSchema, parse } from "../../../utilities/schema"
 import {
   BulkImportRequest,
   BulkImportResponse,
+  Datasource,
   Operation,
   RenameColumn,
   SaveTableRequest,
@@ -31,6 +32,16 @@ function getDatasourceId(table: Table) {
   return breakExternalTableId(table._id).datasourceId
 }
 
+async function emitDatasourceUpdate(ctx: UserCtx, datasource: Datasource) {
+  try {
+    const redactedDatasource =
+      await sdk.datasources.removeSecretSingle(datasource)
+    builderSocket?.emitDatasourceUpdate(ctx, redactedDatasource)
+  } catch (err) {
+    console.log("Failed to broadcast external datasource update", err)
+  }
+}
+
 export async function updateTable(
   ctx: UserCtx<SaveTableRequest, SaveTableResponse>,
   renaming?: RenameColumn
@@ -50,9 +61,7 @@ export async function updateTable(
       inputs,
       { tableId, renaming }
     )
-    const redactedDatasource =
-      await sdk.datasources.removeSecretSingle(datasource)
-    builderSocket?.emitDatasourceUpdate(ctx, redactedDatasource)
+    await emitDatasourceUpdate(ctx, datasource)
     return { table, oldTable }
   } catch (err: any) {
     if (err instanceof Error) {
@@ -73,9 +82,7 @@ export async function destroy(ctx: UserCtx) {
       datasourceId!,
       tableToDelete
     )
-    const redactedDatasource =
-      await sdk.datasources.removeSecretSingle(datasource)
-    builderSocket?.emitDatasourceUpdate(ctx, redactedDatasource)
+    await emitDatasourceUpdate(ctx, datasource)
     return table
   } catch (err: any) {
     if (err instanceof Error) {

--- a/packages/server/src/api/controllers/table/external.ts
+++ b/packages/server/src/api/controllers/table/external.ts
@@ -50,7 +50,9 @@ export async function updateTable(
       inputs,
       { tableId, renaming }
     )
-    builderSocket?.emitDatasourceUpdate(ctx, datasource)
+    const redactedDatasource =
+      await sdk.datasources.removeSecretSingle(datasource)
+    builderSocket?.emitDatasourceUpdate(ctx, redactedDatasource)
     return { table, oldTable }
   } catch (err: any) {
     if (err instanceof Error) {
@@ -71,7 +73,9 @@ export async function destroy(ctx: UserCtx) {
       datasourceId!,
       tableToDelete
     )
-    builderSocket?.emitDatasourceUpdate(ctx, datasource)
+    const redactedDatasource =
+      await sdk.datasources.removeSecretSingle(datasource)
+    builderSocket?.emitDatasourceUpdate(ctx, redactedDatasource)
     return table
   } catch (err: any) {
     if (err instanceof Error) {

--- a/packages/server/src/api/controllers/table/external.ts
+++ b/packages/server/src/api/controllers/table/external.ts
@@ -38,7 +38,7 @@ async function emitDatasourceUpdate(ctx: UserCtx, datasource: Datasource) {
       await sdk.datasources.removeSecretSingle(datasource)
     builderSocket?.emitDatasourceUpdate(ctx, redactedDatasource)
   } catch (err) {
-    console.log("Failed to broadcast external datasource update", err)
+    console.error("Failed to broadcast external datasource update", err)
   }
 }
 

--- a/packages/server/src/api/controllers/table/tests/external.spec.ts
+++ b/packages/server/src/api/controllers/table/tests/external.spec.ts
@@ -61,11 +61,18 @@ const createCtx = () =>
   })
 
 describe("external table controller", () => {
+  let consoleLogSpy: jest.SpyInstance
+
   beforeEach(() => {
     jest.clearAllMocks()
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation()
     jest
       .mocked(sdk.datasources.removeSecretSingle)
       .mockResolvedValue(redactedDatasource)
+  })
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore()
   })
 
   it("redacts the datasource before broadcasting a table update", async () => {
@@ -100,5 +107,58 @@ describe("external table controller", () => {
       ctx,
       redactedDatasource
     )
+  })
+
+  it("returns the updated table when datasource redaction fails", async () => {
+    jest.mocked(sdk.tables.external.save).mockResolvedValue({
+      datasource,
+      oldTable: table,
+      table,
+    })
+    const redactionError = new Error("Plugin metadata unavailable")
+    jest
+      .mocked(sdk.datasources.removeSecretSingle)
+      .mockRejectedValue(redactionError)
+    const ctx = createCtx()
+
+    await expect(updateTable(ctx)).resolves.toEqual({
+      oldTable: table,
+      table,
+    })
+    expect(builderSocket?.emitDatasourceUpdate).not.toHaveBeenCalled()
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "Failed to broadcast external datasource update",
+      redactionError
+    )
+  })
+
+  it("returns the deleted table when datasource redaction fails", async () => {
+    jest.mocked(sdk.tables.getTable).mockResolvedValue(table)
+    jest.mocked(sdk.tables.external.destroy).mockResolvedValue({
+      datasource,
+      table,
+    })
+    jest
+      .mocked(sdk.datasources.removeSecretSingle)
+      .mockRejectedValue(new Error("Plugin metadata unavailable"))
+
+    await expect(destroy(createCtx())).resolves.toEqual(table)
+    expect(builderSocket?.emitDatasourceUpdate).not.toHaveBeenCalled()
+  })
+
+  it("returns the updated table when the websocket broadcast fails", async () => {
+    jest.mocked(sdk.tables.external.save).mockResolvedValue({
+      datasource,
+      oldTable: table,
+      table,
+    })
+    jest.mocked(builderSocket!.emitDatasourceUpdate).mockImplementation(() => {
+      throw new Error("Websocket unavailable")
+    })
+
+    await expect(updateTable(createCtx())).resolves.toEqual({
+      oldTable: table,
+      table,
+    })
   })
 })

--- a/packages/server/src/api/controllers/table/tests/external.spec.ts
+++ b/packages/server/src/api/controllers/table/tests/external.spec.ts
@@ -1,0 +1,104 @@
+import { SourceName } from "@budibase/types"
+import type {
+  Datasource,
+  SaveTableRequest,
+  SaveTableResponse,
+  Table,
+  UserCtx,
+} from "@budibase/types"
+import sdk from "../../../../sdk"
+import { builderSocket } from "../../../../websockets"
+import { destroy, updateTable } from "../external"
+
+jest.mock("../../../../integrations/utils", () => ({
+  breakExternalTableId: jest.fn().mockReturnValue({
+    datasourceId: "datasource_plus_test",
+  }),
+}))
+
+jest.mock("../../../../sdk", () => ({
+  datasources: {
+    removeSecretSingle: jest.fn(),
+  },
+  tables: {
+    external: {
+      destroy: jest.fn(),
+      save: jest.fn(),
+    },
+    getTable: jest.fn(),
+  },
+}))
+
+jest.mock("../../../../websockets", () => ({
+  builderSocket: {
+    emitDatasourceUpdate: jest.fn(),
+  },
+}))
+
+const datasource: Datasource = {
+  _id: "datasource_plus_test",
+  type: "datasource",
+  source: SourceName.POSTGRES,
+  config: { password: "plaintext-secret" },
+}
+
+const redactedDatasource = {
+  ...datasource,
+  config: { password: "********" },
+}
+
+const table = {
+  _id: "datasource_plus_test_table",
+  name: "table",
+  sourceId: datasource._id,
+} as Table
+
+const createCtx = () =>
+  Object.assign({} as UserCtx<SaveTableRequest, SaveTableResponse>, {
+    appId: "app_test",
+    params: { tableId: table._id },
+    request: { body: { ...table } },
+  })
+
+describe("external table controller", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest
+      .mocked(sdk.datasources.removeSecretSingle)
+      .mockResolvedValue(redactedDatasource)
+  })
+
+  it("redacts the datasource before broadcasting a table update", async () => {
+    jest.mocked(sdk.tables.external.save).mockResolvedValue({
+      datasource,
+      oldTable: table,
+      table,
+    })
+    const ctx = createCtx()
+
+    await updateTable(ctx)
+
+    expect(sdk.datasources.removeSecretSingle).toHaveBeenCalledWith(datasource)
+    expect(builderSocket?.emitDatasourceUpdate).toHaveBeenCalledWith(
+      ctx,
+      redactedDatasource
+    )
+  })
+
+  it("redacts the datasource before broadcasting a table deletion", async () => {
+    jest.mocked(sdk.tables.getTable).mockResolvedValue(table)
+    jest.mocked(sdk.tables.external.destroy).mockResolvedValue({
+      datasource,
+      table,
+    })
+    const ctx = createCtx()
+
+    await destroy(ctx)
+
+    expect(sdk.datasources.removeSecretSingle).toHaveBeenCalledWith(datasource)
+    expect(builderSocket?.emitDatasourceUpdate).toHaveBeenCalledWith(
+      ctx,
+      redactedDatasource
+    )
+  })
+})

--- a/packages/server/src/api/controllers/table/tests/external.spec.ts
+++ b/packages/server/src/api/controllers/table/tests/external.spec.ts
@@ -61,18 +61,18 @@ const createCtx = () =>
   })
 
 describe("external table controller", () => {
-  let consoleLogSpy: jest.SpyInstance
+  let consoleErrorSpy: jest.SpyInstance
 
   beforeEach(() => {
     jest.clearAllMocks()
-    consoleLogSpy = jest.spyOn(console, "log").mockImplementation()
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation()
     jest
       .mocked(sdk.datasources.removeSecretSingle)
       .mockResolvedValue(redactedDatasource)
   })
 
   afterEach(() => {
-    consoleLogSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
   })
 
   it("redacts the datasource before broadcasting a table update", async () => {
@@ -126,7 +126,7 @@ describe("external table controller", () => {
       table,
     })
     expect(builderSocket?.emitDatasourceUpdate).not.toHaveBeenCalled()
-    expect(consoleLogSpy).toHaveBeenCalledWith(
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       "Failed to broadcast external datasource update",
       redactionError
     )


### PR DESCRIPTION
## Summary

- Redact datasource secrets before broadcasting external table updates and deletions over the builder socket.
- Add controller tests covering both update and deletion flows.

## Addresses
- https://github.com/Budibase/vulns/issues/147


## Testing

- Added Jest coverage for datasource redaction before websocket broadcasts.
- Not run (not requested)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts datasource secrets before broadcasting external table updates and deletions over the builder socket, so plaintext secrets no longer leak to clients. Adds controller tests covering both update and deletion flows, including error cases where redaction or broadcast failures still return the table result and are logged.

<sup>Written for commit bccbbb291f0c0c7a8b97d74402bfe57675d8905b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



