### PR TITLE
Require provider and agents for identity links

### DIFF
--- a/packages/builder/src/components/common/EscalationRecipients.svelte
+++ b/packages/builder/src/components/common/EscalationRecipients.svelte
@@ -127,7 +127,7 @@
   }
 
   const loadLinks = async (provider: string) => {
-    if (linkCache[provider] || loadingProviders.has(provider)) {
+    if (!agentId || linkCache[provider] || loadingProviders.has(provider)) {
       return
     }
     loadingProviders.add(provider)
@@ -135,7 +135,7 @@
     try {
       const links = await API.fetchChatIdentityLinks(
         provider as ChatIdentityLinkProvider,
-        agentId
+        requestedAgentId
       )
       // Drop a response that arrived after the bot changed.
       if (requestedAgentId !== agentId) {

--- a/packages/frontend-core/src/api/chatLinks.ts
+++ b/packages/frontend-core/src/api/chatLinks.ts
@@ -26,8 +26,8 @@ export interface PagedChannels<T> {
 
 export interface ChatLinksEndpoints {
   fetchChatIdentityLinks: (
-    provider?: ChatIdentityLinkProvider,
-    agentId?: string
+    provider: ChatIdentityLinkProvider,
+    agentId: string
   ) => Promise<ChatIdentityLink[]>
   fetchSlackChannels: (
     agentId: string,
@@ -43,12 +43,8 @@ export const buildChatLinksEndpoints = (
   API: BaseAPIClient
 ): ChatLinksEndpoints => ({
   fetchChatIdentityLinks: async (provider, agentId) => {
-    const params = new URLSearchParams({
-      ...(provider ? { provider } : {}),
-      ...(agentId ? { agentId } : {}),
-    }).toString()
-    const query = params ? `?${params}` : ""
-    return await API.get({ url: `/api/chat-links${query}` })
+    const query = new URLSearchParams({ provider, agentId }).toString()
+    return await API.get({ url: `/api/chat-links?${query}` })
   },
   fetchSlackChannels: async (agentId, cursor) => {
     const query = new URLSearchParams({

--- a/packages/server/src/api/controllers/ai/chatIdentityLinks.ts
+++ b/packages/server/src/api/controllers/ai/chatIdentityLinks.ts
@@ -331,20 +331,28 @@ const resolveAgentSlackTeamId = async (
   })
 }
 
-export async function listChatIdentityLinks(ctx: UserCtx) {
-  const provider = ctx.query.provider as ChatIdentityLinkProvider | undefined
-  const agentId = ctx.query.agentId as string | undefined
-  const links = await sdk.ai.chatIdentityLinks.listChatIdentityLinks(provider)
+const parseChatIdentityLinkProvider = (
+  value: string | string[] | undefined
+): ChatIdentityLinkProvider | undefined =>
+  Object.values(AgentChannelProvider).find(provider => provider === value)
 
-  if (!provider || !agentId) {
-    ctx.body = links
-    return
+export async function listChatIdentityLinks(ctx: UserCtx) {
+  const provider = parseChatIdentityLinkProvider(ctx.query.provider)
+  const agentId = ctx.query.agentId
+
+  if (!provider) {
+    ctx.throw(400, "Valid provider is required")
+  }
+  if (typeof agentId !== "string" || !agentId) {
+    ctx.throw(400, "agentId is required")
   }
 
   const appId = ctx.appId
   if (!appId) {
     ctx.throw(400, "appId is required")
   }
+
+  const links = await sdk.ai.chatIdentityLinks.listChatIdentityLinks(provider)
 
   // Scope the links to identities the agent's bot can actually reach
   if (provider === AgentChannelProvider.SLACK) {
@@ -367,7 +375,7 @@ export async function listChatIdentityLinks(ctx: UserCtx) {
     return
   }
 
-  ctx.body = links
+  provider satisfies never
 }
 
 export async function listSlackChannels(ctx: UserCtx) {

--- a/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
@@ -115,11 +115,18 @@ jest.mock("../../../../sdk/workspace/ai/rag", () => {
 })
 
 import sdk from "../../../../sdk"
-import { context, db, docIds, encryption } from "@budibase/backend-core"
+import {
+  context,
+  db,
+  docIds,
+  encryption,
+  features,
+} from "@budibase/backend-core"
 import { ChatCommands } from "@budibase/shared-core"
 import {
   AgentChannelProvider,
   DocumentType,
+  FeatureFlag,
   type Agent,
   type ChatConversation,
   type SlackAppConfig,
@@ -217,6 +224,98 @@ describe("agent slack integration provisioning", () => {
 
   afterAll(() => {
     config.end()
+  })
+
+  const withEscalation = async <T>(f: () => Promise<T>) =>
+    features.testutils.withFeatureFlags(
+      config.getTenantId(),
+      { [FeatureFlag.ESCALATION]: true },
+      f
+    )
+
+  describe("GET /api/chat-links", () => {
+    it.each([
+      ["without query parameters", {}],
+      ["without an agentId", { provider: AgentChannelProvider.SLACK }],
+      ["without a provider", { agentId: "agent-1" }],
+      [
+        "with an unsupported provider",
+        { provider: "discord", agentId: "agent-1" },
+      ],
+    ])("rejects requests %s", async (_description, query) => {
+      await withEscalation(async () => {
+        await config
+          .getRequest()!
+          .get("/api/chat-links")
+          .set(await config.defaultHeaders())
+          .query(query)
+          .expect(400)
+      })
+    })
+
+    it("returns only links in the agent's Slack workspace", async () => {
+      await withEscalation(async () => {
+        const agent = await config.api.agent.create({
+          name: "Slack Agent",
+          slackIntegration: {
+            botToken: "xoxb-token-1",
+            signingSecret: "slack-signing-secret",
+          },
+        })
+        const otherUser = await config.createUser()
+
+        await config.doInTenant(async () => {
+          await sdk.ai.chatIdentityLinks.upsertChatIdentityLink({
+            provider: AgentChannelProvider.SLACK,
+            externalUserId: "reachable-user",
+            teamId: "T123",
+            globalUserId: config.getUser()._id!,
+          })
+          await sdk.ai.chatIdentityLinks.upsertChatIdentityLink({
+            provider: AgentChannelProvider.SLACK,
+            externalUserId: "other-workspace-user",
+            teamId: "T_OTHER",
+            globalUserId: otherUser._id!,
+          })
+        })
+
+        const response = await config
+          .getRequest()!
+          .get("/api/chat-links")
+          .set(await config.defaultHeaders())
+          .query({ provider: AgentChannelProvider.SLACK, agentId: agent._id })
+          .expect(200)
+
+        expect(response.body).toEqual([
+          expect.objectContaining({ externalUserId: "reachable-user" }),
+        ])
+      })
+    })
+
+    it("returns no links for an unknown agent", async () => {
+      await withEscalation(async () => {
+        await config.doInTenant(async () => {
+          await sdk.ai.chatIdentityLinks.upsertChatIdentityLink({
+            provider: AgentChannelProvider.SLACK,
+            externalUserId: "linked-user",
+            teamId: "T123",
+            globalUserId: config.getUser()._id!,
+          })
+        })
+
+        const response = await config
+          .getRequest()!
+          .get("/api/chat-links")
+          .set(await config.defaultHeaders())
+          .query({
+            provider: AgentChannelProvider.SLACK,
+            agentId: "agent_from_another_workspace",
+          })
+          .expect(200)
+
+        expect(response.body).toEqual([])
+      })
+    })
   })
 
   it("provisions slack channel for an agent", async () => {

--- a/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
@@ -68,12 +68,13 @@ import os from "os"
 import path from "path"
 
 import extract from "extract-zip"
-import { context, docIds } from "@budibase/backend-core"
+import { context, docIds, features } from "@budibase/backend-core"
 import { generator } from "@budibase/backend-core/tests"
 import { ChatCommands } from "@budibase/shared-core"
 import {
   AgentChannelProvider,
   DocumentType,
+  FeatureFlag,
   type Agent,
   type ChatConversation,
   type WebhookChatCompleteResult,
@@ -121,6 +122,53 @@ describe("agent teams integration provisioning", () => {
 
   afterAll(() => {
     config.end()
+  })
+
+  const withEscalation = async <T>(f: () => Promise<T>) =>
+    features.testutils.withFeatureFlags(
+      config.getTenantId(),
+      { [FeatureFlag.ESCALATION]: true },
+      f
+    )
+
+  it("returns only chat links in the agent's Teams tenant", async () => {
+    await withEscalation(async () => {
+      const agent = await config.api.agent.create({
+        name: "Teams Agent",
+        MSTeamsIntegration: {
+          appId: TEAMS_APP_ID,
+          appPassword: "teams-app-password",
+          tenantId: "azure-tenant-id",
+        },
+      })
+      const otherUser = await config.createUser()
+
+      await config.doInTenant(async () => {
+        await sdk.ai.chatIdentityLinks.upsertChatIdentityLink({
+          provider: AgentChannelProvider.MSTEAMS,
+          externalUserId: "reachable-user",
+          providerTenantId: "azure-tenant-id",
+          globalUserId: config.getUser()._id!,
+        })
+        await sdk.ai.chatIdentityLinks.upsertChatIdentityLink({
+          provider: AgentChannelProvider.MSTEAMS,
+          externalUserId: "other-workspace-user",
+          providerTenantId: "other-tenant-id",
+          globalUserId: otherUser._id!,
+        })
+      })
+
+      const response = await config
+        .getRequest()!
+        .get("/api/chat-links")
+        .set(await config.defaultHeaders())
+        .query({ provider: AgentChannelProvider.MSTEAMS, agentId: agent._id })
+        .expect(200)
+
+      expect(response.body).toEqual([
+        expect.objectContaining({ externalUserId: "reachable-user" }),
+      ])
+    })
   })
 
   it("provisions teams channel for an agent", async () => {


### PR DESCRIPTION
## Description
Require provider and agents for identity links

## Addresses
- https://github.com/Budibase/vulns/issues/154

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires `provider` and `agentId` on `GET /api/chat-links`, replacing the previous behavior of returning all links when either was missing. Invalid requests now return 400, and valid responses are scoped to links reachable by the selected agent.

- Updates the builder and frontend client to pass both values and wait for an agent before loading links.
- Validates supported providers and tests Slack workspace, Teams tenant, and unknown-agent filtering.

<sup>Written for commit c82e67d2020b71fd2f682bcd82436de1d359c8df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

