### PR TITLE
Implement role-based access control for updating group apps

### DIFF
--- a/packages/worker/src/api/controllers/global/groups.ts
+++ b/packages/worker/src/api/controllers/global/groups.ts
@@ -71,8 +71,13 @@ export async function updateGroupApps(
   ctx: UserCtx<UpdateGroupAppRequest, UpdateGroupAppResponse>
 ) {
   const groupId = ctx.params.groupId
-  const toAdd = ctx.request.body.add,
-    toRemove = ctx.request.body.remove
+  const toAdd = ctx.request.body.add?.map(({ appId, roleId }) => ({
+      appId: appId.trim(),
+      roleId: roleId.trim(),
+    })),
+    toRemove = ctx.request.body.remove?.map(({ appId }) => ({
+      appId: appId.trim(),
+    }))
 
   for (const { appId } of [...(toAdd || []), ...(toRemove || [])]) {
     if (!ctx.internal && !users.isAdminOrBuilder(ctx.user, appId)) {

--- a/packages/worker/src/api/controllers/global/groups.ts
+++ b/packages/worker/src/api/controllers/global/groups.ts
@@ -71,13 +71,15 @@ export async function updateGroupApps(
   ctx: UserCtx<UpdateGroupAppRequest, UpdateGroupAppResponse>
 ) {
   const groupId = ctx.params.groupId
-  const toAdd = ctx.request.body.add?.map(({ appId, roleId }) => ({
-      appId: appId.trim(),
-      roleId: roleId.trim(),
-    })),
-    toRemove = ctx.request.body.remove?.map(({ appId }) => ({
-      appId: appId.trim(),
-    }))
+  const { add, remove } = ctx.request.body
+
+  const toAdd = add?.map(item => ({
+    appId: item.appId.trim(),
+    roleId: item.roleId.trim(),
+  }))
+  const toRemove = remove?.map(item => ({
+    appId: item.appId.trim(),
+  }))
 
   for (const { appId } of [...(toAdd || []), ...(toRemove || [])]) {
     if (!ctx.internal && !users.isAdminOrBuilder(ctx.user, appId)) {

--- a/packages/worker/src/api/controllers/global/groups.ts
+++ b/packages/worker/src/api/controllers/global/groups.ts
@@ -75,7 +75,12 @@ export async function updateGroupApps(
     toRemove = ctx.request.body.remove
   if (
     (toAdd && !Array.isArray(toAdd)) ||
-    (toRemove && !Array.isArray(toRemove))
+    (toRemove && !Array.isArray(toRemove)) ||
+    toAdd?.some(
+      app =>
+        !app || typeof app.appId !== "string" || typeof app.roleId !== "string"
+    ) ||
+    toRemove?.some(app => !app || typeof app.appId !== "string")
   ) {
     ctx.throw(
       400,
@@ -84,7 +89,7 @@ export async function updateGroupApps(
   }
 
   for (const { appId } of [...(toAdd || []), ...(toRemove || [])]) {
-    if (!users.isAdmin(ctx.user) && !users.isBuilder(ctx.user, appId)) {
+    if (!ctx.internal && !users.isAdminOrBuilder(ctx.user, appId)) {
       ctx.throw(403, "Only app builders or admins can update app permissions.")
     }
   }

--- a/packages/worker/src/api/controllers/global/groups.ts
+++ b/packages/worker/src/api/controllers/global/groups.ts
@@ -1,4 +1,4 @@
-import { csv } from "@budibase/backend-core"
+import { csv, users } from "@budibase/backend-core"
 import {
   BulkAddUsersToGroupRequest,
   BulkAddUsersToGroupResponse,
@@ -82,6 +82,13 @@ export async function updateGroupApps(
       "Must supply a list of objects, with appId and roleId to add or remove"
     )
   }
+
+  for (const { appId } of [...(toAdd || []), ...(toRemove || [])]) {
+    if (!users.isAdmin(ctx.user) && !users.isBuilder(ctx.user, appId)) {
+      ctx.throw(403, "Only app builders or admins can update app permissions.")
+    }
+  }
+
   ctx.body = await groups.updateGroupApps(groupId, {
     appsToAdd: toAdd,
     appsToRemove: toRemove,

--- a/packages/worker/src/api/controllers/global/groups.ts
+++ b/packages/worker/src/api/controllers/global/groups.ts
@@ -86,8 +86,7 @@ export async function updateGroupApps(
       )) ||
     (Array.isArray(toRemove) &&
       toRemove.some(
-        app =>
-          !app || typeof app.appId !== "string" || !app.appId.trim()
+        app => !app || typeof app.appId !== "string" || !app.appId.trim()
       ))
   ) {
     ctx.throw(

--- a/packages/worker/src/api/controllers/global/groups.ts
+++ b/packages/worker/src/api/controllers/global/groups.ts
@@ -74,13 +74,21 @@ export async function updateGroupApps(
   const toAdd = ctx.request.body.add,
     toRemove = ctx.request.body.remove
   if (
-    (toAdd && !Array.isArray(toAdd)) ||
-    (toRemove && !Array.isArray(toRemove)) ||
-    toAdd?.some(
-      app =>
-        !app || typeof app.appId !== "string" || typeof app.roleId !== "string"
-    ) ||
-    toRemove?.some(app => !app || typeof app.appId !== "string")
+    (toAdd != null && !Array.isArray(toAdd)) ||
+    (toRemove != null && !Array.isArray(toRemove)) ||
+    (Array.isArray(toAdd) &&
+      toAdd.some(
+        app =>
+          !app ||
+          typeof app.appId !== "string" ||
+          !app.appId.trim() ||
+          typeof app.roleId !== "string"
+      )) ||
+    (Array.isArray(toRemove) &&
+      toRemove.some(
+        app =>
+          !app || typeof app.appId !== "string" || !app.appId.trim()
+      ))
   ) {
     ctx.throw(
       400,

--- a/packages/worker/src/api/controllers/global/groups.ts
+++ b/packages/worker/src/api/controllers/global/groups.ts
@@ -73,27 +73,6 @@ export async function updateGroupApps(
   const groupId = ctx.params.groupId
   const toAdd = ctx.request.body.add,
     toRemove = ctx.request.body.remove
-  if (
-    (toAdd != null && !Array.isArray(toAdd)) ||
-    (toRemove != null && !Array.isArray(toRemove)) ||
-    (Array.isArray(toAdd) &&
-      toAdd.some(
-        app =>
-          !app ||
-          typeof app.appId !== "string" ||
-          !app.appId.trim() ||
-          typeof app.roleId !== "string"
-      )) ||
-    (Array.isArray(toRemove) &&
-      toRemove.some(
-        app => !app || typeof app.appId !== "string" || !app.appId.trim()
-      ))
-  ) {
-    ctx.throw(
-      400,
-      "Must supply a list of objects, with appId and roleId to add or remove"
-    )
-  }
 
   for (const { appId } of [...(toAdd || []), ...(toRemove || [])]) {
     if (!ctx.internal && !users.isAdminOrBuilder(ctx.user, appId)) {

--- a/packages/worker/src/api/routes/global/groups.ts
+++ b/packages/worker/src/api/routes/global/groups.ts
@@ -38,7 +38,7 @@ function buildGroupAppUpdateValidation() {
         .items(
           Joi.object({
             appId,
-            roleId: Joi.string().required(),
+            roleId: Joi.string().trim().required(),
           })
         )
         .optional(),

--- a/packages/worker/src/api/routes/global/groups.ts
+++ b/packages/worker/src/api/routes/global/groups.ts
@@ -29,6 +29,24 @@ function buildGroupSaveValidation() {
   )
 }
 
+function buildGroupAppUpdateValidation() {
+  const appId = Joi.string().trim().required()
+
+  return auth.joiValidator.body(
+    Joi.object({
+      add: Joi.array()
+        .items(
+          Joi.object({
+            appId,
+            roleId: Joi.string().required(),
+          })
+        )
+        .optional(),
+      remove: Joi.array().items(Joi.object({ appId })).optional(),
+    }).required()
+  )
+}
+
 router
   .post(
     "/api/global/groups",
@@ -87,6 +105,7 @@ router
     "/api/global/groups/:groupId/apps",
     auth.builderOrAdmin,
     proMiddleware.feature.requireFeature(Feature.USER_GROUPS),
+    buildGroupAppUpdateValidation(),
     controller.updateGroupApps
   )
 

--- a/packages/worker/src/api/routes/global/tests/groups.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/groups.spec.ts
@@ -454,6 +454,36 @@ describe("/api/global/groups", () => {
     })
   })
 
+  describe("update group app validation", () => {
+    let group: UserGroup
+
+    beforeAll(async () => {
+      const response = await config.api.groups.saveGroup(
+        structures.groups.UserGroup()
+      )
+      group = response.body as UserGroup
+    })
+
+    it("rejects malformed app entries", async () => {
+      await config.request
+        .post(`/api/global/groups/${group._id}/apps`)
+        .send({ add: [null] })
+        .set(config.defaultHeaders())
+        .expect(400)
+    })
+
+    it("allows internal requests", async () => {
+      await config.request
+        .post(`/api/global/groups/${group._id}/apps`)
+        .send({ add: [{ appId: "app_internal", roleId: "BASIC" }] })
+        .set({
+          ...config.internalAPIHeaders(),
+          ...config.tenantIdHeaders(),
+        })
+        .expect(200)
+    })
+  })
+
   describe("with basic role", () => {
     it("fetch should return forbidden", async () => {
       const user = await config.createUser({

--- a/packages/worker/src/api/routes/global/tests/groups.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/groups.spec.ts
@@ -464,10 +464,33 @@ describe("/api/global/groups", () => {
       group = response.body as UserGroup
     })
 
+    it.each([
+      { add: "" },
+      { add: 0 },
+      { add: false },
+      { remove: "" },
+      { remove: 0 },
+      { remove: false },
+    ])("rejects a malformed list value: %p", async body => {
+      await config.request
+        .post(`/api/global/groups/${group._id}/apps`)
+        .send(body)
+        .set(config.defaultHeaders())
+        .expect(400)
+    })
+
     it("rejects malformed app entries", async () => {
       await config.request
         .post(`/api/global/groups/${group._id}/apps`)
         .send({ add: [null] })
+        .set(config.defaultHeaders())
+        .expect(400)
+    })
+
+    it.each(["", "   "])("rejects a blank app ID: %p", async appId => {
+      await config.request
+        .post(`/api/global/groups/${group._id}/apps`)
+        .send({ add: [{ appId, roleId: "BASIC" }] })
         .set(config.defaultHeaders())
         .expect(400)
     })

--- a/packages/worker/src/api/routes/global/tests/groups.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/groups.spec.ts
@@ -495,10 +495,18 @@ describe("/api/global/groups", () => {
         .expect(400)
     })
 
-    it("allows internal requests", async () => {
+    it.each(["", "   "])("rejects a blank role ID: %p", async roleId => {
       await config.request
         .post(`/api/global/groups/${group._id}/apps`)
-        .send({ add: [{ appId: "app_internal", roleId: "BASIC" }] })
+        .send({ add: [{ appId: "app_test", roleId }] })
+        .set(config.defaultHeaders())
+        .expect(400)
+    })
+
+    it("normalizes internal app updates", async () => {
+      await config.request
+        .post(`/api/global/groups/${group._id}/apps`)
+        .send({ add: [{ appId: " app_internal ", roleId: " BASIC " }] })
         .set({
           ...config.internalAPIHeaders(),
           ...config.tenantIdHeaders(),

--- a/packages/worker/src/api/routes/global/tests/groups.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/groups.spec.ts
@@ -383,6 +383,14 @@ describe("/api/global/groups", () => {
       })
     })
 
+    it("can update group app roles", async () => {
+      await config.withUser(builder, async () => {
+        await config.api.groups.updateGroupApps(group._id!, {
+          add: [{ appId: "app_global_builder", roleId: "BASIC" }],
+        })
+      })
+    })
+
     it("update should return forbidden", async () => {
       await config.withUser(builder, async () => {
         await config.api.groups.updateGroupUsers(
@@ -390,6 +398,55 @@ describe("/api/global/groups", () => {
           {
             add: [builder._id!],
             remove: [],
+          },
+          { expect: 403 }
+        )
+      })
+    })
+  })
+
+  describe("with app builder role", () => {
+    const allowedAppId = "app_allowed"
+    const disallowedAppId = "app_disallowed"
+    let builder: User
+    let group: UserGroup
+
+    beforeAll(async () => {
+      builder = await config.createUser({
+        builder: {
+          global: false,
+          creator: true,
+          apps: [allowedAppId],
+        },
+        admin: { global: false },
+        roles: { [allowedAppId]: "CREATOR" },
+      })
+
+      const response = await config.api.groups.saveGroup(
+        structures.groups.UserGroup()
+      )
+      group = response.body as UserGroup
+    })
+
+    it("forbids updating roles for an app the user does not build", async () => {
+      await config.withUser(builder, async () => {
+        await config.api.groups.updateGroupApps(
+          group._id!,
+          {
+            add: [{ appId: disallowedAppId, roleId: "ADMIN" }],
+          },
+          { expect: 403 }
+        )
+      })
+    })
+
+    it("forbids a mixed update containing an unauthorized app", async () => {
+      await config.withUser(builder, async () => {
+        await config.api.groups.updateGroupApps(
+          group._id!,
+          {
+            add: [{ appId: allowedAppId, roleId: "BASIC" }],
+            remove: [{ appId: disallowedAppId }],
           },
           { expect: 403 }
         )


### PR DESCRIPTION
## Description
Implement role-based access control for updating group apps

## Addresses
- https://github.com/Budibase/vulns/issues/152

## Launchcontrol
Implement role-based access control for updating group apps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts updates to group app role assignments so only app builders or admins can change permissions, and rejects malformed app entries.

- Checks each app in the add/remove lists; non-admins and non-builders get a 403.
- Rejects mixed updates containing an unauthorized app instead of partially applying them.
- Rejects entries with invalid, missing, or blank `appId`/`roleId` with a 400, and trims accepted IDs.
- Internal requests bypass the permission check.
- Adds tests for allowed, disallowed, mixed, malformed, and internal request scenarios.

<sup>Written for commit b1edc65a11c30fd392c82b9ae152e7c968ff8dd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

