### PR TITLE
[19601] Reconcile LiteLLM after backup cutover

### DIFF
--- a/packages/pro/src/sdk/backups/processing.ts
+++ b/packages/pro/src/sdk/backups/processing.ts
@@ -367,11 +367,18 @@ async function importProcessor(
         logging.logAlert("LiteLLM reconciliation failed after app restore", err)
         status = BackupStatus.FAILED
         const errorMessage = err instanceof Error ? err.message : String(err)
-        await backups.trackBackupError(
-          appId,
-          backupId,
-          `Backup restore LiteLLM reconciliation failed: ${errorMessage}`
-        )
+        try {
+          await backups.trackBackupError(
+            appId,
+            backupId,
+            `Backup restore LiteLLM reconciliation failed: ${errorMessage}`
+          )
+        } catch (trackingErr) {
+          logging.logAlert(
+            "Failed to track LiteLLM reconciliation error after app restore",
+            trackingErr
+          )
+        }
       }
       try {
         await cleanupPromotedWorkspaceFiles(

--- a/packages/pro/src/sdk/backups/processing.ts
+++ b/packages/pro/src/sdk/backups/processing.ts
@@ -345,6 +345,7 @@ async function importProcessor(
         {
           objectStoreAppId: tempWorkspaceId,
           preserveLiteLLMConfig: true,
+          reconcileLiteLLMModels: false,
         }
       )
       // Copy files before database cutover. We only add/overwrite desired keys
@@ -360,6 +361,21 @@ async function importProcessor(
         source: tempWorkspaceId,
         target: devWorkspaceId,
       }).replicate()
+      try {
+        await opts.reconcileLiteLLMModels()
+      } catch (err) {
+        logging.logAlert(
+          "LiteLLM reconciliation failed after app restore",
+          err
+        )
+        status = BackupStatus.FAILED
+        const errorMessage = err instanceof Error ? err.message : String(err)
+        await backups.trackBackupError(
+          appId,
+          backupId,
+          `Backup restore LiteLLM reconciliation failed: ${errorMessage}`
+        )
+      }
       try {
         await cleanupPromotedWorkspaceFiles(
           promotedWorkspaceFiles.sourceFileKeys,

--- a/packages/pro/src/sdk/backups/processing.ts
+++ b/packages/pro/src/sdk/backups/processing.ts
@@ -364,10 +364,7 @@ async function importProcessor(
       try {
         await opts.reconcileLiteLLMModels()
       } catch (err) {
-        logging.logAlert(
-          "LiteLLM reconciliation failed after app restore",
-          err
-        )
+        logging.logAlert("LiteLLM reconciliation failed after app restore", err)
         status = BackupStatus.FAILED
         const errorMessage = err instanceof Error ? err.message : String(err)
         await backups.trackBackupError(

--- a/packages/pro/src/sdk/backups/tests/index.spec.ts
+++ b/packages/pro/src/sdk/backups/tests/index.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "@budibase/types"
 import tk from "timekeeper"
 import { Readable } from "stream"
+import backupMetadata from "../backup"
 import { default as backups } from "../"
 import { DBTestConfiguration, mocks } from "../../../../tests"
 
@@ -293,9 +294,26 @@ describe("backups", () => {
       const backup = await createBackup()
       await waitForQueue()
       const replicateSpy = jest.spyOn(db.Replication.prototype, "replicate")
-      reconcileLiteLLMModelsFn.mockRejectedValue(
-        new Error("LiteLLM reconciliation failed")
+      const trackBackupErrorSpy = jest
+        .spyOn(backupMetadata, "trackBackupError")
+        .mockRejectedValue(new Error("Tracking failed"))
+      let streamUploadsBeforeReconciliation = 0
+      mockedObjectStore.listAllObjects.mockImplementation((_bucket, prefix) =>
+        (async function* () {
+          if (prefix?.includes("_temp_")) {
+            yield { Key: `${prefix}attachments/restore.txt` }
+          }
+          if (prefix === `${config.workspaceId}/`) {
+            yield { Key: `${prefix}attachments/restore.txt` }
+          }
+        })()
       )
+      mockedObjectStore.objectExists.mockResolvedValue(true)
+      reconcileLiteLLMModelsFn.mockImplementation(async () => {
+        streamUploadsBeforeReconciliation =
+          mockedObjectStore.streamUpload.mock.calls.length
+        throw new Error("LiteLLM reconciliation failed")
+      })
 
       try {
         const response = await backups.triggerWorkspaceRestore(
@@ -312,8 +330,13 @@ describe("backups", () => {
         expect(processedRestore.status).toEqual(BackupStatus.FAILED)
         expect(replicateSpy).toHaveBeenCalledTimes(1)
         expect(reconcileLiteLLMModelsFn).toHaveBeenCalledTimes(1)
+        expect(trackBackupErrorSpy).toHaveBeenCalledTimes(1)
+        expect(mockedObjectStore.streamUpload).toHaveBeenCalledTimes(
+          streamUploadsBeforeReconciliation
+        )
       } finally {
         replicateSpy.mockRestore()
+        trackBackupErrorSpy.mockRestore()
       }
     })
   })

--- a/packages/pro/src/sdk/backups/tests/index.spec.ts
+++ b/packages/pro/src/sdk/backups/tests/index.spec.ts
@@ -341,6 +341,53 @@ describe("backups", () => {
     })
   })
 
+  it("should not roll back promoted files when reconciliation fails", async () => {
+    await config.doInTenant(async () => {
+      const backup = await createBackup()
+      await waitForQueue()
+      const replicateSpy = jest.spyOn(db.Replication.prototype, "replicate")
+      let streamUploadsBeforeReconciliation = 0
+      mockedObjectStore.listAllObjects.mockImplementation((_bucket, prefix) =>
+        (async function* () {
+          if (prefix?.includes("_temp_")) {
+            yield { Key: `${prefix}attachments/restore.txt` }
+          }
+          if (prefix === `${config.workspaceId}/`) {
+            yield { Key: `${prefix}attachments/restore.txt` }
+          }
+        })()
+      )
+      mockedObjectStore.objectExists.mockResolvedValue(true)
+      reconcileLiteLLMModelsFn.mockImplementation(async () => {
+        streamUploadsBeforeReconciliation =
+          mockedObjectStore.streamUpload.mock.calls.length
+        throw new Error("LiteLLM reconciliation failed")
+      })
+
+      try {
+        const response = await backups.triggerWorkspaceRestore(
+          config.workspaceId,
+          backup._id,
+          "backup restore",
+          USER_ID
+        )
+        await waitForQueue()
+
+        const processedRestore = await backups.getWorkspaceBackup(
+          response!.restoreId
+        )
+        expect(processedRestore.status).toEqual(BackupStatus.FAILED)
+        expect(replicateSpy).toHaveBeenCalledTimes(1)
+        expect(reconcileLiteLLMModelsFn).toHaveBeenCalledTimes(1)
+        expect(mockedObjectStore.streamUpload).toHaveBeenCalledTimes(
+          streamUploadsBeforeReconciliation
+        )
+      } finally {
+        replicateSpy.mockRestore()
+      }
+    })
+  })
+
   it("should overwrite existing target object store files during restore", async () => {
     await config.doInTenant(async () => {
       const backup = await createBackup()

--- a/packages/pro/src/sdk/backups/tests/index.spec.ts
+++ b/packages/pro/src/sdk/backups/tests/index.spec.ts
@@ -178,6 +178,51 @@ describe("backups", () => {
     statsFn = jest.fn(),
     reconcileLiteLLMModelsFn = jest.fn()
 
+  const expectRestoreToFailWithoutRollingBack = async (
+    backup: WorkspaceBackup
+  ) => {
+    let streamUploadsBeforeReconciliation = 0
+    mockedObjectStore.listAllObjects.mockImplementation((_bucket, prefix) =>
+      (async function* () {
+        if (prefix?.includes("_temp_")) {
+          yield { Key: `${prefix}attachments/restore.txt` }
+        }
+        if (prefix === `${config.workspaceId}/`) {
+          yield { Key: `${prefix}attachments/restore.txt` }
+        }
+      })()
+    )
+    mockedObjectStore.objectExists.mockResolvedValue(true)
+    reconcileLiteLLMModelsFn.mockImplementation(async () => {
+      streamUploadsBeforeReconciliation =
+        mockedObjectStore.streamUpload.mock.calls.length
+      throw new Error("LiteLLM reconciliation failed")
+    })
+
+    const replicateSpy = jest.spyOn(db.Replication.prototype, "replicate")
+    try {
+      const response = await backups.triggerWorkspaceRestore(
+        config.workspaceId,
+        backup._id,
+        "backup restore",
+        USER_ID
+      )
+      await waitForQueue()
+
+      const processedRestore = await backups.getWorkspaceBackup(
+        response!.restoreId
+      )
+      expect(processedRestore.status).toEqual(BackupStatus.FAILED)
+      expect(replicateSpy).toHaveBeenCalledTimes(1)
+      expect(reconcileLiteLLMModelsFn).toHaveBeenCalledTimes(1)
+      expect(mockedObjectStore.streamUpload).toHaveBeenCalledTimes(
+        streamUploadsBeforeReconciliation
+      )
+    } finally {
+      replicateSpy.mockRestore()
+    }
+  }
+
   beforeAll(async () => {
     mocks.licenses.useBackups()
     await backups.init({
@@ -293,49 +338,14 @@ describe("backups", () => {
     await config.doInTenant(async () => {
       const backup = await createBackup()
       await waitForQueue()
-      const replicateSpy = jest.spyOn(db.Replication.prototype, "replicate")
       const trackBackupErrorSpy = jest
         .spyOn(backupMetadata, "trackBackupError")
         .mockRejectedValue(new Error("Tracking failed"))
-      let streamUploadsBeforeReconciliation = 0
-      mockedObjectStore.listAllObjects.mockImplementation((_bucket, prefix) =>
-        (async function* () {
-          if (prefix?.includes("_temp_")) {
-            yield { Key: `${prefix}attachments/restore.txt` }
-          }
-          if (prefix === `${config.workspaceId}/`) {
-            yield { Key: `${prefix}attachments/restore.txt` }
-          }
-        })()
-      )
-      mockedObjectStore.objectExists.mockResolvedValue(true)
-      reconcileLiteLLMModelsFn.mockImplementation(async () => {
-        streamUploadsBeforeReconciliation =
-          mockedObjectStore.streamUpload.mock.calls.length
-        throw new Error("LiteLLM reconciliation failed")
-      })
 
       try {
-        const response = await backups.triggerWorkspaceRestore(
-          config.workspaceId,
-          backup._id,
-          "backup restore",
-          USER_ID
-        )
-        await waitForQueue()
-
-        const processedRestore = await backups.getWorkspaceBackup(
-          response!.restoreId
-        )
-        expect(processedRestore.status).toEqual(BackupStatus.FAILED)
-        expect(replicateSpy).toHaveBeenCalledTimes(1)
-        expect(reconcileLiteLLMModelsFn).toHaveBeenCalledTimes(1)
+        await expectRestoreToFailWithoutRollingBack(backup)
         expect(trackBackupErrorSpy).toHaveBeenCalledTimes(1)
-        expect(mockedObjectStore.streamUpload).toHaveBeenCalledTimes(
-          streamUploadsBeforeReconciliation
-        )
       } finally {
-        replicateSpy.mockRestore()
         trackBackupErrorSpy.mockRestore()
       }
     })
@@ -345,46 +355,7 @@ describe("backups", () => {
     await config.doInTenant(async () => {
       const backup = await createBackup()
       await waitForQueue()
-      const replicateSpy = jest.spyOn(db.Replication.prototype, "replicate")
-      let streamUploadsBeforeReconciliation = 0
-      mockedObjectStore.listAllObjects.mockImplementation((_bucket, prefix) =>
-        (async function* () {
-          if (prefix?.includes("_temp_")) {
-            yield { Key: `${prefix}attachments/restore.txt` }
-          }
-          if (prefix === `${config.workspaceId}/`) {
-            yield { Key: `${prefix}attachments/restore.txt` }
-          }
-        })()
-      )
-      mockedObjectStore.objectExists.mockResolvedValue(true)
-      reconcileLiteLLMModelsFn.mockImplementation(async () => {
-        streamUploadsBeforeReconciliation =
-          mockedObjectStore.streamUpload.mock.calls.length
-        throw new Error("LiteLLM reconciliation failed")
-      })
-
-      try {
-        const response = await backups.triggerWorkspaceRestore(
-          config.workspaceId,
-          backup._id,
-          "backup restore",
-          USER_ID
-        )
-        await waitForQueue()
-
-        const processedRestore = await backups.getWorkspaceBackup(
-          response!.restoreId
-        )
-        expect(processedRestore.status).toEqual(BackupStatus.FAILED)
-        expect(replicateSpy).toHaveBeenCalledTimes(1)
-        expect(reconcileLiteLLMModelsFn).toHaveBeenCalledTimes(1)
-        expect(mockedObjectStore.streamUpload).toHaveBeenCalledTimes(
-          streamUploadsBeforeReconciliation
-        )
-      } finally {
-        replicateSpy.mockRestore()
-      }
+      await expectRestoreToFailWithoutRollingBack(backup)
     })
   })
 

--- a/packages/pro/src/sdk/backups/tests/index.spec.ts
+++ b/packages/pro/src/sdk/backups/tests/index.spec.ts
@@ -174,7 +174,8 @@ describe("backups", () => {
 
   const exportWorkspaceFn = jest.fn(),
     importWorkspaceFn = jest.fn(),
-    statsFn = jest.fn()
+    statsFn = jest.fn(),
+    reconcileLiteLLMModelsFn = jest.fn()
 
   beforeAll(async () => {
     mocks.licenses.useBackups()
@@ -183,6 +184,7 @@ describe("backups", () => {
         exportWorkspaceFn,
         importWorkspaceFn,
         statsFn,
+        reconcileLiteLLMModels: reconcileLiteLLMModelsFn,
       },
     })
   })
@@ -194,6 +196,7 @@ describe("backups", () => {
     exportWorkspaceFn.mockReset().mockReturnValue("/path")
     importWorkspaceFn.mockReset().mockImplementation()
     statsFn.mockReset().mockImplementation()
+    reconcileLiteLLMModelsFn.mockReset().mockImplementation()
     mockedObjectStore.listAllObjects
       .mockReset()
       .mockImplementation(() => (async function* () {})())
@@ -263,8 +266,10 @@ describe("backups", () => {
         expect.objectContaining({
           objectStoreAppId: tempAppId,
           preserveLiteLLMConfig: true,
+          reconcileLiteLLMModels: false,
         })
       )
+      expect(reconcileLiteLLMModelsFn).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -280,6 +285,36 @@ describe("backups", () => {
       expect(restoreWorkspaceId).toEqual(
         db.getDevWorkspaceID(config.workspaceId)
       )
+    })
+  })
+
+  it("should mark restore as failed when LiteLLM reconciliation fails", async () => {
+    await config.doInTenant(async () => {
+      const backup = await createBackup()
+      await waitForQueue()
+      const replicateSpy = jest.spyOn(db.Replication.prototype, "replicate")
+      reconcileLiteLLMModelsFn.mockRejectedValue(
+        new Error("LiteLLM reconciliation failed")
+      )
+
+      try {
+        const response = await backups.triggerWorkspaceRestore(
+          config.workspaceId,
+          backup._id,
+          "backup restore",
+          USER_ID
+        )
+        await waitForQueue()
+
+        const processedRestore = await backups.getWorkspaceBackup(
+          response!.restoreId
+        )
+        expect(processedRestore.status).toEqual(BackupStatus.FAILED)
+        expect(replicateSpy).toHaveBeenCalledTimes(1)
+        expect(reconcileLiteLLMModelsFn).toHaveBeenCalledTimes(1)
+      } finally {
+        replicateSpy.mockRestore()
+      }
     })
   })
 

--- a/packages/pro/src/types/init.ts
+++ b/packages/pro/src/types/init.ts
@@ -24,6 +24,7 @@ export interface ImportWorkspaceOpts {
   importObjStoreContents?: boolean
   objectStoreAppId?: string
   preserveLiteLLMConfig?: boolean
+  reconcileLiteLLMModels?: boolean
 }
 
 export type ExportWorkspaceFn = (
@@ -48,4 +49,5 @@ export interface BackupProcessingOpts {
   exportWorkspaceFn: ExportWorkspaceFn
   importWorkspaceFn: ImportWorkspaceFn
   statsFn: StatsFn
+  reconcileLiteLLMModels: () => Promise<void>
 }

--- a/packages/server/src/sdk/workspace/backups/imports.ts
+++ b/packages/server/src/sdk/workspace/backups/imports.ts
@@ -196,6 +196,7 @@ export interface ImportAppOpts {
   importObjStoreContents?: boolean
   objectStoreAppId?: string
   preserveLiteLLMConfig?: boolean
+  reconcileLiteLLMModels?: boolean
 }
 
 async function sanitizeLiteLLMImportData(db: Database) {
@@ -254,6 +255,7 @@ export const importApp: ImportWorkspaceFn = async (
     updateAttachmentColumns: true,
     importObjStoreContents: true,
     preserveLiteLLMConfig: false,
+    reconcileLiteLLMModels: true,
     ...opts,
   }
   const prodAppId = dbCore.getProdWorkspaceID(appId)
@@ -362,7 +364,9 @@ export const importApp: ImportWorkspaceFn = async (
     await sanitizeLiteLLMImportData(db)
   }
 
-  await sdk.ai.configs.reconcileLiteLLMModels()
+  if (importOpts.reconcileLiteLLMModels) {
+    await sdk.ai.configs.reconcileLiteLLMModels()
+  }
 
   // clear up afterward
   if (tmpPath) {

--- a/packages/server/src/startup/index.ts
+++ b/packages/server/src/startup/index.ts
@@ -98,6 +98,7 @@ async function initPro() {
         exportWorkspaceFn: sdk.backups.exportWorkspace,
         importWorkspaceFn: sdk.backups.importApp,
         statsFn: sdk.backups.calculateBackupStats,
+        reconcileLiteLLMModels: sdk.ai.configs.reconcileLiteLLMModels,
       },
     },
   })


### PR DESCRIPTION
## Description

Backup restores currently reconcile LiteLLM against the old workspace database. The archive is loaded into a temporary database, but reconciliation reads from the active workspace context. Any repairs can therefore be lost when the restored database replaces it.

This change defers reconciliation until after database cutover, ensuring models and keys are reconciled against the restored configuration.

The `reconcileLiteLLMModels` import option controls **when reconciliation runs**, independently of `preserveLiteLLMConfig`, which controls whether imported model IDs and keys are retained:

- **Import into a new workspace:** leave reconciliation enabled—the default. The imported database is already the active target.
- **Restore a backup:** disable reconciliation during the temporary import, then run it explicitly after cutover. Reconciliation is deferred, not skipped.
- **Update an existing workspace from an export:** unchanged by this PR. This flow uses a temporary database and copies selected documents, excluding AI configurations and LiteLLM keys. It does not replace the workspace’s AI configuration.

If reconciliation fails after cutover, the restore is marked failed and the error is recorded, but the restored database and files remain in place. Files are not rolled back because they now belong to the restored database.

## Addresses

- https://github.com/Budibase/budibase/issues/19601

## Launchcontrol

Fixes backup restoration reconciling LiteLLM against the old workspace configuration instead of the restored configuration.
