### PR TITLE
Fix cloud backup restores missing workspace context

### DIFF
--- a/packages/pro/src/sdk/backups/processing.ts
+++ b/packages/pro/src/sdk/backups/processing.ts
@@ -1,4 +1,5 @@
 import {
+  context,
   db,
   db as dbCore,
   Duration,
@@ -309,8 +310,8 @@ async function importProcessor(
     nameForBackup = data.import.nameForBackup,
     createdBy = data.import.createdBy
   const tenantId = tenancy.getTenantIDFromWorkspaceID(appId) as string
-  return tenancy.doInTenant(tenantId, async () => {
-    const devWorkspaceId = dbCore.getDevWorkspaceID(appId)
+  const devWorkspaceId = dbCore.getDevWorkspaceID(appId)
+  return context.doInWorkspaceContext(devWorkspaceId, async () => {
     const tempWorkspaceId = `${devWorkspaceId}_temp_${Date.now()}`
 
     const { rev } = await backups.updateRestoreStatus(

--- a/packages/pro/src/sdk/backups/tests/index.spec.ts
+++ b/packages/pro/src/sdk/backups/tests/index.spec.ts
@@ -268,6 +268,21 @@ describe("backups", () => {
     })
   })
 
+  it("should process restores in the workspace context", async () => {
+    await config.doInTenant(async () => {
+      let restoreWorkspaceId: string | undefined
+      importWorkspaceFn.mockImplementation(() => {
+        restoreWorkspaceId = context.getCurrentContext()?.appId
+      })
+
+      await createRestore()
+
+      expect(restoreWorkspaceId).toEqual(
+        db.getDevWorkspaceID(config.workspaceId)
+      )
+    })
+  })
+
   it("should overwrite existing target object store files during restore", async () => {
     await config.doInTenant(async () => {
       const backup = await createBackup()


### PR DESCRIPTION
## Description
Cloud backup restores run asynchronously with tenant context but no workspace context. The import path performs LiteLLM reconciliation, which requires a workspace database and fails with `Unable to retrieve workspace DB - no workspace ID.`.

Run the restore workflow in the target development workspace context. This supplies both the workspace and tenant IDs to downstream SDK calls.

The regression test inspects the actual async context inside the queued importer. It fails against the previous implementation with an undefined workspace ID and passes with this change.

----------------------------------------------------------------------------------

The stack trace:

- importBackup
- triggerWorkspaceRestore -> adds the job to the queue

- importProcessor
- importWorkspaceFn (importApp) : **this is where the fix was needed - do this in a workspace context, not a tenant context**
- reconcileLiteLLMModels (introduced: https://github.com/Budibase/budibase/commit/6607c2f2cfcc80e158eab92c927d46f20e4aba60#diff-033b9a47ad2fd4b3363ae6908cd3edd980890972623b43468a56ca01ebba6713)

```ts
export async function reconcileLiteLLMModels() {
  const workspaceId = context.getWorkspaceId()
  ...
```

So in the tenant context, `getWorkspaceId()` was failing, but now in the workspace context it will correctly get this ID.


## Addresses
- https://github.com/Budibase/ideas/issues/9
- https://github.com/Budibase/budibase/issues/19471

## Launchcontrol
Fixes cloud backup restores failing because background restore jobs did not know which workspace they were restoring.
