### PR TITLE
Implement tenant validation middleware and restrict snippets exposure

### DIFF
--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -460,7 +460,6 @@ export async function fetchAppPackage(
 
   // Only filter screens if the user is not a builder call
   const isBuilder = users.isBuilder(ctx.user, appId) && !utils.isClient(ctx)
-
   const isDev = isDevWorkspaceID(ctx.params.appId)
   if (!isBuilder) {
     const userRoleId = getUserRoleId(ctx)
@@ -518,8 +517,16 @@ export async function fetchAppPackage(
       : undefined
   }
 
+  const clientApplication = {
+    ...application,
+    snippets: isBuilder ? application.snippets : undefined,
+  }
+
   ctx.body = {
-    application: { ...application, upgradableVersion: envCore.VERSION },
+    application: {
+      ...clientApplication,
+      upgradableVersion: envCore.VERSION,
+    },
     licenseType: license?.plan.type || PlanType.FREE,
     screens,
     layouts,

--- a/packages/server/src/api/routes/routing.ts
+++ b/packages/server/src/api/routes/routing.ts
@@ -1,7 +1,12 @@
 import * as controller from "../controllers/routing"
+import { ensureUserBelongsToWorkspaceTenant } from "../../middleware/ensureUserBelongsToWorkspaceTenant"
 import { publicRoutes, builderRoutes } from "./endpointGroups"
 
 // gets correct structure for user role
-publicRoutes.get("/api/routing/client", controller.clientFetch)
+publicRoutes.get(
+  "/api/routing/client",
+  ensureUserBelongsToWorkspaceTenant,
+  controller.clientFetch
+)
 // gets the full structure, not just the correct screen ID for user role
 builderRoutes.get("/api/routing", controller.fetch)

--- a/packages/server/src/api/routes/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/tests/workspace.spec.ts
@@ -1014,6 +1014,23 @@ describe("/applications", () => {
       )
     })
 
+    it("should not expose snippets to public calls", async () => {
+      await config.api.workspace.update(workspace.appId, {
+        snippets: [{ name: "PrivateSnippet", code: "return 'secret'" }],
+      })
+      await config.publish()
+
+      const res = await config.withHeaders(
+        { referer: `http://localhost:10000/app${workspace.url}` },
+        () =>
+          config.api.workspace.getAppPackage(config.getProdWorkspaceId(), {
+            publicUser: true,
+          })
+      )
+
+      expect(res.application.snippets).toBeUndefined()
+    })
+
     it("should expose recaptcha availability to public app packages", async () => {
       mocks.licenses.useUnlimited({ features: [Feature.RECAPTCHA] })
 

--- a/packages/server/src/api/routes/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/tests/workspace.spec.ts
@@ -968,6 +968,16 @@ describe("/applications", () => {
       const res = await config.api.workspace.getDefinition(workspace.appId)
       expect(res.libraries.length).toEqual(1)
     })
+
+    it("should reject users from another tenant", async () => {
+      await config.newTenant()
+
+      await config.withHeaders({ [Header.WORKSPACE_ID]: workspace.appId }, () =>
+        config.api.workspace.getDefinition(workspace.appId, {
+          status: 401,
+        })
+      )
+    })
   })
 
   describe("fetchAppPackage", () => {
@@ -975,6 +985,16 @@ describe("/applications", () => {
       const res = await config.api.workspace.getAppPackage(workspace.appId)
       expect(res.application).toBeDefined()
       expect(res.application.appId).toEqual(config.getDevWorkspaceId())
+    })
+
+    it("should reject users from another tenant", async () => {
+      await config.newTenant()
+
+      await config.withHeaders({ [Header.WORKSPACE_ID]: workspace.appId }, () =>
+        config.api.workspace.getAppPackage(workspace.appId, {
+          expectations: { status: 401 },
+        })
+      )
     })
 
     it("should retrieve all the screens for builder calls", async () => {

--- a/packages/server/src/api/routes/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/tests/workspace.spec.ts
@@ -1035,9 +1035,16 @@ describe("/applications", () => {
     })
 
     it("should not expose snippets to public calls", async () => {
+      const snippets = [{ name: "PrivateSnippet", code: "return 'secret'" }]
       await config.api.workspace.update(workspace.appId, {
-        snippets: [{ name: "PrivateSnippet", code: "return 'secret'" }],
+        snippets,
       })
+
+      const builderPackage = await config.api.workspace.getAppPackage(
+        workspace.appId
+      )
+      expect(builderPackage.application.snippets).toEqual(snippets)
+
       await config.publish()
 
       const res = await config.withHeaders(

--- a/packages/server/src/api/routes/workspace.ts
+++ b/packages/server/src/api/routes/workspace.ts
@@ -1,4 +1,5 @@
 import { skipMigrationRedirect } from "../../middleware/workspaceMigrations"
+import { ensureUserBelongsToWorkspaceTenant } from "../../middleware/ensureUserBelongsToWorkspaceTenant"
 import * as deploymentController from "../controllers/deploy"
 import * as controller from "../controllers/workspace"
 import { builderRoutes, creatorRoutes, publicRoutes } from "./endpointGroups"
@@ -33,7 +34,15 @@ creatorRoutes.post(
 // Client only endpoints
 publicRoutes
   .get("/api/client/applications", controller.fetchClientApps)
-  .get("/api/applications/:appId/definition", controller.fetchAppDefinition)
+  .get(
+    "/api/applications/:appId/definition",
+    ensureUserBelongsToWorkspaceTenant,
+    controller.fetchAppDefinition
+  )
   .get("/api/applications", controller.fetch)
   .get("/api/microfrontend/bootstrap", controller.fetchMicrofrontendBootstrap)
-  .get("/api/applications/:appId/appPackage", controller.fetchAppPackage)
+  .get(
+    "/api/applications/:appId/appPackage",
+    ensureUserBelongsToWorkspaceTenant,
+    controller.fetchAppPackage
+  )

--- a/packages/server/src/middleware/ensureUserBelongsToWorkspaceTenant.ts
+++ b/packages/server/src/middleware/ensureUserBelongsToWorkspaceTenant.ts
@@ -1,0 +1,21 @@
+import { context, tenancy } from "@budibase/backend-core"
+import type { UserCtx } from "@budibase/types"
+import type { Next } from "koa"
+import env from "../environment"
+
+export const ensureUserBelongsToWorkspaceTenant = async (
+  ctx: UserCtx,
+  next: Next
+) => {
+  const workspaceId = context.getWorkspaceId()
+  if (
+    env.MULTI_TENANCY &&
+    workspaceId &&
+    ctx.user?.tenantId &&
+    !tenancy.isUserInWorkspaceTenant(workspaceId, ctx.user)
+  ) {
+    ctx.throw(401, "Session not authenticated")
+  }
+
+  return next()
+}


### PR DESCRIPTION
## Description
Implement tenant validation middleware and restrict snippets exposure

## Addresses
- https://github.com/Budibase/vulns/issues/142

## Launchcontrol
Implement tenant validation middleware and restrict snippets exposure


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-tenant access to workspace endpoints and stops public app package responses from exposing snippets.

- When multi-tenancy is enabled, requests to client-facing workspace routes from a user outside the workspace tenant now return 401.
- App package responses include `snippets` only for builder calls, so public clients no longer receive them.

<sup>Written for commit 30145550741778c233075c3a60a55fcada0a17c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



