### PR TITLE
Don't automatically subscribe to slack threads

### DIFF
--- a/packages/server/__mocks__/chat.ts
+++ b/packages/server/__mocks__/chat.ts
@@ -29,8 +29,6 @@ const mockWebhookState: Record<MockProvider, MockPostEphemeralResult> = {
   teams: defaultPostEphemeralResult(),
 }
 const mockChatOptions: ChatOptions[] = []
-const subscribedThreads = new Set<string>()
-let subscribeError: Error | undefined
 
 const toMessageText = (value: unknown) =>
   typeof value === "string" ? value : JSON.stringify(value)
@@ -167,12 +165,6 @@ export const resetMockChatState = () => {
   mockWebhookState.slack = defaultPostEphemeralResult()
   mockWebhookState.teams = defaultPostEphemeralResult()
   mockChatOptions.length = 0
-  subscribedThreads.clear()
-  subscribeError = undefined
-}
-
-export const setMockSubscribeError = (error?: Error) => {
-  subscribeError = error
 }
 
 export const setMockPostEphemeralResult = (
@@ -330,12 +322,6 @@ export class Chat {
           id: `slack:${channelId}:${threadTs}`,
           channelId,
           ...createMessageCollector("slack", messages),
-          subscribe: async () => {
-            if (subscribeError) {
-              throw subscribeError
-            }
-            subscribedThreads.add(`slack:${channelId}:${threadTs}`)
-          },
           channel,
         }
         const isMention = isSlackMentionMessage(event)
@@ -355,11 +341,6 @@ export class Chat {
         } else {
           if (isMention) {
             await invokeHandlers(this.mentionHandlers, thread, message)
-          } else if (
-            event.thread_ts &&
-            subscribedThreads.has(`slack:${channelId}:${threadTs}`)
-          ) {
-            await invokeHandlers(this.subscribedHandlers, thread, message)
           }
           await invokeHandlers(this.newMessageHandlers, thread, message)
         }

--- a/packages/server/src/api/controllers/webhook/slack.ts
+++ b/packages/server/src/api/controllers/webhook/slack.ts
@@ -196,7 +196,6 @@ type SlackInput = {
   isDirectMessage: boolean
   teamId?: string
   threadId?: string
-  subscribe?: () => Promise<void>
 }
 
 const createSlackInputHandler = ({
@@ -223,7 +222,6 @@ const createSlackInputHandler = ({
     isDirectMessage,
     teamId,
     threadId,
-    subscribe,
   }: SlackInput) => {
     const displayName = author.fullName || author.userName || externalUserId
 
@@ -244,7 +242,6 @@ const createSlackInputHandler = ({
     }
 
     try {
-      await subscribe?.()
       await handleChatMessage({
         reply: async text => {
           await target.post(text)
@@ -320,7 +317,6 @@ const createSlackMessageHandler = (
       externalUserId: message.author.userId,
       isDirectMessage: isSlackDirectMessage(raw),
       teamId: raw?.team_id || raw?.team,
-      subscribe: () => thread.subscribe(),
     })
   }
 }
@@ -472,7 +468,6 @@ export async function slackWebhook(
       })
 
       chat.onNewMention(handler)
-      chat.onSubscribedMessage(handler)
       chat.onNewMessage(/./, async (thread, message) => {
         const raw = message.raw as SlackEvent | undefined
         if (!isSlackDirectMessage(raw) || message.isMention) {

--- a/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
@@ -11,7 +11,6 @@ interface ChatMockModule {
     provider: "slack" | "teams",
     result: { usedFallback: boolean }
   ) => void
-  setMockSubscribeError: (error?: Error) => void
 }
 
 interface SlackManifest {
@@ -129,11 +128,9 @@ import { setupDefaultCompletionsAIConfig } from "../../../../tests/utilities/aiC
 import { webhookChat } from "../../../controllers/ai/chatConversations"
 
 const SECRET_ENCODING_PREFIX = "bbai_enc::"
-const {
-  resetMockChatState,
-  setMockPostEphemeralResult,
-  setMockSubscribeError,
-} = jest.requireActual("chat") as ChatMockModule
+const { resetMockChatState, setMockPostEphemeralResult } = jest.requireActual(
+  "chat"
+) as ChatMockModule
 
 const mockedWebhookChat = webhookChat as jest.MockedFunction<typeof webhookChat>
 const mockedGetFileUrlForAgent = jest.mocked(sdk.ai.rag.getFileUrlForAgent)
@@ -1071,33 +1068,6 @@ describe("agent slack integration provisioning", () => {
       expect(extractLinkUrl(response.body.messages)).toBeTruthy()
     })
 
-    it("posts a fallback error when thread subscribe fails", async () => {
-      const { agent } = await setupProvisionedSlackAgent()
-      const path = `/api/webhooks/slack/${config.getProdWorkspaceId()}/${agent._id}`
-      setMockSubscribeError(new Error("missing conversations:write"))
-
-      const response = await postSlackMessage({
-        path,
-        body: {
-          type: "event_callback",
-          event: {
-            type: "message",
-            text: "hello slack",
-            user: "user-1",
-            channel: "D123",
-            channel_type: "im",
-            ts: "1700000000.100",
-            team_id: "T123",
-          },
-        },
-      })
-
-      expect(mockedWebhookChat).not.toHaveBeenCalled()
-      expect(response.body.messages).toContain(
-        "Sorry, something went wrong while processing your request."
-      )
-    })
-
     it("allows optional-link unlinked users and reuses their synthetic conversation", async () => {
       const { agent } = await setupProvisionedSlackAgent({
         requireUserLink: false,
@@ -1388,10 +1358,11 @@ describe("agent slack integration provisioning", () => {
       expect(mockedGetFileUrlForAgent).not.toHaveBeenCalled()
     })
 
-    it("handles replies in a channel thread without another mention", async () => {
+    it("requires every participant to mention the agent in a channel thread", async () => {
       const { agent, linkExternalUser } = await setupProvisionedSlackAgent()
       const path = `/api/webhooks/slack/${config.getProdWorkspaceId()}/${agent._id}`
       await linkExternalUser("user-1")
+      await linkExternalUser("user-2")
 
       await postSlackMessage({
         path,
@@ -1409,7 +1380,7 @@ describe("agent slack integration provisioning", () => {
         },
       })
 
-      const response = await postSlackMessage({
+      const untaggedFollowUp = await postSlackMessage({
         path,
         body: {
           type: "event_callback",
@@ -1426,11 +1397,75 @@ describe("agent slack integration provisioning", () => {
         },
       })
 
-      expect(response.body.messages).toContain("Mock assistant response")
-      expect(mockedWebhookChat).toHaveBeenCalledTimes(2)
+      const untaggedOtherParticipant = await postSlackMessage({
+        path,
+        body: {
+          type: "event_callback",
+          event: {
+            type: "message",
+            text: "unrelated discussion",
+            user: "user-2",
+            channel: "C123",
+            channel_type: "channel",
+            ts: "1700000000.300",
+            thread_ts: "1700000000.100",
+            team_id: "T123",
+          },
+        },
+      })
+
+      const taggedFollowUp = await postSlackMessage({
+        path,
+        body: {
+          type: "event_callback",
+          event: {
+            type: "message",
+            text: "<@U123> tagged follow-up question",
+            user: "user-1",
+            channel: "C123",
+            channel_type: "channel",
+            ts: "1700000000.400",
+            thread_ts: "1700000000.100",
+            team_id: "T123",
+          },
+        },
+      })
+
+      const taggedOtherParticipant = await postSlackMessage({
+        path,
+        body: {
+          type: "event_callback",
+          event: {
+            type: "message",
+            text: "<@U123> separate question",
+            user: "user-2",
+            channel: "C123",
+            channel_type: "channel",
+            ts: "1700000000.500",
+            thread_ts: "1700000000.100",
+            team_id: "T123",
+          },
+        },
+      })
+
+      expect(untaggedFollowUp.body.messages).toEqual([])
+      expect(untaggedOtherParticipant.body.messages).toEqual([])
+      expect(taggedFollowUp.body.messages).toContain("Mock assistant response")
+      expect(taggedOtherParticipant.body.messages).toContain(
+        "Mock assistant response"
+      )
+      expect(mockedWebhookChat).toHaveBeenCalledTimes(3)
+
       const conversations = await fetchConversations()
-      expect(conversations).toHaveLength(1)
-      expect(conversations[0]?.messages).toHaveLength(4)
+      expect(conversations).toHaveLength(2)
+      const user1Conversation = conversations.find(
+        conversation => conversation.channel?.externalUserId === "user-1"
+      )
+      const user2Conversation = conversations.find(
+        conversation => conversation.channel?.externalUserId === "user-2"
+      )
+      expect(user1Conversation?.messages).toHaveLength(4)
+      expect(user2Conversation?.messages).toHaveLength(2)
     })
 
     it("does not append RAG source links when downloads are disabled", async () => {


### PR DESCRIPTION
## Description
Reverting https://github.com/Budibase/budibase/pull/19577

The idea of this was being able to get the agent to automatically answer threads where they are anwsering in
<img width="433" height="367" alt="image" src="https://github.com/user-attachments/assets/ec04c061-344e-4369-b587-6f0acbdfeb72" />


The issue is that the agent keeps answering all messages, even if they are not related to them
<img width="420" height="574" alt="image" src="https://github.com/user-attachments/assets/a7a9df3b-35b5-41b0-b229-8771b29d4a47" />


A possible solution would be the agent figuring out if it should or not answer that message, but it requires more thinking about use cases. For now, we are just reverting it. It will only reply if tagged (as before)

<img width="437" height="394" alt="image" src="https://github.com/user-attachments/assets/6eaa95cc-b8c5-47c6-ae9f-8a2ec07b39c1" />



## Launchcontrol
Stop subscribing automatically to all threads

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slack agents no longer automatically subscribe to Slack threads after replying. Previously, this made them answer unrelated follow-ups; channel-thread replies now require a mention, while direct-message handling is unchanged.

**Bug Fixes**

- Integration coverage checks replies from multiple linked participants and keeps their conversations separate.
- Removes thread-subscription callbacks, mock state, and subscription failure handling.

<sup>Written for commit 675952c9e8a1ce00a0a09bb922c574cfb1972a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

