### PR TITLE
Agents - support unlinking

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/DeploymentChannels/MicrosoftTeamsConfig.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/DeploymentChannels/MicrosoftTeamsConfig.svelte
@@ -25,6 +25,7 @@
 
   const MS_TEAMS_NEW_COMMAND = ChatCommands.NEW
   const MS_TEAMS_LINK_COMMAND = ChatCommands.LINK
+  const MS_TEAMS_UNLINK_COMMAND = ChatCommands.UNLINK
   let { agent }: { agent?: Agent } = $props()
 
   let draftAgentId: string | undefined = $state()
@@ -192,7 +193,8 @@
     </Body>
     <Body size="S">
       Use `{MS_TEAMS_LINK_COMMAND}` or `/{MS_TEAMS_LINK_COMMAND}` to link or
-      refresh your Budibase account.
+      refresh your Budibase account, and `{MS_TEAMS_UNLINK_COMMAND}` or `/{MS_TEAMS_UNLINK_COMMAND}`
+      to disconnect it.
     </Body>
 
     <CopyInput

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/DeploymentChannels/SlackConfig.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/DeploymentChannels/SlackConfig.svelte
@@ -24,6 +24,7 @@
   } from "./utils"
 
   const SLACK_LINK_COMMAND = ChatCommands.LINK
+  const SLACK_UNLINK_COMMAND = ChatCommands.UNLINK
   let { agent }: { agent?: Agent } = $props()
 
   let draftAgentId: string | undefined = $state()
@@ -213,7 +214,8 @@
       threads are used as the conversation boundary automatically.
     </Body>
     <Body size="S">
-      Use `/{SLACK_LINK_COMMAND}` to link or refresh your Budibase account.
+      Use `/{SLACK_LINK_COMMAND}` to link or refresh your Budibase account, and
+      `/{SLACK_UNLINK_COMMAND}` to disconnect it.
     </Body>
 
     <CopyInput

--- a/packages/server/src/api/controllers/webhook/chatHandler.ts
+++ b/packages/server/src/api/controllers/webhook/chatHandler.ts
@@ -497,6 +497,30 @@ export const handleChatMessage = async ({
       return
     }
 
+    if (command === ChatCommands.UNLINK) {
+      if (!existingLink) {
+        await reply(
+          `Your ${providerDisplayName(provider)} account is not linked. Run ${getLinkCommand(
+            provider
+          )} to connect it.`
+        )
+        return
+      }
+
+      await sdk.ai.chatIdentityLinks.deleteChatIdentityLink({
+        provider,
+        externalUserId: user.externalUserId,
+        teamId: channel.teamId,
+        providerTenantId: channel.tenantId,
+      })
+      await reply(
+        `Your ${providerDisplayName(provider)} account has been unlinked from Budibase. Run ${getLinkCommand(
+          provider
+        )} to connect it again.`
+      )
+      return
+    }
+
     const linkingRequired = requireUserLink !== false
     let chatUser: ContextUser
     let userId: string

--- a/packages/server/src/api/controllers/webhook/chatLogger.ts
+++ b/packages/server/src/api/controllers/webhook/chatLogger.ts
@@ -1,0 +1,42 @@
+import type { Logger } from "chat"
+import env from "../../../environment"
+
+type ChatLogLevel = "debug" | "info" | "warn" | "error"
+
+const formatMessage = (component: string, message: string) =>
+  `[${component}] ${message}`
+
+const noop = () => {}
+
+const isChatLoggerEnabled = () => !!env.CHAT_SDK_LOGGER
+
+export const createChatLogger = (component = "chat-sdk"): Logger => {
+  if (!isChatLoggerEnabled()) {
+    return {
+      child: childPrefix => createChatLogger(`${component}:${childPrefix}`),
+      debug: noop,
+      info: noop,
+      warn: noop,
+      error: noop,
+    }
+  }
+
+  const log =
+    (level: ChatLogLevel) =>
+    (message: string, ...args: unknown[]) => {
+      const formatted = formatMessage(component, message)
+      if (level === "info") {
+        console.log(formatted, ...args)
+        return
+      }
+      console[level](formatted, ...args)
+    }
+
+  return {
+    child: childPrefix => createChatLogger(`${component}:${childPrefix}`),
+    debug: log("debug"),
+    info: log("info"),
+    warn: log("warn"),
+    error: log("error"),
+  }
+}

--- a/packages/server/src/api/controllers/webhook/ms-teams.ts
+++ b/packages/server/src/api/controllers/webhook/ms-teams.ts
@@ -165,34 +165,33 @@ export const parseTeamsCommand = (
   }
   const lower = normalized.toLowerCase()
 
-  if (
-    lower === ChatCommands.NEW ||
-    lower === `/${ChatCommands.NEW}` ||
-    lower.startsWith(`/${ChatCommands.NEW} `)
-  ) {
-    return {
-      command: ChatCommands.NEW,
-      content: normalized.replace(
-        new RegExp(`^/?${ChatCommands.NEW}\\s*`, "i"),
-        ""
-      ),
+  const parseNamedCommand = (
+    command:
+      | typeof ChatCommands.NEW
+      | typeof ChatCommands.LINK
+      | typeof ChatCommands.UNLINK
+  ) => {
+    if (
+      lower === command ||
+      lower === `/${command}` ||
+      lower.startsWith(`/${command} `)
+    ) {
+      return {
+        command,
+        content: normalized.replace(new RegExp(`^/?${command}\\s*`, "i"), ""),
+      }
     }
-  }
-  if (
-    lower === ChatCommands.LINK ||
-    lower === `/${ChatCommands.LINK}` ||
-    lower.startsWith(`/${ChatCommands.LINK} `)
-  ) {
-    return {
-      command: ChatCommands.LINK,
-      content: normalized.replace(
-        new RegExp(`^/?${ChatCommands.LINK}\\s*`, "i"),
-        ""
-      ),
-    }
+    return undefined
   }
 
-  return { command: ChatCommands.ASK, content: normalized }
+  return (
+    parseNamedCommand(ChatCommands.NEW) ||
+    parseNamedCommand(ChatCommands.UNLINK) ||
+    parseNamedCommand(ChatCommands.LINK) || {
+      command: ChatCommands.ASK,
+      content: normalized,
+    }
+  )
 }
 
 export const splitTeamsMessage = (

--- a/packages/server/src/api/controllers/webhook/ms-teams.ts
+++ b/packages/server/src/api/controllers/webhook/ms-teams.ts
@@ -153,6 +153,24 @@ export const stripTeamsMentions = (
   return withoutMentionEntities.replace(/\s+/g, " ").trim()
 }
 
+const TEAMS_SLASH_COMMANDS = [
+  ChatCommands.UNLINK,
+  ChatCommands.NEW,
+  ChatCommands.LINK,
+] as const
+
+const parseTeamsSlashCommand = (text: string) => {
+  for (const command of TEAMS_SLASH_COMMANDS) {
+    if (!new RegExp(`^/?${command}(?:\\s|$)`, "i").test(text)) {
+      continue
+    }
+    return {
+      command,
+      content: text.replace(new RegExp(`^/?${command}\\s*`, "i"), ""),
+    }
+  }
+}
+
 export const parseTeamsCommand = (
   text?: string,
   entities?: MSTeamsActivity["entities"]
@@ -164,31 +182,9 @@ export const parseTeamsCommand = (
   if (!normalized) {
     return { command: ChatCommands.UNSUPPORTED, content: "" }
   }
-  const lower = normalized.toLowerCase()
-
-  const parseNamedCommand = (
-    command:
-      | typeof ChatCommands.NEW
-      | typeof ChatCommands.LINK
-      | typeof ChatCommands.UNLINK
-  ) => {
-    if (
-      lower === command ||
-      lower === `/${command}` ||
-      lower.startsWith(`/${command} `)
-    ) {
-      return {
-        command,
-        content: normalized.replace(new RegExp(`^/?${command}\\s*`, "i"), ""),
-      }
-    }
-    return undefined
-  }
 
   return (
-    parseNamedCommand(ChatCommands.NEW) ||
-    parseNamedCommand(ChatCommands.UNLINK) ||
-    parseNamedCommand(ChatCommands.LINK) || {
+    parseTeamsSlashCommand(normalized) || {
       command: ChatCommands.ASK,
       content: normalized,
     }

--- a/packages/server/src/api/controllers/webhook/ms-teams.ts
+++ b/packages/server/src/api/controllers/webhook/ms-teams.ts
@@ -161,7 +161,7 @@ const TEAMS_SLASH_COMMANDS = [
 
 const parseTeamsSlashCommand = (text: string) => {
   for (const command of TEAMS_SLASH_COMMANDS) {
-    if (!new RegExp(`^/?${command}(?:\\s|$)`, "i").test(text)) {
+    if (!new RegExp(`^(?:/${command}(?:\\s|$)|${command}$)`, "i").test(text)) {
       continue
     }
     return {

--- a/packages/server/src/api/controllers/webhook/ms-teams.ts
+++ b/packages/server/src/api/controllers/webhook/ms-teams.ts
@@ -29,6 +29,7 @@ import sdk from "../../../sdk"
 import { escalationProcessor } from "../../../escalation/processor"
 import { validateMSTeamsServiceUrl } from "../../../utilities/msTeams"
 import { handleChatMessage, NO_ASSISTANT_RESPONSE_MESSAGE } from "./chatHandler"
+import { createChatLogger } from "./chatLogger"
 import { getTeamsState } from "./chatState"
 import { postLinkPromptPrivately } from "./linkPrompt"
 import { runChatWebhook } from "./runChatWebhook"
@@ -487,7 +488,7 @@ export async function MSTeamsWebhook(
           }),
         },
         state: await getTeamsState(),
-        logger: "silent",
+        logger: createChatLogger(),
         fallbackStreamingPlaceholderText: TEAMS_PROCESSING_MESSAGE,
         streamingUpdateIntervalMs: TEAMS_STREAMING_UPDATE_INTERVAL_MS,
       })

--- a/packages/server/src/api/controllers/webhook/slack.ts
+++ b/packages/server/src/api/controllers/webhook/slack.ts
@@ -183,7 +183,10 @@ export const pickSlackConversation = ({
 
 type SlackReplyTarget = PrivatePostTarget
 
-type SlackCommand = typeof ChatCommands.ASK | typeof ChatCommands.LINK
+type SlackCommand =
+  | typeof ChatCommands.ASK
+  | typeof ChatCommands.LINK
+  | typeof ChatCommands.UNLINK
 
 type SlackInput = {
   target: SlackReplyTarget
@@ -374,8 +377,8 @@ export async function slackWebhook(
       })
       const handler = createSlackMessageHandler(handleSlackInput)
 
-      chat.onSlashCommand(
-        `/${ChatCommands.LINK}`,
+      const handleSlackSlashCommand =
+        (command: typeof ChatCommands.LINK | typeof ChatCommands.UNLINK) =>
         async (event: SlashCommandEvent) => {
           const raw = event.raw as Record<string, string | undefined>
           const channelId = raw.channel_id
@@ -387,7 +390,7 @@ export async function slackWebhook(
             target: event.channel as SlackReplyTarget,
             privateTarget: event.channel as SlackReplyTarget,
             author: event.user,
-            command: ChatCommands.LINK,
+            command,
             content: event.text,
             channelId,
             externalUserId: event.user.userId,
@@ -398,6 +401,14 @@ export async function slackWebhook(
             teamId: raw.team_id,
           })
         }
+
+      chat.onSlashCommand(
+        `/${ChatCommands.LINK}`,
+        handleSlackSlashCommand(ChatCommands.LINK)
+      )
+      chat.onSlashCommand(
+        `/${ChatCommands.UNLINK}`,
+        handleSlackSlashCommand(ChatCommands.UNLINK)
       )
       // TODO: Make these a strict set
       chat.onAction(async (event: ActionEvent) => {

--- a/packages/server/src/api/controllers/webhook/slack.ts
+++ b/packages/server/src/api/controllers/webhook/slack.ts
@@ -20,6 +20,7 @@ import {
 import sdk from "../../../sdk"
 import { escalationProcessor } from "../../../escalation/processor"
 import { handleChatMessage } from "./chatHandler"
+import { createChatLogger } from "./chatLogger"
 import { getSlackState } from "./chatState"
 import { postLinkPromptPrivately, PrivatePostTarget } from "./linkPrompt"
 import { runChatWebhook } from "./runChatWebhook"
@@ -356,16 +357,18 @@ export async function slackWebhook(
         throw new Error("Slack state adapter is required")
       }
 
+      const logger = createChatLogger()
       const chat = new Chat({
         userName: "Budibase",
         adapters: {
           slack: createSlackAdapter({
             botToken: integration.botToken,
             signingSecret: integration.signingSecret,
+            logger: logger.child("slack"),
           }),
         },
         state,
-        logger: "silent",
+        logger,
       })
 
       const handleSlackInput = createSlackInputHandler({

--- a/packages/server/src/api/controllers/webhook/tests/ms-teams.spec.ts
+++ b/packages/server/src/api/controllers/webhook/tests/ms-teams.spec.ts
@@ -90,6 +90,8 @@ describe("teams webhook helpers", () => {
     ],
     [ChatCommands.LINK, { command: ChatCommands.LINK, content: "" }],
     [`/${ChatCommands.LINK}`, { command: ChatCommands.LINK, content: "" }],
+    [ChatCommands.UNLINK, { command: ChatCommands.UNLINK, content: "" }],
+    [`/${ChatCommands.UNLINK}`, { command: ChatCommands.UNLINK, content: "" }],
     ["status", { command: ChatCommands.ASK, content: "status" }],
   ] as const)("parses command text %s", (text, expected) => {
     expect(parseTeamsCommand(text)).toEqual(expected)

--- a/packages/server/src/api/controllers/webhook/tests/ms-teams.spec.ts
+++ b/packages/server/src/api/controllers/webhook/tests/ms-teams.spec.ts
@@ -92,6 +92,11 @@ describe("teams webhook helpers", () => {
     [`/${ChatCommands.LINK}`, { command: ChatCommands.LINK, content: "" }],
     [ChatCommands.UNLINK, { command: ChatCommands.UNLINK, content: "" }],
     [`/${ChatCommands.UNLINK}`, { command: ChatCommands.UNLINK, content: "" }],
+    [
+      `/${ChatCommands.UNLINK} now`,
+      { command: ChatCommands.UNLINK, content: "now" },
+    ],
+    ["linking", { command: ChatCommands.ASK, content: "linking" }],
     ["status", { command: ChatCommands.ASK, content: "status" }],
   ] as const)("parses command text %s", (text, expected) => {
     expect(parseTeamsCommand(text)).toEqual(expected)

--- a/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
@@ -359,6 +359,13 @@ describe("agent slack integration provisioning", () => {
       usage_hint: `/${ChatCommands.LINK}`,
       should_escape: false,
     })
+    expect(manifest.features.slash_commands).toContainEqual({
+      command: `/${ChatCommands.UNLINK}`,
+      url: endpointUrl,
+      description: "Unlink your Slack user from your Budibase account.",
+      usage_hint: `/${ChatCommands.UNLINK}`,
+      should_escape: false,
+    })
     expect(manifest.settings.event_subscriptions.bot_events).toEqual([
       "app_mention",
       "message.im",
@@ -843,6 +850,53 @@ describe("agent slack integration provisioning", () => {
 
       expect(response.body.messages.join(" ")).toContain("already linked")
       expect(extractLinkUrl(response.body.messages)).toBeTruthy()
+    })
+
+    it(`unlinks an existing mapping when /${ChatCommands.UNLINK} is run`, async () => {
+      const { agent, linkExternalUser } = await setupProvisionedSlackAgent()
+      const path = `/api/webhooks/slack/${config.getProdWorkspaceId()}/${agent._id}`
+      await linkExternalUser("user-1")
+
+      const response = await postSlackMessage({
+        path,
+        body: {
+          command: `/${ChatCommands.UNLINK}`,
+          text: "",
+          channel_id: "D123",
+          user_id: "user-1",
+          user_name: "Slack User",
+          team_id: "T123",
+        },
+      })
+
+      expect(response.body.messages.join(" ")).toContain("unlinked")
+      await config.doInTenant(async () => {
+        const link = await sdk.ai.chatIdentityLinks.getChatIdentityLink({
+          provider: AgentChannelProvider.SLACK,
+          externalUserId: "user-1",
+          teamId: "T123",
+        })
+        expect(link).toBeUndefined()
+      })
+    })
+
+    it(`tells unlinked users they are not linked when /${ChatCommands.UNLINK} is run`, async () => {
+      const { agent } = await setupProvisionedSlackAgent()
+      const path = `/api/webhooks/slack/${config.getProdWorkspaceId()}/${agent._id}`
+
+      const response = await postSlackMessage({
+        path,
+        body: {
+          command: `/${ChatCommands.UNLINK}`,
+          text: "",
+          channel_id: "D123",
+          user_id: "user-1",
+          user_name: "Slack User",
+          team_id: "T123",
+        },
+      })
+
+      expect(response.body.messages.join(" ")).toContain("not linked")
     })
 
     it("stores Slack links separately for the same external user in different teams", async () => {

--- a/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
@@ -310,6 +310,10 @@ describe("agent teams integration provisioning", () => {
         title: ChatCommands.LINK,
         description: "Link your Microsoft Teams user to Budibase.",
       })
+      expect(manifest.bots[0].commandLists[0].commands).toContainEqual({
+        title: ChatCommands.UNLINK,
+        description: "Unlink your Microsoft Teams user from Budibase.",
+      })
       expect(manifest.validDomains).toHaveLength(1)
       expect(manifestText).not.toContain("teams-package-password")
 
@@ -553,6 +557,35 @@ describe("agent teams integration provisioning", () => {
       expect(mockedWebhookChat).not.toHaveBeenCalled()
       expect(response.body.messages.join(" ")).toContain(ChatCommands.LINK)
       expect(extractLinkUrl(response.body.messages)).toBeTruthy()
+    })
+
+    it(`unlinks an existing mapping when ${ChatCommands.UNLINK} is sent`, async () => {
+      const { agent, linkExternalUser } = await setupProvisionedTeamsAgent()
+      const path = `/api/webhooks/ms-teams/${config.getProdWorkspaceId()}/${agent._id}`
+      await linkExternalUser("user-1")
+
+      const response = await postTeamsMessage({
+        path,
+        body: {
+          id: "activity-unlink-1",
+          type: "message",
+          text: ChatCommands.UNLINK,
+          from: { id: "user-1", name: "Teams User" },
+          conversation: { id: "conversation-1", conversationType: "personal" },
+          channelData: { tenant: { id: "tenant-1" } },
+        },
+      })
+
+      expect(mockedWebhookChat).not.toHaveBeenCalled()
+      expect(response.body.messages.join(" ")).toContain("unlinked")
+      await config.doInTenant(async () => {
+        const link = await sdk.ai.chatIdentityLinks.getChatIdentityLink({
+          provider: AgentChannelProvider.MSTEAMS,
+          externalUserId: "user-1",
+          providerTenantId: "tenant-1",
+        })
+        expect(link).toBeUndefined()
+      })
     })
 
     it("allows optional-link unlinked users and reuses their synthetic conversation", async () => {

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -93,6 +93,7 @@ const environment = {
   APPS_SERVICE: process.env.APPS_SERVICE,
   SALT_ROUNDS: process.env.SALT_ROUNDS,
   LOGGER: process.env.LOGGER,
+  CHAT_SDK_LOGGER: process.env.CHAT_SDK_LOGGER,
   ACCOUNT_PORTAL_URL: process.env.ACCOUNT_PORTAL_URL,
   INTERNAL_ACCOUNT_PORTAL_URL:
     process.env.INTERNAL_ACCOUNT_PORTAL_URL || process.env.ACCOUNT_PORTAL_URL,

--- a/packages/server/src/sdk/workspace/ai/chatIdentityLinks.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/chatIdentityLinks.spec.ts
@@ -41,4 +41,30 @@ describe("chatIdentityLinks", () => {
       expect(link?.globalUserId).toEqual(config.getUser()._id)
     })
   })
+
+  it("deletes a stored identity link", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      await sdk.ai.chatIdentityLinks.upsertChatIdentityLink({
+        provider: AgentChannelProvider.SLACK,
+        externalUserId: "external-user-1",
+        teamId: "team-1",
+        globalUserId: config.getUser()._id!,
+        linkedBy: config.getUser()._id!,
+      })
+
+      const deleted = await sdk.ai.chatIdentityLinks.deleteChatIdentityLink({
+        provider: AgentChannelProvider.SLACK,
+        externalUserId: "external-user-1",
+        teamId: "team-1",
+      })
+      const remaining = await sdk.ai.chatIdentityLinks.getChatIdentityLink({
+        provider: AgentChannelProvider.SLACK,
+        externalUserId: "external-user-1",
+        teamId: "team-1",
+      })
+
+      expect(deleted).toEqual(true)
+      expect(remaining).toBeUndefined()
+    })
+  })
 })

--- a/packages/server/src/sdk/workspace/ai/chatIdentityLinks.ts
+++ b/packages/server/src/sdk/workspace/ai/chatIdentityLinks.ts
@@ -219,6 +219,27 @@ export const getChatIdentityLink = async ({
   return await db.tryGet<ChatIdentityLink>(linkId)
 }
 
+export const deleteChatIdentityLink = async ({
+  provider,
+  externalUserId,
+  teamId,
+  providerTenantId,
+}: ChatIdentityLinkLookupInput): Promise<boolean> => {
+  const existing = await getChatIdentityLink({
+    provider,
+    externalUserId,
+    teamId,
+    providerTenantId,
+  })
+  if (!existing?._id || !existing._rev) {
+    return false
+  }
+
+  const db = tenancy.getGlobalDB()
+  await db.remove(existing._id, existing._rev)
+  return true
+}
+
 export const upsertChatIdentityLink = async ({
   provider,
   externalUserId,

--- a/packages/server/src/sdk/workspace/ai/deployments/ms-teams.ts
+++ b/packages/server/src/sdk/workspace/ai/deployments/ms-teams.ts
@@ -129,6 +129,10 @@ export const buildMSTeamsManifest = ({
                 title: ChatCommands.LINK,
                 description: "Link your Microsoft Teams user to Budibase.",
               },
+              {
+                title: ChatCommands.UNLINK,
+                description: "Unlink your Microsoft Teams user from Budibase.",
+              },
             ],
           },
         ],

--- a/packages/server/src/sdk/workspace/ai/deployments/slack.ts
+++ b/packages/server/src/sdk/workspace/ai/deployments/slack.ts
@@ -107,6 +107,13 @@ export const buildSlackManifest = ({
           usage_hint: `/${ChatCommands.LINK}`,
           should_escape: false,
         },
+        {
+          command: `/${ChatCommands.UNLINK}`,
+          url: messagingEndpointUrl,
+          description: "Unlink your Slack user from your Budibase account.",
+          usage_hint: `/${ChatCommands.UNLINK}`,
+          should_escape: false,
+        },
       ],
     },
     oauth_config: {

--- a/packages/shared-core/src/constants/chat.ts
+++ b/packages/shared-core/src/constants/chat.ts
@@ -2,6 +2,7 @@ export const ChatCommands = {
   ASK: "ask",
   NEW: "new",
   LINK: "link",
+  UNLINK: "unlink",
   UNSUPPORTED: "unsupported",
 } as const
 
@@ -11,11 +12,13 @@ export type SupportedChatCommand =
   | typeof ChatCommands.ASK
   | typeof ChatCommands.NEW
   | typeof ChatCommands.LINK
+  | typeof ChatCommands.UNLINK
   | typeof ChatCommands.UNSUPPORTED
 
 export const SupportedChatCommands = [
   ChatCommands.ASK,
   ChatCommands.NEW,
   ChatCommands.LINK,
+  ChatCommands.UNLINK,
   ChatCommands.UNSUPPORTED,
 ] as const


### PR DESCRIPTION
## Description
Support unlinking users for slack and teams

## Launchcontrol
Support unlinking users for slack and teams via /unlink

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `/unlink` command so Slack and Microsoft Teams users can disconnect their Budibase identity. Previously linking was one-way — users could link or refresh a mapping but never remove it, so a mis-bound account stayed stuck.

- Handles `/unlink` in the shared chat handler with replies for both linked and unlinked users, and deletes the stored mapping via a new `deleteChatIdentityLink` SDK function.
- Registers `/unlink` in the Slack slash command and Teams bot command manifests, and updates the builder channel config copy to document it.
- Adds an optional chat SDK logger toggled by the `CHAT_SDK_LOGGER` env var to help debug Slack and Teams webhook issues.

<sup>Written for commit 5998cd550abf9dd35da0300f92d977398e647043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

