### PR TITLE
Fix cloud backup restores missing workspace context

### DIFF
--- a/packages/pro/src/sdk/backups/processing.ts
+++ b/packages/pro/src/sdk/backups/processing.ts
@@ -1,4 +1,5 @@
 import {
+  context,
   db,
   db as dbCore,
   Duration,
@@ -309,8 +310,8 @@ async function importProcessor(
     nameForBackup = data.import.nameForBackup,
     createdBy = data.import.createdBy
   const tenantId = tenancy.getTenantIDFromWorkspaceID(appId) as string
-  return tenancy.doInTenant(tenantId, async () => {
-    const devWorkspaceId = dbCore.getDevWorkspaceID(appId)
+  const devWorkspaceId = dbCore.getDevWorkspaceID(appId)
+  return context.doInWorkspaceContext(devWorkspaceId, async () => {
     const tempWorkspaceId = `${devWorkspaceId}_temp_${Date.now()}`
 
     const { rev } = await backups.updateRestoreStatus(

--- a/packages/pro/src/sdk/backups/tests/index.spec.ts
+++ b/packages/pro/src/sdk/backups/tests/index.spec.ts
@@ -268,6 +268,21 @@ describe("backups", () => {
     })
   })
 
+  it("should process restores in the workspace context", async () => {
+    await config.doInTenant(async () => {
+      let restoreWorkspaceId: string | undefined
+      importWorkspaceFn.mockImplementation(() => {
+        restoreWorkspaceId = context.getCurrentContext()?.appId
+      })
+
+      await createRestore()
+
+      expect(restoreWorkspaceId).toEqual(
+        db.getDevWorkspaceID(config.workspaceId)
+      )
+    })
+  })
+
   it("should overwrite existing target object store files during restore", async () => {
     await config.doInTenant(async () => {
       const backup = await createBackup()


### PR DESCRIPTION
## Description

Backports the cloud backup restore workspace-context fix to the `3.44.1` hotfix branch.

Cloud backup restores run asynchronously with tenant context but no workspace context. The import path performs LiteLLM reconciliation, which requires a workspace database and fails with `Unable to retrieve workspace DB - no workspace ID.`.

This change runs the restore importer in the target development workspace context. The regression test verifies the workspace context inside the queued importer.

Validation: `yarn test src/sdk/backups/tests/index.spec.ts --runInBand` from `packages/pro` (29 tests passed).

## Addresses

- https://github.com/Budibase/ideas/issues/9
- https://github.com/Budibase/budibase/issues/19471

## Launchcontrol

Fixes cloud backup restores failing because background restore jobs did not know which workspace they were restoring.
