### PR TITLE
fix(sql): allow JSON column creation for Postgres datasources (#19512)

### DIFF
--- a/packages/backend-core/src/sql/sqlTable.ts
+++ b/packages/backend-core/src/sql/sqlTable.ts
@@ -25,6 +25,7 @@ function generateSchema(
   schema: CreateTableBuilder,
   table: Table,
   tables: Record<string, Table>,
+  sqlClient: SqlClient,
   oldTable?: Table,
   renamed?: RenameColumn
 ) {
@@ -154,8 +155,17 @@ function generateSchema(
       case FieldType.AI:
         // This is allowed, but nothing to do on the external datasource
         break
-      case FieldType.AUTO:
       case FieldType.JSON:
+        // native JSON columns are only proven safe for Postgres here - other
+        // dialects go through knex's generic .json() emulation (e.g. a
+        // NVARCHAR+CHECK column in SQL Server) which hasn't been verified
+        // against this codebase's expectations
+        if (sqlClient === SqlClient.POSTGRES) {
+          schema.json(key)
+          break
+        }
+        throw new Error(`${column.type} is not a valid SQL type`)
+      case FieldType.AUTO:
       case FieldType.INTERNAL:
         throw new Error(`${column.type} is not a valid SQL type`)
 
@@ -192,10 +202,11 @@ function generateSchema(
 function buildCreateTable(
   knex: SchemaBuilder,
   table: Table,
-  tables: Record<string, Table>
+  tables: Record<string, Table>,
+  sqlClient: SqlClient
 ): SchemaBuilder {
   return knex.createTable(table.name, schema => {
-    generateSchema(schema, table, tables)
+    generateSchema(schema, table, tables, sqlClient)
   })
 }
 
@@ -203,11 +214,12 @@ function buildUpdateTable(
   knex: SchemaBuilder,
   table: Table,
   tables: Record<string, Table>,
+  sqlClient: SqlClient,
   oldTable?: Table,
   renamed?: RenameColumn
 ): SchemaBuilder {
   return knex.alterTable(table.name, schema => {
-    generateSchema(schema, table, tables, oldTable, renamed)
+    generateSchema(schema, table, tables, sqlClient, oldTable, renamed)
   })
 }
 
@@ -262,7 +274,12 @@ class SqlTableQueryBuilder {
 
     switch (this._operation(json)) {
       case Operation.CREATE_TABLE:
-        query = buildCreateTable(client, json.table, json.tables)
+        query = buildCreateTable(
+          client,
+          json.table,
+          json.tables,
+          this.sqlClient
+        )
         break
       case Operation.UPDATE_TABLE:
         if (!json.table) {
@@ -284,6 +301,7 @@ class SqlTableQueryBuilder {
           client,
           json.table,
           json.tables,
+          this.sqlClient,
           json.meta?.oldTable,
           json.meta?.renamed
         )

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -624,6 +624,10 @@
         FIELDS.ATTACHMENT_SINGLE,
         FIELDS.ATTACHMENTS,
         FIELDS.SIGNATURE_SINGLE,
+        // only Postgres has a proven-safe native JSON column path in the
+        // backend DDL builder (sqlTable.ts) - other SQL dialects still reject
+        // it there
+        ...(datasource?.source === SourceName.POSTGRES ? [FIELDS.JSON] : []),
       ]
     } else if (isExternalTable && isGoogleSheet) {
       // google-sheets supports minimum set (no attachments or user references)


### PR DESCRIPTION
The builder's Create Column modal excluded FIELDS.JSON for every SQL
external datasource, even though reading an existing json/jsonb column
already worked fine (a separate introspection code path). Turns out
the exclusion was intentional: sqlTable.ts's DDL generator threw
"json is not a valid SQL type" for any FieldType.JSON column, for every
SQL dialect. Enabling the type in the UI alone would have just traded
a disabled dropdown option for a 500 on save.

Fix, scoped deliberately to Postgres only:
- sqlTable.ts: thread sqlClient through generateSchema/buildCreateTable/
  buildUpdateTable, and call schema.json(key) - the same knex builder
  already used for FieldType.ARRAY/ATTACHMENTS on external Postgres
  tables - when sqlClient is SqlClient.POSTGRES. Every other dialect
  keeps throwing exactly as before.
- CreateEditColumn.svelte: only add FIELDS.JSON to the allowed list for
  SQL external tables when the datasource is Postgres.

MySQL/MSSQL/Oracle are intentionally left out: knex's .json() emulates
the column differently per dialect (e.g. NVARCHAR+CHECK on SQL
Server), and that hasn't been verified against this codebase's
expectations, so this stays out of scope rather than guessing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables creating JSON columns on Postgres external SQL datasources from the builder. Previously the JSON type was disabled for all SQL datasources because the DDL generator threw "json is not a valid SQL type"; now Postgres emits a native `json` column and other dialects keep throwing as before.

- Passes the SQL client type through the DDL builder so Postgres can call `schema.json()`.
- Lists JSON in the Create Column modal only for Postgres datasources.
- MySQL, MSSQL, and Oracle stay out of scope since knex emulates `.json()` differently per dialect and that's unverified.

<sup>Written for commit 8ea3f667040f85c3aeddf03c0157e8e4a4039856. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

