### PR TITLE
Infer agent-session container status (active/waiting/completed/failed)

### DIFF
--- a/packages/backend-core/src/events/processors/platformActions/index.ts
+++ b/packages/backend-core/src/events/processors/platformActions/index.ts
@@ -1,4 +1,5 @@
 export {
   enqueuePlatformActionSessionIndex,
+  enqueuePlatformActionSessionLifecycle,
   initPlatformActionSessionIndexQueue as init,
 } from "./indexQueue"

--- a/packages/backend-core/src/events/processors/platformActions/indexQueue.ts
+++ b/packages/backend-core/src/events/processors/platformActions/indexQueue.ts
@@ -1,4 +1,9 @@
-import type { PlatformActionSessionIndexJob } from "@budibase/types"
+import { v4 as uuidv4 } from "uuid"
+import type {
+  ActionSourceContext,
+  PlatformActionContainerStatus,
+  PlatformActionSessionIndexJob,
+} from "@budibase/types"
 import * as context from "../../../context"
 import { BudibaseQueue, JobQueue } from "../../../queue"
 import { upsertPlatformActionSession } from "./sessionIndex"
@@ -6,6 +11,13 @@ import { upsertPlatformActionSession } from "./sessionIndex"
 const DEFAULT_INDEX_QUEUE_CONCURRENCY = 2
 const DEFAULT_INDEX_QUEUE_BACKOFF_MS = 5000
 const DEFAULT_INDEX_QUEUE_ATTEMPTS = 6
+
+export interface PlatformActionSessionLifecycleInput
+  extends ActionSourceContext {
+  signal: PlatformActionContainerStatus
+  timestamp?: string
+  lifecycleId?: string
+}
 
 let platformActionSessionIndexQueue:
   | BudibaseQueue<PlatformActionSessionIndexJob>
@@ -75,5 +87,28 @@ export async function enqueuePlatformActionSessionIndex(
   job: PlatformActionSessionIndexJob
 ): Promise<void> {
   initPlatformActionSessionIndexQueue()
-  await getIndexQueue().add(job, { jobId: job.platformActionId })
+  await getIndexQueue().add(job, { jobId: job.indexId })
+}
+
+export async function enqueuePlatformActionSessionLifecycle({
+  sourceType,
+  sourceId,
+  signal,
+  timestamp = new Date().toISOString(),
+  lifecycleId = `platform_action_lifecycle_${uuidv4()}`,
+}: PlatformActionSessionLifecycleInput): Promise<void> {
+  const workspaceId = context.getWorkspaceId()
+  if (!workspaceId) {
+    throw new Error("Cannot index platform action session without a workspace")
+  }
+
+  await enqueuePlatformActionSessionIndex({
+    workspaceId,
+    indexId: lifecycleId,
+    sourceType,
+    sourceId,
+    incrementsActionCount: false,
+    signal,
+    timestamp,
+  })
 }

--- a/packages/backend-core/src/events/processors/platformActions/platformActionsPersistProcessor.ts
+++ b/packages/backend-core/src/events/processors/platformActions/platformActionsPersistProcessor.ts
@@ -32,6 +32,22 @@ function isActionSourceContext(
   )
 }
 
+function getSessionSignal(
+  event: Event,
+  properties: Record<string, unknown>
+): PlatformActionSessionIndexJob["signal"] {
+  if (event.endsWith(":failed")) {
+    return "failed"
+  }
+  if (
+    event === Event.ACTION_AI_AGENT_EXECUTED &&
+    properties.awaitingEscalation === true
+  ) {
+    return "waiting"
+  }
+  return "completed"
+}
+
 export default class PlatformActionPersistProcessor implements EventProcessor {
   async processEvent(
     event: Event,
@@ -86,7 +102,7 @@ export default class PlatformActionPersistProcessor implements EventProcessor {
       sourceType: doc.sourceType,
       sourceId: doc.sourceId,
       incrementsActionCount: true,
-      signal: event.endsWith(":failed") ? "failed" : "completed",
+      signal: getSessionSignal(event, properties),
       timestamp: isoTimestamp,
     }
 

--- a/packages/backend-core/src/events/processors/platformActions/platformActionsPersistProcessor.ts
+++ b/packages/backend-core/src/events/processors/platformActions/platformActionsPersistProcessor.ts
@@ -41,6 +41,13 @@ function getSessionSignal(
   }
   if (
     event === Event.ACTION_AI_AGENT_EXECUTED &&
+    (properties.finalStatus === "completed" ||
+      properties.finalStatus === "failed")
+  ) {
+    return properties.finalStatus
+  }
+  if (
+    event === Event.ACTION_AI_AGENT_EXECUTED &&
     properties.awaitingEscalation === true
   ) {
     return "waiting"

--- a/packages/backend-core/src/events/processors/platformActions/platformActionsPersistProcessor.ts
+++ b/packages/backend-core/src/events/processors/platformActions/platformActionsPersistProcessor.ts
@@ -86,7 +86,8 @@ export default class PlatformActionPersistProcessor implements EventProcessor {
       sourceType: doc.sourceType,
       sourceId: doc.sourceId,
       eventName: event,
-      outcome: event.endsWith(":failed") ? "failure" : "success",
+      incrementsActionCount: true,
+      signal: event.endsWith(":failed") ? "failed" : "completed",
       timestamp: isoTimestamp,
     }
 

--- a/packages/backend-core/src/events/processors/platformActions/platformActionsPersistProcessor.ts
+++ b/packages/backend-core/src/events/processors/platformActions/platformActionsPersistProcessor.ts
@@ -82,10 +82,9 @@ export default class PlatformActionPersistProcessor implements EventProcessor {
 
     const indexJob: PlatformActionSessionIndexJob = {
       workspaceId,
-      platformActionId: platformActionEventId,
+      indexId: platformActionEventId,
       sourceType: doc.sourceType,
       sourceId: doc.sourceId,
-      eventName: event,
       incrementsActionCount: true,
       signal: event.endsWith(":failed") ? "failed" : "completed",
       timestamp: isoTimestamp,

--- a/packages/backend-core/src/events/processors/platformActions/sessionIndex.ts
+++ b/packages/backend-core/src/events/processors/platformActions/sessionIndex.ts
@@ -3,7 +3,6 @@ import {
   LockType,
   type ActionSourceContext,
   type PlatformActionContainerStatus,
-  type PlatformActionOutcome,
   type PlatformActionSessionIndexDoc,
 } from "@budibase/types"
 import * as context from "../../../context"
@@ -13,19 +12,32 @@ import { buildPlatformActionSession, getPlatformActionSessionId } from "./utils"
 const LOCK_TTL_MS = 10000
 const MAX_PUT_CONFLICT_ATTEMPTS = 3
 
+const TERMINAL_STATUSES: ReadonlySet<PlatformActionContainerStatus> = new Set([
+  "completed",
+  "failed",
+])
+
+function isTerminalSignal(signal: PlatformActionContainerStatus): boolean {
+  return TERMINAL_STATUSES.has(signal)
+}
+
 export interface UpsertPlatformActionSessionInput extends ActionSourceContext {
-  outcome: PlatformActionOutcome
+  incrementsActionCount: boolean
+  signal: PlatformActionContainerStatus
   timestamp: string
 }
 
 function nextStatus(
   existingStatus: PlatformActionContainerStatus | undefined,
-  outcome: PlatformActionOutcome
+  signal: PlatformActionContainerStatus
 ): PlatformActionContainerStatus {
-  if (existingStatus === "failed" || outcome === "failure") {
+  if (existingStatus === "failed" || signal === "failed") {
     return "failed"
   }
-  return "completed"
+  if (existingStatus && TERMINAL_STATUSES.has(existingStatus)) {
+    return existingStatus
+  }
+  return signal
 }
 
 function earliest(a: string, b: string): string {
@@ -40,6 +52,7 @@ export async function upsertPlatformActionSession(
   input: UpsertPlatformActionSessionInput
 ): Promise<void> {
   const sessionId = getPlatformActionSessionId(input)
+  const isTerminal = isTerminalSignal(input.signal)
 
   const lockResponse = await locks.doWithLock(
     {
@@ -54,31 +67,36 @@ export async function upsertPlatformActionSession(
       for (let attempt = 0; attempt < MAX_PUT_CONFLICT_ATTEMPTS; attempt++) {
         const existing =
           await db.tryGet<PlatformActionSessionIndexDoc>(sessionId)
-        const status = nextStatus(existing?.status, input.outcome)
-
-        // Prevent out-of-order event timestamps
+        const status = nextStatus(existing?.status, input.signal)
         const startedAt = existing
           ? earliest(existing.startedAt, input.timestamp)
           : input.timestamp
-        const completedAt = existing
-          ? latest(existing.completedAt ?? existing.startedAt, input.timestamp)
-          : input.timestamp
 
-        // updatedAt isn't known yet - db.put() below stamps it for real.
         const doc: Omit<PlatformActionSessionIndexDoc, "updatedAt"> = existing
           ? {
               ...existing,
               status,
-              actionCount: existing.actionCount + 1,
               startedAt,
+              ...(input.incrementsActionCount
+                ? { actionCount: existing.actionCount + 1 }
+                : {}),
             }
           : buildPlatformActionSession({
               sourceType: input.sourceType,
               sourceId: input.sourceId,
               status,
               startedAt,
+              actionCount: input.incrementsActionCount ? 1 : 0,
             })
-        doc.completedAt = completedAt
+
+        if (isTerminal) {
+          doc.completedAt = existing
+            ? latest(
+                existing.completedAt ?? existing.startedAt,
+                input.timestamp
+              )
+            : input.timestamp
+        }
 
         try {
           await db.put(doc)
@@ -95,9 +113,6 @@ export async function upsertPlatformActionSession(
   )
 
   if (!lockResponse.executed) {
-    // Another job already holds the lock for this session - let Bull's
-    // retry/backoff pick this update back up instead of dropping it, since
-    // every event must be reflected in actionCount.
     throw new Error(
       `Could not acquire lock to index platform action session ${sessionId}`
     )

--- a/packages/backend-core/src/events/processors/platformActions/sessionIndex.ts
+++ b/packages/backend-core/src/events/processors/platformActions/sessionIndex.ts
@@ -29,15 +29,35 @@ export interface UpsertPlatformActionSessionInput extends ActionSourceContext {
 
 function nextStatus(
   existingStatus: PlatformActionContainerStatus | undefined,
-  signal: PlatformActionContainerStatus
-): PlatformActionContainerStatus {
-  if (existingStatus === "failed" || signal === "failed") {
-    return "failed"
+  existingStatusUpdatedAt: string | undefined,
+  signal: PlatformActionContainerStatus,
+  timestamp: string
+): {
+  status: PlatformActionContainerStatus
+  statusUpdatedAt: string
+  updated: boolean
+} {
+  if (!existingStatus || !existingStatusUpdatedAt) {
+    return { status: signal, statusUpdatedAt: timestamp, updated: true }
   }
-  if (existingStatus && TERMINAL_STATUSES.has(existingStatus)) {
-    return existingStatus
+
+  if (new Date(timestamp) > new Date(existingStatusUpdatedAt)) {
+    return { status: signal, statusUpdatedAt: timestamp, updated: true }
   }
-  return signal
+  if (
+    new Date(timestamp).getTime() ===
+      new Date(existingStatusUpdatedAt).getTime() &&
+    signal === "failed" &&
+    existingStatus !== "failed"
+  ) {
+    return { status: signal, statusUpdatedAt: timestamp, updated: true }
+  }
+
+  return {
+    status: existingStatus,
+    statusUpdatedAt: existingStatusUpdatedAt,
+    updated: false,
+  }
 }
 
 function earliest(a: string, b: string): string {
@@ -70,7 +90,21 @@ export async function upsertPlatformActionSession(
         if (!existing && !input.incrementsActionCount) {
           return
         }
-        const status = nextStatus(existing?.status, input.signal)
+        const existingStatusUpdatedAt = existing
+          ? (existing.statusUpdatedAt ??
+            existing.completedAt ??
+            existing.startedAt)
+          : undefined
+        const {
+          status,
+          statusUpdatedAt,
+          updated: updatesStatus,
+        } = nextStatus(
+          existing?.status,
+          existingStatusUpdatedAt,
+          input.signal,
+          input.timestamp
+        )
         const startedAt = existing
           ? earliest(existing.startedAt, input.timestamp)
           : input.timestamp
@@ -79,6 +113,7 @@ export async function upsertPlatformActionSession(
           ? {
               ...existing,
               status,
+              statusUpdatedAt,
               startedAt,
               ...(input.incrementsActionCount
                 ? { actionCount: existing.actionCount + 1 }
@@ -89,16 +124,19 @@ export async function upsertPlatformActionSession(
               sourceId: input.sourceId,
               status,
               startedAt,
+              statusUpdatedAt,
               actionCount: input.incrementsActionCount ? 1 : 0,
             })
 
-        if (isTerminal) {
+        if (isTerminal && updatesStatus) {
           doc.completedAt = existing
             ? latest(
                 existing.completedAt ?? existing.startedAt,
                 input.timestamp
               )
             : input.timestamp
+        } else if (updatesStatus) {
+          delete doc.completedAt
         }
 
         try {

--- a/packages/backend-core/src/events/processors/platformActions/sessionIndex.ts
+++ b/packages/backend-core/src/events/processors/platformActions/sessionIndex.ts
@@ -67,6 +67,9 @@ export async function upsertPlatformActionSession(
       for (let attempt = 0; attempt < MAX_PUT_CONFLICT_ATTEMPTS; attempt++) {
         const existing =
           await db.tryGet<PlatformActionSessionIndexDoc>(sessionId)
+        if (!existing && !input.incrementsActionCount) {
+          return
+        }
         const status = nextStatus(existing?.status, input.signal)
         const startedAt = existing
           ? earliest(existing.startedAt, input.timestamp)

--- a/packages/backend-core/src/events/processors/platformActions/sessionIndex.ts
+++ b/packages/backend-core/src/events/processors/platformActions/sessionIndex.ts
@@ -154,6 +154,9 @@ export async function upsertPlatformActionSession(
   )
 
   if (!lockResponse.executed) {
+    // Another job already holds the lock for this session - let Bull's
+    // retry/backoff pick this update back up instead of dropping it, since
+    // every event must be reflected in actionCount.
     throw new Error(
       `Could not acquire lock to index platform action session ${sessionId}`
     )

--- a/packages/backend-core/src/events/processors/platformActions/tests/indexQueue.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/indexQueue.spec.ts
@@ -40,7 +40,8 @@ describe("enqueuePlatformActionSessionIndex", () => {
       sourceType: "agent_session",
       sourceId: "session-1",
       eventName: "action:ai_agent:executed",
-      outcome: "success",
+      incrementsActionCount: true,
+      signal: "completed",
       timestamp: new Date().toISOString(),
     }
 

--- a/packages/backend-core/src/events/processors/platformActions/tests/indexQueue.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/indexQueue.spec.ts
@@ -1,10 +1,14 @@
 import type { PlatformActionSessionIndexJob } from "@budibase/types"
 import { structures } from "../../../../../tests"
+import * as context from "../../../../context"
 import * as db from "../../../../db"
 
 jest.mock("../sessionIndex")
 import { upsertPlatformActionSession } from "../sessionIndex"
-import { enqueuePlatformActionSessionIndex } from "../indexQueue"
+import {
+  enqueuePlatformActionSessionIndex,
+  enqueuePlatformActionSessionLifecycle,
+} from "../indexQueue"
 
 const mockUpsert = upsertPlatformActionSession as jest.MockedFunction<
   typeof upsertPlatformActionSession
@@ -32,14 +36,13 @@ describe("enqueuePlatformActionSessionIndex", () => {
     mockUpsert.mockResolvedValue(undefined)
   })
 
-  it("does not materialize a job twice when enqueued twice with the same platformActionId", async () => {
+  it("does not materialize a job twice when enqueued twice with the same indexId", async () => {
     const workspaceId = db.generateWorkspaceID(structures.tenant.id())
     const job: PlatformActionSessionIndexJob = {
       workspaceId,
-      platformActionId: `platform_action_${structures.uuid()}`,
+      indexId: `platform_action_${structures.uuid()}`,
       sourceType: "agent_session",
       sourceId: "session-1",
-      eventName: "action:ai_agent:executed",
       incrementsActionCount: true,
       signal: "completed",
       timestamp: new Date().toISOString(),
@@ -53,6 +56,30 @@ describe("enqueuePlatformActionSessionIndex", () => {
     await new Promise(resolve => setTimeout(resolve, SETTLE_MS))
 
     expect(mockUpsert).toHaveBeenCalledTimes(1)
+  })
+
+  it("enqueues lifecycle signals without incrementing actionCount", async () => {
+    const workspaceId = db.generateWorkspaceID(structures.tenant.id())
+
+    await context.doInWorkspaceContext(workspaceId, async () => {
+      await enqueuePlatformActionSessionLifecycle({
+        sourceType: "agent_session",
+        sourceId: "session-1",
+        signal: "active",
+        lifecycleId: "platform_action_lifecycle_test",
+      })
+    })
+
+    await waitFor(() => mockUpsert.mock.calls.length > 0)
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        incrementsActionCount: false,
+        signal: "active",
+        sourceType: "agent_session",
+        sourceId: "session-1",
+      })
+    )
   })
 })
 

--- a/packages/backend-core/src/events/processors/platformActions/tests/platformActionsPersistProcessor.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/platformActionsPersistProcessor.spec.ts
@@ -132,6 +132,50 @@ describe("PlatformActionPersistProcessor", () => {
     }
   )
 
+  it("marks an agent action as waiting only when it awaits an escalation", async () => {
+    await run(async () => {
+      await processor.processEvent(
+        Event.ACTION_AI_AGENT_EXECUTED,
+        identity,
+        {
+          sourceType: "agent_session",
+          sourceId: "session-1",
+          awaitingEscalation: true,
+        },
+        undefined
+      )
+
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          incrementsActionCount: true,
+          signal: "waiting",
+        })
+      )
+    })
+  })
+
+  it("does not apply an escalation state to a non-agent action", async () => {
+    await run(async () => {
+      await processor.processEvent(
+        Event.ACTION_AUTOMATION_STEP_EXECUTED,
+        identity,
+        {
+          sourceType: "automation_run",
+          sourceId: "run-1",
+          awaitingEscalation: true,
+        },
+        undefined
+      )
+
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          incrementsActionCount: true,
+          signal: "completed",
+        })
+      )
+    })
+  })
+
   it("does not enqueue a session index job when Layer 1 persistence fails", async () => {
     await run(async () => {
       const putSpy = jest

--- a/packages/backend-core/src/events/processors/platformActions/tests/platformActionsPersistProcessor.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/platformActionsPersistProcessor.spec.ts
@@ -154,6 +154,28 @@ describe("PlatformActionPersistProcessor", () => {
     })
   })
 
+  it("uses an agent action's final status when its request was judged failed", async () => {
+    await run(async () => {
+      await processor.processEvent(
+        Event.ACTION_AI_AGENT_EXECUTED,
+        identity,
+        {
+          sourceType: "agent_session",
+          sourceId: "session-1",
+          finalStatus: "failed",
+        },
+        undefined
+      )
+
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          incrementsActionCount: true,
+          signal: "failed",
+        })
+      )
+    })
+  })
+
   it("does not apply an escalation state to a non-agent action", async () => {
     await run(async () => {
       await processor.processEvent(

--- a/packages/backend-core/src/events/processors/platformActions/tests/platformActionsPersistProcessor.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/platformActionsPersistProcessor.spec.ts
@@ -107,11 +107,11 @@ describe("PlatformActionPersistProcessor", () => {
   })
 
   it.each([
-    [Event.ACTION_AI_AGENT_EXECUTED, "success"],
-    [Event.ACTION_AI_AGENT_FAILED, "failure"],
+    [Event.ACTION_AI_AGENT_EXECUTED, "completed"],
+    [Event.ACTION_AI_AGENT_FAILED, "failed"],
   ])(
-    "enqueues a session index job with outcome %s for %s",
-    async (event, outcome) => {
+    "enqueues a session index job with signal %s for %s",
+    async (event, signal) => {
       await run(async () => {
         await processor.processEvent(
           event,
@@ -122,7 +122,8 @@ describe("PlatformActionPersistProcessor", () => {
 
         expect(mockEnqueue).toHaveBeenCalledWith(
           expect.objectContaining({
-            outcome,
+            incrementsActionCount: true,
+            signal,
             sourceType: "agent_session",
             sourceId: "session-1",
           })

--- a/packages/backend-core/src/events/processors/platformActions/tests/sessionIndex.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/sessionIndex.spec.ts
@@ -28,7 +28,8 @@ describe("upsertPlatformActionSession", () => {
       await upsertPlatformActionSession({
         sourceType: "agent_session",
         sourceId,
-        outcome: "success",
+        incrementsActionCount: true,
+        signal: "completed",
         timestamp: "2026-08-31T00:00:00.000Z",
       })
 
@@ -49,7 +50,8 @@ describe("upsertPlatformActionSession", () => {
       await upsertPlatformActionSession({
         sourceType: "agent_session",
         sourceId,
-        outcome: "failure",
+        incrementsActionCount: true,
+        signal: "failed",
         timestamp: "2026-08-31T00:00:00.000Z",
       })
 
@@ -66,12 +68,14 @@ describe("upsertPlatformActionSession", () => {
 
       await upsertPlatformActionSession({
         ...input,
-        outcome: "success",
+        incrementsActionCount: true,
+        signal: "completed",
         timestamp: "2026-08-31T00:00:00.000Z",
       })
       await upsertPlatformActionSession({
         ...input,
-        outcome: "success",
+        incrementsActionCount: true,
+        signal: "completed",
         timestamp: "2026-08-31T00:05:00.000Z",
       })
 
@@ -94,12 +98,14 @@ describe("upsertPlatformActionSession", () => {
       // contention retry).
       await upsertPlatformActionSession({
         ...input,
-        outcome: "success",
+        incrementsActionCount: true,
+        signal: "completed",
         timestamp: "2026-08-31T00:05:00.000Z",
       })
       await upsertPlatformActionSession({
         ...input,
-        outcome: "success",
+        incrementsActionCount: true,
+        signal: "completed",
         timestamp: "2026-08-31T00:00:00.000Z",
       })
 
@@ -118,12 +124,14 @@ describe("upsertPlatformActionSession", () => {
 
       await upsertPlatformActionSession({
         ...input,
-        outcome: "failure",
+        incrementsActionCount: true,
+        signal: "failed",
         timestamp: "2026-08-31T00:00:00.000Z",
       })
       await upsertPlatformActionSession({
         ...input,
-        outcome: "success",
+        incrementsActionCount: true,
+        signal: "completed",
         timestamp: "2026-08-31T00:05:00.000Z",
       })
 
@@ -131,6 +139,38 @@ describe("upsertPlatformActionSession", () => {
 
       expect(doc.status).toBe("failed")
       expect(doc.actionCount).toBe(2)
+    })
+  })
+
+  it("updates lifecycle state without incrementing actionCount", async () => {
+    await run(async () => {
+      const sourceId = generator.guid()
+      const input = { sourceType: "agent_session" as const, sourceId }
+
+      await upsertPlatformActionSession({
+        ...input,
+        incrementsActionCount: false,
+        signal: "active",
+        timestamp: "2026-08-31T00:00:00.000Z",
+      })
+      await upsertPlatformActionSession({
+        ...input,
+        incrementsActionCount: false,
+        signal: "waiting",
+        timestamp: "2026-08-31T00:01:00.000Z",
+      })
+      await upsertPlatformActionSession({
+        ...input,
+        incrementsActionCount: false,
+        signal: "completed",
+        timestamp: "2026-08-31T00:02:00.000Z",
+      })
+
+      const doc = await getSessionDoc(sourceId)
+
+      expect(doc.status).toBe("completed")
+      expect(doc.actionCount).toBe(0)
+      expect(doc.completedAt).toBe("2026-08-31T00:02:00.000Z")
     })
   })
 
@@ -157,7 +197,8 @@ describe("upsertPlatformActionSession", () => {
           try {
             await upsertPlatformActionSession({
               ...input,
-              outcome: "success",
+              incrementsActionCount: true,
+              signal: "completed",
               timestamp,
             })
             return
@@ -207,7 +248,8 @@ describe("upsertPlatformActionSession", () => {
           () =>
             upsertPlatformActionSession({
               ...input,
-              outcome: "success",
+              incrementsActionCount: true,
+              signal: "completed",
               timestamp: "2026-08-31T00:00:00.000Z",
             })
         )

--- a/packages/backend-core/src/events/processors/platformActions/tests/sessionIndex.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/sessionIndex.spec.ts
@@ -142,7 +142,7 @@ describe("upsertPlatformActionSession", () => {
     })
   })
 
-  it("updates lifecycle state without incrementing actionCount", async () => {
+  it("does not create a session index for a lifecycle signal without an action", async () => {
     await run(async () => {
       const sourceId = generator.guid()
       const input = { sourceType: "agent_session" as const, sourceId }
@@ -153,24 +153,14 @@ describe("upsertPlatformActionSession", () => {
         signal: "active",
         timestamp: "2026-08-31T00:00:00.000Z",
       })
-      await upsertPlatformActionSession({
-        ...input,
-        incrementsActionCount: false,
-        signal: "waiting",
-        timestamp: "2026-08-31T00:01:00.000Z",
-      })
-      await upsertPlatformActionSession({
-        ...input,
-        incrementsActionCount: false,
-        signal: "completed",
-        timestamp: "2026-08-31T00:02:00.000Z",
-      })
 
-      const doc = await getSessionDoc(sourceId)
+      const doc = await context
+        .getWorkspaceDB()
+        .tryGet<PlatformActionSessionIndexDoc>(
+          getPlatformActionSessionId(input)
+        )
 
-      expect(doc.status).toBe("completed")
-      expect(doc.actionCount).toBe(0)
-      expect(doc.completedAt).toBe("2026-08-31T00:02:00.000Z")
+      expect(doc).toBeUndefined()
     })
   })
 

--- a/packages/backend-core/src/events/processors/platformActions/tests/sessionIndex.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/sessionIndex.spec.ts
@@ -38,6 +38,7 @@ describe("upsertPlatformActionSession", () => {
       expect(doc.actionCount).toBe(1)
       expect(doc.status).toBe("completed")
       expect(doc.startedAt).toBe("2026-08-31T00:00:00.000Z")
+      expect(doc.statusUpdatedAt).toBe("2026-08-31T00:00:00.000Z")
       expect(doc.updatedAt).toBe(mocks.date.MOCK_DATE.toISOString())
       expect(doc.completedAt).toBe("2026-08-31T00:00:00.000Z")
     })
@@ -117,7 +118,7 @@ describe("upsertPlatformActionSession", () => {
     })
   })
 
-  it("keeps status failed once set, even after a later success event", async () => {
+  it("uses the latest signal to update the session status", async () => {
     await run(async () => {
       const sourceId = generator.guid()
       const input = { sourceType: "agent_session" as const, sourceId }
@@ -137,7 +138,8 @@ describe("upsertPlatformActionSession", () => {
 
       const doc = await getSessionDoc(sourceId)
 
-      expect(doc.status).toBe("failed")
+      expect(doc.status).toBe("completed")
+      expect(doc.statusUpdatedAt).toBe("2026-08-31T00:05:00.000Z")
       expect(doc.actionCount).toBe(2)
     })
   })
@@ -161,6 +163,59 @@ describe("upsertPlatformActionSession", () => {
         )
 
       expect(doc).toBeUndefined()
+    })
+  })
+
+  it("reopens an existing session without incrementing actionCount", async () => {
+    await run(async () => {
+      const sourceId = generator.guid()
+      const input = { sourceType: "agent_session" as const, sourceId }
+
+      await upsertPlatformActionSession({
+        ...input,
+        incrementsActionCount: true,
+        signal: "completed",
+        timestamp: "2026-08-31T00:00:00.000Z",
+      })
+      await upsertPlatformActionSession({
+        ...input,
+        incrementsActionCount: false,
+        signal: "active",
+        timestamp: "2026-08-31T00:05:00.000Z",
+      })
+
+      const doc = await getSessionDoc(sourceId)
+
+      expect(doc.status).toBe("active")
+      expect(doc.statusUpdatedAt).toBe("2026-08-31T00:05:00.000Z")
+      expect(doc.actionCount).toBe(1)
+      expect(doc.completedAt).toBeUndefined()
+    })
+  })
+
+  it("ignores a lifecycle signal older than the current status", async () => {
+    await run(async () => {
+      const sourceId = generator.guid()
+      const input = { sourceType: "agent_session" as const, sourceId }
+
+      await upsertPlatformActionSession({
+        ...input,
+        incrementsActionCount: true,
+        signal: "completed",
+        timestamp: "2026-08-31T00:05:00.000Z",
+      })
+      await upsertPlatformActionSession({
+        ...input,
+        incrementsActionCount: false,
+        signal: "waiting",
+        timestamp: "2026-08-31T00:00:00.000Z",
+      })
+
+      const doc = await getSessionDoc(sourceId)
+
+      expect(doc.status).toBe("completed")
+      expect(doc.statusUpdatedAt).toBe("2026-08-31T00:05:00.000Z")
+      expect(doc.actionCount).toBe(1)
     })
   })
 

--- a/packages/backend-core/src/events/processors/platformActions/tests/sessionIndex.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/sessionIndex.spec.ts
@@ -144,6 +144,34 @@ describe("upsertPlatformActionSession", () => {
     })
   })
 
+  it.each([
+    ["completed", "failed"],
+    ["failed", "completed"],
+  ] as const)(
+    "keeps failed when %s then %s arrive at the same timestamp",
+    async (firstSignal, secondSignal) => {
+      await run(async () => {
+        const sourceId = generator.guid()
+        const timestamp = "2026-08-31T00:00:00.000Z"
+        const input = {
+          sourceType: "agent_session" as const,
+          sourceId,
+          incrementsActionCount: true,
+          timestamp,
+        }
+
+        await upsertPlatformActionSession({ ...input, signal: firstSignal })
+        await upsertPlatformActionSession({ ...input, signal: secondSignal })
+
+        const doc = await getSessionDoc(sourceId)
+
+        expect(doc.status).toBe("failed")
+        expect(doc.statusUpdatedAt).toBe(timestamp)
+        expect(doc.actionCount).toBe(2)
+      })
+    }
+  )
+
   it("adds statusUpdatedAt when updating a legacy session doc", async () => {
     await run(async () => {
       const sourceId = generator.guid()

--- a/packages/backend-core/src/events/processors/platformActions/tests/sessionIndex.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/sessionIndex.spec.ts
@@ -144,6 +144,34 @@ describe("upsertPlatformActionSession", () => {
     })
   })
 
+  it("adds statusUpdatedAt when updating a legacy session doc", async () => {
+    await run(async () => {
+      const sourceId = generator.guid()
+      const input = { sourceType: "agent_session" as const, sourceId }
+
+      await context.getWorkspaceDB().put({
+        _id: getPlatformActionSessionId(input),
+        ...input,
+        status: "completed",
+        actionCount: 1,
+        startedAt: "2026-08-31T00:00:00.000Z",
+        completedAt: "2026-08-31T00:00:00.000Z",
+      })
+      await upsertPlatformActionSession({
+        ...input,
+        incrementsActionCount: false,
+        signal: "active",
+        timestamp: "2026-08-31T00:05:00.000Z",
+      })
+
+      const doc = await getSessionDoc(sourceId)
+
+      expect(doc.status).toBe("active")
+      expect(doc.statusUpdatedAt).toBe("2026-08-31T00:05:00.000Z")
+      expect(doc.actionCount).toBe(1)
+    })
+  })
+
   it("does not create a session index for a lifecycle signal without an action", async () => {
     await run(async () => {
       const sourceId = generator.guid()

--- a/packages/backend-core/src/events/processors/platformActions/tests/utils.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/utils.spec.ts
@@ -42,6 +42,8 @@ describe("platformActions utils", () => {
         sourceId: "session-1",
         status: "completed",
         startedAt: "2026-08-31T00:00:00.000Z",
+        statusUpdatedAt: "2026-08-31T00:00:00.000Z",
+        actionCount: 1,
       })
 
       // updatedAt is deliberately absent: db.put() always stamps it with
@@ -56,6 +58,7 @@ describe("platformActions utils", () => {
         sourceId: "session-1",
         status: "completed",
         startedAt: "2026-08-31T00:00:00.000Z",
+        statusUpdatedAt: "2026-08-31T00:00:00.000Z",
       })
       expect(doc).not.toHaveProperty("updatedAt")
     })
@@ -66,6 +69,8 @@ describe("platformActions utils", () => {
         sourceId: "run-1",
         status: "failed",
         startedAt: "2026-08-31T00:00:00.000Z",
+        statusUpdatedAt: "2026-08-31T00:00:00.000Z",
+        actionCount: 1,
         assetType: "automation",
         assetId: "automation-1",
         assetLabel: "My automation",

--- a/packages/backend-core/src/events/processors/platformActions/tests/utils.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/utils.spec.ts
@@ -36,7 +36,7 @@ describe("platformActions utils", () => {
   })
 
   describe("buildPlatformActionSession", () => {
-    it("initialises a fresh session doc with actionCount 1", () => {
+    it("builds a session doc with the provided fields", () => {
       const doc = buildPlatformActionSession({
         sourceType: "agent_session",
         sourceId: "session-1",

--- a/packages/backend-core/src/events/processors/platformActions/utils.ts
+++ b/packages/backend-core/src/events/processors/platformActions/utils.ts
@@ -21,6 +21,7 @@ export function getPlatformActionSessionId({
 export interface PlatformActionSessionInput extends ActionSourceContext {
   status: PlatformActionContainerStatus
   startedAt: string
+  statusUpdatedAt: string
   actionCount: number
   assetType?: string
   assetId?: string

--- a/packages/backend-core/src/events/processors/platformActions/utils.ts
+++ b/packages/backend-core/src/events/processors/platformActions/utils.ts
@@ -21,6 +21,7 @@ export function getPlatformActionSessionId({
 export interface PlatformActionSessionInput extends ActionSourceContext {
   status: PlatformActionContainerStatus
   startedAt: string
+  actionCount: number
   assetType?: string
   assetId?: string
   assetLabel?: string
@@ -37,7 +38,6 @@ export function buildPlatformActionSession(
 ): Omit<PlatformActionSessionIndexDoc, "updatedAt"> {
   return {
     _id: getPlatformActionSessionId(input),
-    actionCount: 1,
     ...input,
   }
 }

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -347,6 +347,8 @@ const finalizeAgentRequestTracking = async ({
         error: updateError,
       })
     })
+
+  return outcome
 }
 
 interface ResolvedChatStreamRequest {
@@ -643,16 +645,6 @@ export async function webhookChat({
     throw responseResult.reason
   }
 
-  events.action.aiAgentExecuted({
-    agentId,
-    ...buildAgentSessionActionContext({
-      sessionId,
-      requestId: trackingHandle?.requestId ?? requestId,
-    }),
-    ...(toolCallTracking.isAwaitingEscalation()
-      ? { awaitingEscalation: true }
-      : {}),
-  })
   const ragSources = run.getUsedKnowledgeSourcesMetadata()
 
   const finalAssistantMessage =
@@ -672,13 +664,24 @@ export async function webhookChat({
     (finishReasonResult.status === "fulfilled" &&
       finishReasonResult.value === "tool-calls")
   await toolCallTracking.flush()
-  await finalizeAgentRequestTracking({
+  const finalOutcome = await finalizeAgentRequestTracking({
     trackingHandle,
     agentId,
     sessionId,
     toolCallsIncomplete,
     unrecoveredToolFailures,
     finalResponse: assistantText,
+  })
+  events.action.aiAgentExecuted({
+    agentId,
+    ...buildAgentSessionActionContext({
+      sessionId,
+      requestId: trackingHandle?.requestId ?? requestId,
+    }),
+    ...(toolCallTracking.isAwaitingEscalation()
+      ? { awaitingEscalation: true }
+      : {}),
+    ...(finalOutcome ? { finalStatus: finalOutcome.status } : {}),
   })
 
   return {
@@ -841,6 +844,19 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
       },
       onFinish: async ({ messages }) => {
         await run.sessionLogIndexer.index()
+        await toolCallTracking.flush()
+
+        const finalAssistantMessage = [...messages]
+          .reverse()
+          .find(message => message.role === "assistant")
+        const finalOutcome = await finalizeAgentRequestTracking({
+          trackingHandle,
+          agentId,
+          sessionId,
+          toolCallsIncomplete: streamResult.toolCallsIncomplete,
+          unrecoveredToolFailures,
+          finalResponse: getAssistantMessageText(finalAssistantMessage),
+        })
         events.action.aiAgentExecuted({
           agentId,
           ...buildAgentSessionActionContext({
@@ -852,23 +868,8 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
           ...(toolCallTracking.isAwaitingEscalation()
             ? { awaitingEscalation: true }
             : {}),
+          ...(finalOutcome ? { finalStatus: finalOutcome.status } : {}),
         })
-
-        await toolCallTracking.flush()
-
-        const finalAssistantMessage = [...messages]
-          .reverse()
-          .find(message => message.role === "assistant")
-        const finalizeTask = finalizeAgentRequestTracking({
-          trackingHandle,
-          agentId,
-          sessionId,
-          toolCallsIncomplete: streamResult.toolCallsIncomplete,
-          unrecoveredToolFailures,
-          finalResponse: getAssistantMessageText(finalAssistantMessage),
-        })
-
-        await finalizeTask
       },
       consumeSseStream: consumeStream,
       sendReasoning: true,

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -213,6 +213,7 @@ const buildToolCallTrackingHandler = ({
   // before writing the terminal status.
   let chain = Promise.resolve()
   let needsInputUpdate = Promise.resolve()
+  let awaitingEscalation = false
 
   const onToolCallCompleted = ({
     toolName,
@@ -230,6 +231,7 @@ const buildToolCallTrackingHandler = ({
     }
     const outputStatus = (output as { status?: string } | undefined)?.status
     if (outputStatus === EscalateToolResultStatus.PENDING_APPROVAL) {
+      awaitingEscalation = true
       needsInputUpdate = needsInputUpdate.then(() =>
         sdk.ai.agentRequests
           .updateRequestStatus({
@@ -270,6 +272,7 @@ const buildToolCallTrackingHandler = ({
   return {
     onToolCallCompleted,
     flush: () => Promise.all([chain, needsInputUpdate]),
+    isAwaitingEscalation: () => awaitingEscalation,
   }
 }
 
@@ -646,6 +649,9 @@ export async function webhookChat({
       sessionId,
       requestId: trackingHandle?.requestId ?? requestId,
     }),
+    ...(toolCallTracking.isAwaitingEscalation()
+      ? { awaitingEscalation: true }
+      : {}),
   })
   const ragSources = run.getUsedKnowledgeSourcesMetadata()
 
@@ -843,6 +849,9 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
               trackingHandle?.requestId ??
               run.sessionLogIndexer.getRequestIds().at(-1),
           }),
+          ...(toolCallTracking.isAwaitingEscalation()
+            ? { awaitingEscalation: true }
+            : {}),
         })
 
         await toolCallTracking.flush()

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -226,12 +226,14 @@ const buildToolCallTrackingHandler = ({
     input?: unknown
     output?: unknown
   }) => {
-    if (!trackingHandle) {
-      return
-    }
     const outputStatus = (output as { status?: string } | undefined)?.status
     if (outputStatus === EscalateToolResultStatus.PENDING_APPROVAL) {
       awaitingEscalation = true
+    }
+    if (!trackingHandle) {
+      return
+    }
+    if (outputStatus === EscalateToolResultStatus.PENDING_APPROVAL) {
       needsInputUpdate = needsInputUpdate.then(() =>
         sdk.ai.agentRequests
           .updateRequestStatus({

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -55,6 +55,28 @@ import {
   resolvePreviewSessionId,
 } from "../../../sdk/workspace/ai/agentLogs/shared"
 
+const markAgentSessionActive = async ({
+  agentId,
+  sessionId,
+}: {
+  agentId: string
+  sessionId: string
+}) => {
+  await events.platformActions
+    .enqueuePlatformActionSessionLifecycle({
+      sourceType: "agent_session",
+      sourceId: sessionId,
+      signal: "active",
+    })
+    .catch(error => {
+      console.error("Failed to mark agent session active", {
+        agentId,
+        sessionId,
+        error,
+      })
+    })
+}
+
 const getGlobalUserId = (ctx: UserCtx) => {
   const userId = ctx.user?.globalId || ctx.user?.userId || ctx.user?._id
   if (!userId) {
@@ -523,6 +545,7 @@ export async function webhookChat({
     toolDisplayNames: run.toolDisplayNames,
   })
 
+  await markAgentSessionActive({ agentId, sessionId })
   const result = await run.stream({
     pendingToolCalls,
     unrecoveredToolFailures,
@@ -748,6 +771,7 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
       toolDisplayNames: run.toolDisplayNames,
     })
 
+    await markAgentSessionActive({ agentId, sessionId })
     const result = await run.stream({
       pendingToolCalls,
       unrecoveredToolFailures,

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -328,6 +328,40 @@ describe("resumeOperation", () => {
     })
   })
 
+  it("corrects a completed agent action to failed when finalizing the resume throws", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      mockApprovedRun("Approved and booked.")
+      const resolveFinalRequestOutcomeSpy = jest
+        .spyOn(sdk.ai.agentRequests, "resolveFinalRequestOutcome")
+        .mockRejectedValueOnce(new Error("DB unavailable"))
+
+      await expect(
+        resumeOperation({
+          doc: baseDoc({ requestId, response: { accepted: true } }),
+          escalationId: "esc_primary",
+          resolution: "resolved",
+          ctx: baseCtx,
+        })
+      ).rejects.toThrow("DB unavailable")
+
+      // The action was already emitted as completed before the failure -
+      // don't emit a second action (it would double-count actionCount),
+      // correct the materialized session status instead.
+      expect(aiAgentExecutedMock).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId })
+      )
+      expect(aiAgentFailedMock).not.toHaveBeenCalled()
+      expect(enqueueLifecycleMock).toHaveBeenCalledWith({
+        sourceType: "agent_session",
+        sourceId: "session_1",
+        signal: "failed",
+      })
+
+      resolveFinalRequestOutcomeSpy.mockRestore()
+    })
+  })
+
   it("reconstructs an automation user with its requester role", async () => {
     await config.doInContext(config.getProdWorkspaceId(), async () => {
       mockApprovedRun("Approved and created.")

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -247,6 +247,70 @@ describe("resumeOperation", () => {
     })
   })
 
+  it("emits a failed action when the resumed agent cannot be prepared", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      getOrThrowMock.mockRejectedValue(new Error("Agent unavailable"))
+
+      await expect(
+        resumeOperation({
+          doc: baseDoc({ requestId, response: { accepted: true } }),
+          escalationId: "esc_primary",
+          resolution: "resolved",
+          ctx: baseCtx,
+        })
+      ).rejects.toThrow("Agent unavailable")
+
+      expect(aiAgentFailedMock).toHaveBeenCalledWith({
+        agentId: "agent_1",
+        sourceType: "agent_session",
+        sourceId: "session_1",
+        sessionId: "session_1",
+        requestId,
+        reason: "error",
+        errorMessage: "Agent unavailable",
+      })
+    })
+  })
+
+  it("keeps a completed agent action when session log indexing fails", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      prepareAgentChatRunMock.mockResolvedValue({
+        toolDisplayNames: {},
+        sessionLogIndexer: {
+          index: jest
+            .fn()
+            .mockRejectedValue(new Error("Log index unavailable")),
+        },
+        stream: jest.fn().mockResolvedValue({
+          finishReason: Promise.resolve("stop"),
+          toUIMessageStream: () =>
+            (async function* () {
+              yield {
+                id: "",
+                role: "assistant",
+                parts: [{ type: "text", text: "Approved and booked." }],
+              }
+            })(),
+        }),
+      })
+      getOrThrowMock.mockResolvedValue({ _id: "agent_1" } as Agent)
+
+      await resumeOperation({
+        doc: baseDoc({ requestId, response: { accepted: true } }),
+        escalationId: "esc_primary",
+        resolution: "resolved",
+        ctx: baseCtx,
+      })
+
+      expect(aiAgentExecutedMock).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId })
+      )
+      expect(aiAgentFailedMock).not.toHaveBeenCalled()
+    })
+  })
+
   it("reconstructs an automation user with its requester role", async () => {
     await config.doInContext(config.getProdWorkspaceId(), async () => {
       mockApprovedRun("Approved and created.")

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -284,6 +284,11 @@ describe("resumeOperation", () => {
         ])
       )
       expect(request.status).toEqual("failed")
+      expect(enqueueLifecycleMock).toHaveBeenCalledWith({
+        sourceType: "agent_session",
+        sourceId: "session_1",
+        signal: "failed",
+      })
     })
   })
 

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -1,4 +1,4 @@
-import { context } from "@budibase/backend-core"
+import { context, events } from "@budibase/backend-core"
 import {
   Agent,
   DocumentType,
@@ -44,6 +44,11 @@ const prepareAgentChatRunMock = sdk.ai.agents.prepareAgentChatRun as jest.Mock
 const getOrThrowMock = sdk.ai.agents.getOrThrow as jest.Mock
 const recordEscalationResolvedMock = sdk.ai.agentRequests
   .recordEscalationResolved as jest.Mock
+const enqueueLifecycleMock = jest.spyOn(
+  events.platformActions,
+  "enqueuePlatformActionSessionLifecycle"
+)
+const aiAgentExecutedMock = jest.spyOn(events.action, "aiAgentExecuted")
 
 const mockApprovedRun = (text: string) => {
   prepareAgentChatRunMock.mockResolvedValue({
@@ -98,6 +103,8 @@ describe("resumeOperation", () => {
   beforeEach(async () => {
     prepareAgentChatRunMock.mockReset()
     getOrThrowMock.mockReset()
+    enqueueLifecycleMock.mockReset().mockResolvedValue(undefined)
+    aiAgentExecutedMock.mockReset()
     await config.newTenant()
   })
 
@@ -146,6 +153,33 @@ describe("resumeOperation", () => {
 
       const { getRequestId } = prepareAgentChatRunMock.mock.calls[0][0]
       expect(getRequestId()).toEqual(requestId)
+    })
+  })
+
+  it("marks an action-backed request session active and emits its resumed action", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      mockApprovedRun("Approved and booked.")
+
+      await resumeOperation({
+        doc: baseDoc({ requestId, response: { accepted: true } }),
+        escalationId: "esc_primary",
+        resolution: "resolved",
+        ctx: baseCtx,
+      })
+
+      expect(enqueueLifecycleMock).toHaveBeenCalledWith({
+        sourceType: "agent_session",
+        sourceId: "session_1",
+        signal: "active",
+      })
+      expect(aiAgentExecutedMock).toHaveBeenCalledWith({
+        agentId: "agent_1",
+        sourceType: "agent_session",
+        sourceId: "session_1",
+        sessionId: "session_1",
+        requestId,
+      })
     })
   })
 
@@ -291,14 +325,19 @@ describe("resumeOperation", () => {
 
   it("does nothing when the escalation has no associated request", async () => {
     await config.doInContext(config.getProdWorkspaceId(), async () => {
+      mockApprovedRun("Approved and booked.")
+
       await expect(
         resumeOperation({
-          doc: baseDoc(),
+          doc: baseDoc({ response: { accepted: true } }),
           escalationId: "esc_primary",
-          resolution: "expired",
+          resolution: "resolved",
           ctx: baseCtx,
         })
       ).resolves.toBeUndefined()
+
+      expect(enqueueLifecycleMock).not.toHaveBeenCalled()
+      expect(aiAgentExecutedMock).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -40,14 +40,26 @@ jest.mock("ai", () => {
   }
 })
 
+jest.mock("@budibase/backend-core", () => {
+  const actual = jest.requireActual("@budibase/backend-core")
+  return {
+    ...actual,
+    events: {
+      ...actual.events,
+      platformActions: {
+        ...actual.events.platformActions,
+        enqueuePlatformActionSessionLifecycle: jest.fn(),
+      },
+    },
+  }
+})
+
 const prepareAgentChatRunMock = sdk.ai.agents.prepareAgentChatRun as jest.Mock
 const getOrThrowMock = sdk.ai.agents.getOrThrow as jest.Mock
 const recordEscalationResolvedMock = sdk.ai.agentRequests
   .recordEscalationResolved as jest.Mock
-const enqueueLifecycleMock = jest.spyOn(
-  events.platformActions,
-  "enqueuePlatformActionSessionLifecycle"
-)
+const enqueueLifecycleMock = events.platformActions
+  .enqueuePlatformActionSessionLifecycle as jest.Mock
 const aiAgentExecutedMock = jest.spyOn(events.action, "aiAgentExecuted")
 const aiAgentFailedMock = jest.spyOn(events.action, "aiAgentFailed")
 

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -187,6 +187,11 @@ describe("resumeOperation", () => {
         sourceId: "session_1",
         signal: "active",
       })
+      expect(enqueueLifecycleMock).toHaveBeenCalledWith({
+        sourceType: "agent_session",
+        sourceId: "session_1",
+        signal: "completed",
+      })
       expect(aiAgentExecutedMock).toHaveBeenCalledWith({
         agentId: "agent_1",
         sourceType: "agent_session",

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -49,6 +49,7 @@ const enqueueLifecycleMock = jest.spyOn(
   "enqueuePlatformActionSessionLifecycle"
 )
 const aiAgentExecutedMock = jest.spyOn(events.action, "aiAgentExecuted")
+const aiAgentFailedMock = jest.spyOn(events.action, "aiAgentFailed")
 
 const mockApprovedRun = (text: string) => {
   prepareAgentChatRunMock.mockResolvedValue({
@@ -105,6 +106,7 @@ describe("resumeOperation", () => {
     getOrThrowMock.mockReset()
     enqueueLifecycleMock.mockReset().mockResolvedValue(undefined)
     aiAgentExecutedMock.mockReset()
+    aiAgentFailedMock.mockReset()
     await config.newTenant()
   })
 
@@ -206,6 +208,42 @@ describe("resumeOperation", () => {
         ])
       )
       expect(prepareAgentChatRunMock).not.toHaveBeenCalled()
+    })
+  })
+
+  it("emits a failed action when the resumed agent stream fails", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      prepareAgentChatRunMock.mockResolvedValue({
+        toolDisplayNames: {},
+        sessionLogIndexer: { index: jest.fn().mockResolvedValue(undefined) },
+        stream: jest.fn().mockRejectedValue(new Error("Model unavailable")),
+      })
+      getOrThrowMock.mockResolvedValue({ _id: "agent_1" } as Agent)
+
+      await expect(
+        resumeOperation({
+          doc: baseDoc({ requestId, response: { accepted: true } }),
+          escalationId: "esc_primary",
+          resolution: "resolved",
+          ctx: baseCtx,
+        })
+      ).rejects.toThrow("Model unavailable")
+
+      expect(enqueueLifecycleMock).toHaveBeenCalledWith({
+        sourceType: "agent_session",
+        sourceId: "session_1",
+        signal: "active",
+      })
+      expect(aiAgentFailedMock).toHaveBeenCalledWith({
+        agentId: "agent_1",
+        sourceType: "agent_session",
+        sourceId: "session_1",
+        sessionId: "session_1",
+        requestId,
+        reason: "error",
+        errorMessage: "Model unavailable",
+      })
     })
   })
 
@@ -384,7 +422,7 @@ describe("resumeOperation", () => {
         sessionLogIndexer: { index: jest.fn().mockResolvedValue(undefined) },
         stream: jest
           .fn()
-          .mockImplementation(async ({ onToolCalls, onToolCallCompleted }) => {
+          .mockImplementation(async ({ onToolCallCompleted }) => {
             const escalateTool = createEscalateTool({
               agentId: "agent_1",
               operationId: "op_1",
@@ -420,7 +458,6 @@ describe("resumeOperation", () => {
               context: {},
             })
 
-            onToolCalls?.([ESCALATE_TOOL_NAME])
             await onToolCallCompleted?.({
               toolName: ESCALATE_TOOL_NAME,
               status: "success",
@@ -473,6 +510,13 @@ describe("resumeOperation", () => {
 
       // The new escalation is still pending, so the request must not close.
       expect(request.status).toEqual("needs_input")
+      expect(aiAgentExecutedMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "agent_1",
+          requestId,
+          awaitingEscalation: true,
+        })
+      )
     })
   })
 })

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -414,6 +414,41 @@ describe("resumeOperation", () => {
     })
   })
 
+  it("keeps the session waiting after an approved turn while another escalation is pending", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      await sdk.ai.agentRequests.updateRequestStatus({
+        requestId,
+        status: "needs_input",
+      })
+      await context.getWorkspaceDB().put(
+        baseDoc({
+          _id: `${DocumentType.ESCALATION_CONTEXT}${SEPARATOR}esc_other`,
+          requestId,
+        })
+      )
+      mockApprovedRun("Approved and booked.")
+
+      await resumeOperation({
+        doc: baseDoc({ requestId, response: { accepted: true } }),
+        escalationId: "esc_primary",
+        resolution: "resolved",
+        ctx: baseCtx,
+      })
+
+      const [request] =
+        await sdk.ai.agentRequests.fetchRequestsByAgent("agent_1")
+      expect(request.status).toBe("needs_input")
+      expect(aiAgentExecutedMock).toHaveBeenCalledTimes(1)
+      expect(aiAgentFailedMock).not.toHaveBeenCalled()
+      expect(enqueueLifecycleMock).toHaveBeenLastCalledWith({
+        sourceType: "agent_session",
+        sourceId: "session_1",
+        signal: "waiting",
+      })
+    })
+  })
+
   it("records escalation_resolved with outcome expired", async () => {
     await config.doInContext(config.getProdWorkspaceId(), async () => {
       const { requestId } = (await createRequest())!

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -32,6 +32,10 @@ jest.mock("../sdk/workspace/ai/agentRequests", () => {
   }
 })
 
+jest.mock("../sdk/workspace/escalations", () => ({
+  ...jest.requireActual("../sdk/workspace/escalations"),
+}))
+
 jest.mock("ai", () => {
   const actual = jest.requireActual("ai")
   return {

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -336,29 +336,31 @@ describe("resumeOperation", () => {
         .spyOn(sdk.ai.agentRequests, "resolveFinalRequestOutcome")
         .mockRejectedValueOnce(new Error("DB unavailable"))
 
-      await expect(
-        resumeOperation({
-          doc: baseDoc({ requestId, response: { accepted: true } }),
-          escalationId: "esc_primary",
-          resolution: "resolved",
-          ctx: baseCtx,
+      try {
+        await expect(
+          resumeOperation({
+            doc: baseDoc({ requestId, response: { accepted: true } }),
+            escalationId: "esc_primary",
+            resolution: "resolved",
+            ctx: baseCtx,
+          })
+        ).rejects.toThrow("DB unavailable")
+
+        // The action was already emitted as completed before the failure -
+        // don't emit a second action (it would double-count actionCount),
+        // correct the materialized session status instead.
+        expect(aiAgentExecutedMock).toHaveBeenCalledWith(
+          expect.objectContaining({ requestId })
+        )
+        expect(aiAgentFailedMock).not.toHaveBeenCalled()
+        expect(enqueueLifecycleMock).toHaveBeenCalledWith({
+          sourceType: "agent_session",
+          sourceId: "session_1",
+          signal: "failed",
         })
-      ).rejects.toThrow("DB unavailable")
-
-      // The action was already emitted as completed before the failure -
-      // don't emit a second action (it would double-count actionCount),
-      // correct the materialized session status instead.
-      expect(aiAgentExecutedMock).toHaveBeenCalledWith(
-        expect.objectContaining({ requestId })
-      )
-      expect(aiAgentFailedMock).not.toHaveBeenCalled()
-      expect(enqueueLifecycleMock).toHaveBeenCalledWith({
-        sourceType: "agent_session",
-        sourceId: "session_1",
-        signal: "failed",
-      })
-
-      resolveFinalRequestOutcomeSpy.mockRestore()
+      } finally {
+        resolveFinalRequestOutcomeSpy.mockRestore()
+      }
     })
   })
 

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -451,6 +451,50 @@ describe("resumeOperation", () => {
     })
   })
 
+  it("preserves the request when the session status escalation lookup fails", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      await sdk.ai.agentRequests.updateRequestStatus({
+        requestId,
+        status: "needs_input",
+      })
+      mockApprovedRun("Approved and booked.")
+      const outcomeSpy = jest
+        .spyOn(sdk.ai.agentRequests, "resolveFinalRequestOutcome")
+        .mockResolvedValueOnce(undefined)
+      const lookupSpy = jest
+        .spyOn(sdk.escalations, "listContextDocs")
+        .mockRejectedValueOnce(new Error("DB unavailable"))
+
+      try {
+        await resumeOperation({
+          doc: baseDoc({ requestId, response: { accepted: true } }),
+          escalationId: "esc_primary",
+          resolution: "resolved",
+          ctx: baseCtx,
+        })
+
+        const [request] =
+          await sdk.ai.agentRequests.fetchRequestsByAgent("agent_1")
+        expect(request.status).toBe("needs_input")
+        expect(aiAgentExecutedMock).toHaveBeenCalledTimes(1)
+        expect(aiAgentFailedMock).not.toHaveBeenCalled()
+        expect(enqueueLifecycleMock.mock.calls).toEqual([
+          [
+            {
+              sourceType: "agent_session",
+              sourceId: "session_1",
+              signal: "active",
+            },
+          ],
+        ])
+      } finally {
+        lookupSpy.mockRestore()
+        outcomeSpy.mockRestore()
+      }
+    })
+  })
+
   it("records escalation_resolved with outcome expired", async () => {
     await config.doInContext(config.getProdWorkspaceId(), async () => {
       const { requestId } = (await createRequest())!

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -798,7 +798,15 @@ export async function resumeOperation({
   } catch (error) {
     await toolCallChain
     await needsInputUpdate
-    emitAgentResumeFailure(error)
+    // A failure after the terminal action already fired (e.g. persisting the
+    // resume result, or judging the final outcome) can't emit a second action
+    // without double-counting actionCount - correct the already-materialized
+    // session status instead.
+    if (hasEmittedTerminalAction) {
+      await updatePlatformActionSessionStatus("failed")
+    } else {
+      emitAgentResumeFailure(error)
+    }
     await markEscalationRequestResolved({
       status: "failed",
       error: error instanceof Error ? error.message : String(error),

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -20,6 +20,7 @@ import {
   EscalationSource,
   EscalateToolResultStatus,
   PendingToolCall,
+  PlatformActionContainerStatus,
   SEPARATOR,
   SuspendedOperationContext,
   type AgentExecutionContext,
@@ -408,6 +409,28 @@ export async function resumeOperation({
       })
   }
 
+  const updatePlatformActionSessionStatus = async (
+    signal: PlatformActionContainerStatus
+  ) => {
+    if (!doc.requestId) {
+      return
+    }
+    await events.platformActions
+      .enqueuePlatformActionSessionLifecycle({
+        sourceType: "agent_session",
+        sourceId: ctx.sessionId,
+        signal,
+      })
+      .catch(error => {
+        console.error("Failed to update agent session status on escalation", {
+          escalationId,
+          agentId: ctx.agentId,
+          signal,
+          error,
+        })
+      })
+  }
+
   if (outcome !== "approved") {
     const text =
       outcome === "expired"
@@ -429,6 +452,7 @@ export async function resumeOperation({
             status: "failed",
             error: "Escalation expired without a response",
           })
+          await updatePlatformActionSessionStatus("failed")
         }
       } else {
         // A rejection is a human decision, not automatically a failure, let
@@ -444,6 +468,7 @@ export async function resumeOperation({
         })
         if (judged) {
           await markEscalationRequestResolved(judged)
+          await updatePlatformActionSessionStatus(judged.status)
         }
       }
     }
@@ -500,6 +525,7 @@ export async function resumeOperation({
       await persistResumeResult(escalationId, textMessage(text))
       await deliverOperationResult(ctx, text)
       await markEscalationRequestResolved({ status: "failed", error: text })
+      await updatePlatformActionSessionStatus("failed")
       return
     }
     if (executed.failed) {
@@ -619,24 +645,7 @@ export async function resumeOperation({
   let needsInputUpdate = Promise.resolve()
   let awaitingEscalation = false
 
-  if (doc.requestId) {
-    await events.platformActions
-      .enqueuePlatformActionSessionLifecycle({
-        sourceType: "agent_session",
-        sourceId: ctx.sessionId,
-        signal: "active",
-      })
-      .catch(error => {
-        console.error(
-          "Failed to mark agent session active on escalation resume",
-          {
-            escalationId,
-            agentId: ctx.agentId,
-            error,
-          }
-        )
-      })
-  }
+  await updatePlatformActionSessionStatus("active")
 
   try {
     const result = await run.stream({

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -792,6 +792,7 @@ export async function resumeOperation({
       })
       if (judged) {
         await markEscalationRequestResolved(judged)
+        await updatePlatformActionSessionStatus(judged.status)
       }
     }
   } catch (error) {

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -475,179 +475,196 @@ export async function resumeOperation({
     return
   }
 
-  const agent = await sdk.ai.agents.getOrThrow(ctx.agentId)
-
-  const resumeUserId = ctx.userId ?? "escalation-resume"
-
-  // Linked user check. Retrieve or generate transient. The current user state
-  // determines tool authorization when the operation resumes.
-  let user: ContextUser
-  try {
-    user = await getFullUser(resumeUserId)
-  } catch {
-    const roleId = resumeUserId.startsWith("automation:")
-      ? ctx.requester?.executorRole
-      : undefined
-    user = {
-      _id: resumeUserId,
-      globalId: resumeUserId,
-      userId: resumeUserId,
-      tenantId: context.getTenantId(),
-      email: `${encodeURIComponent(resumeUserId)}@escalation.budibase.local`,
-      roleId,
-    }
-  }
-
-  // System prompt, not a user message, so the model doesn't distrust the
-  // approval as user input.
-  let approvalInstructions: string
-  let messages: ModelMessage[]
-  let storedCallFailure: string | undefined
-  let executedApproval: { toolName: string } | undefined
-  // recordToolCall awaits an LLM summary internally - chain the calls in the
-  // background (preserving completion order) and flush the tail (await
-  // toolCallChain below) before writing the terminal status.
   let toolCallChain = Promise.resolve()
-
-  if (ctx.pendingToolCall) {
-    // Gate-raised escalation (AI_TOOL_ESCALATION): the frozen call is
-    // executed server-side, exactly as approved - the model only narrates
-    // the injected result.
-    const executed = await executeApprovedToolCall({
-      agent,
-      ctx,
-      appId: doc.appId,
-      user,
-      pending: ctx.pendingToolCall,
-    })
-    if (!executed) {
-      const text = `This request was approved, but the "${ctx.pendingToolCall.toolName}" action is no longer available so it could not be carried out.`
-      await persistResumeResult(escalationId, textMessage(text))
-      await deliverOperationResult(ctx, text)
-      await markEscalationRequestResolved({ status: "failed", error: text })
-      await updatePlatformActionSessionStatus("failed")
-      return
-    }
-    if (executed.failed) {
-      storedCallFailure = executed.toolName
-    }
-    if (doc.requestId) {
-      const requestId = doc.requestId
-      toolCallChain = toolCallChain.then(() =>
-        sdk.ai.agentRequests
-          .recordToolCall({
-            requestId,
-            agentId: ctx.agentId,
-            sessionId: ctx.sessionId,
-            toolName: executed.toolName,
-            status: executed.failed ? "error" : "success",
-            input: ctx.pendingToolCall!.args,
-            output: executed.output,
-          })
-          .catch(error => {
-            console.error(
-              "Failed to record approved tool call on escalation resume",
-              { escalationId, agentId: ctx.agentId, error }
-            )
-          })
-      )
-    }
-    approvalInstructions =
-      "ESCALATION APPROVAL: The user's request in this conversation was " +
-      "APPROVED by an authorised human reviewer and the approved action has " +
-      "already been executed - its tool result is included in this " +
-      "conversation. Do not run that tool again for this request and do not " +
-      "escalate it again. Report the outcome truthfully: if the result shows " +
-      "an error, say the action failed and why - never imply it succeeded. " +
-      "A genuinely new, different request may still be escalated separately."
-    messages = [...ctx.messages, ...executed.messages]
-    executedApproval = { toolName: executed.toolName }
-  } else {
-    // LEGACY: free-form escalate-tool escalation - nothing has executed, the
-    // model re-performs the action itself. Kept only to drain in-flight
-    // escalations from ESCALATION-flag tenants; deleted with the escalate
-    // surface in the tail PR.
-    approvalInstructions =
-      "ESCALATION APPROVAL: The user's request in this conversation has been " +
-      "reviewed and APPROVED by an authorised human reviewer. This specific " +
-      "request is already approved - do not escalate or ask for approval again " +
-      "for it. Begin your reply by briefly confirming the request was approved, " +
-      "then CARRY OUT the user's original request: take the action they asked " +
-      "for using your available tools. Actually attempt it. If you cannot " +
-      "complete it because a required tool or capability is missing, say " +
-      "specifically what is missing and that the request could not be " +
-      "completed - never imply it was done when it was not. If doing so " +
-      "surfaces a genuinely new request that needs its own human sign-off, you " +
-      "may escalate that separately."
-
-    // Add in messages to confirm that the request is approved.
-    const escalateCallId = `esc_call_${escalationId}`
-    messages = [
-      ...ctx.messages,
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool-call",
-            toolCallId: escalateCallId,
-            toolName: "escalate",
-            input: {
-              title: doc.title ?? "Escalation",
-              summary: doc.summary ?? "",
-              reason: "Human approval required",
-            },
-          },
-        ],
-      },
-      {
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: escalateCallId,
-            toolName: "escalate",
-            output: {
-              type: "json",
-              value: {
-                status: "approved",
-                decision: "approved",
-                note:
-                  "An authorised human reviewer approved this request. Proceed " +
-                  "to fulfil it and confirm to the user. Do not escalate this " +
-                  "same request again - a genuinely new, different request " +
-                  "can still be escalated separately.",
-              },
-            },
-          },
-        ],
-      },
-    ]
-  }
-
-  const run = await sdk.ai.agents.prepareAgentChatRun({
-    agent,
-    agentId: ctx.agentId,
-    modelMessages: messages,
-    errorLabel: "escalation resume",
-    sessionId: ctx.sessionId,
-    user,
-    operationId: ctx.operationId,
-    additionalInstructions: approvalInstructions,
-    getRequestId: () => doc.requestId,
-    executedApproval,
-  })
-
-  const pendingToolCalls = new Set<string>()
-  const unrecoveredToolFailures = new Set<string>()
-  if (storedCallFailure) {
-    unrecoveredToolFailures.add(storedCallFailure)
-  }
   let needsInputUpdate = Promise.resolve()
   let awaitingEscalation = false
+  let hasEmittedTerminalAction = false
 
-  await updatePlatformActionSessionStatus("active")
+  const emitAgentResumeFailure = (error: unknown) => {
+    if (!doc.requestId || hasEmittedTerminalAction) {
+      return
+    }
+    events.action.aiAgentFailed({
+      agentId: ctx.agentId,
+      sourceType: "agent_session",
+      sourceId: ctx.sessionId,
+      sessionId: ctx.sessionId,
+      requestId: doc.requestId,
+      reason: ActionFailureReason.ERROR,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    })
+    hasEmittedTerminalAction = true
+  }
 
   try {
+    const agent = await sdk.ai.agents.getOrThrow(ctx.agentId)
+
+    const resumeUserId = ctx.userId ?? "escalation-resume"
+
+    // Linked user check. Retrieve or generate transient. The current user state
+    // determines tool authorization when the operation resumes.
+    let user: ContextUser
+    try {
+      user = await getFullUser(resumeUserId)
+    } catch {
+      const roleId = resumeUserId.startsWith("automation:")
+        ? ctx.requester?.executorRole
+        : undefined
+      user = {
+        _id: resumeUserId,
+        globalId: resumeUserId,
+        userId: resumeUserId,
+        tenantId: context.getTenantId(),
+        email: `${encodeURIComponent(resumeUserId)}@escalation.budibase.local`,
+        roleId,
+      }
+    }
+
+    // System prompt, not a user message, so the model doesn't distrust the
+    // approval as user input.
+    let approvalInstructions: string
+    let messages: ModelMessage[]
+    let storedCallFailure: string | undefined
+    let executedApproval: { toolName: string } | undefined
+    // recordToolCall awaits an LLM summary internally - chain the calls in the
+    // background (preserving completion order) and flush the tail (await
+    // toolCallChain below) before writing the terminal status.
+
+    if (ctx.pendingToolCall) {
+      // Gate-raised escalation (AI_TOOL_ESCALATION): the frozen call is
+      // executed server-side, exactly as approved - the model only narrates
+      // the injected result.
+      const executed = await executeApprovedToolCall({
+        agent,
+        ctx,
+        appId: doc.appId,
+        user,
+        pending: ctx.pendingToolCall,
+      })
+      if (!executed) {
+        const text = `This request was approved, but the "${ctx.pendingToolCall.toolName}" action is no longer available so it could not be carried out.`
+        await persistResumeResult(escalationId, textMessage(text))
+        await deliverOperationResult(ctx, text)
+        await markEscalationRequestResolved({ status: "failed", error: text })
+        emitAgentResumeFailure(new Error(text))
+        return
+      }
+      if (executed.failed) {
+        storedCallFailure = executed.toolName
+      }
+      if (doc.requestId) {
+        const requestId = doc.requestId
+        toolCallChain = toolCallChain.then(() =>
+          sdk.ai.agentRequests
+            .recordToolCall({
+              requestId,
+              agentId: ctx.agentId,
+              sessionId: ctx.sessionId,
+              toolName: executed.toolName,
+              status: executed.failed ? "error" : "success",
+              input: ctx.pendingToolCall!.args,
+              output: executed.output,
+            })
+            .catch(error => {
+              console.error(
+                "Failed to record approved tool call on escalation resume",
+                { escalationId, agentId: ctx.agentId, error }
+              )
+            })
+        )
+      }
+      approvalInstructions =
+        "ESCALATION APPROVAL: The user's request in this conversation was " +
+        "APPROVED by an authorised human reviewer and the approved action has " +
+        "already been executed - its tool result is included in this " +
+        "conversation. Do not run that tool again for this request and do not " +
+        "escalate it again. Report the outcome truthfully: if the result shows " +
+        "an error, say the action failed and why - never imply it succeeded. " +
+        "A genuinely new, different request may still be escalated separately."
+      messages = [...ctx.messages, ...executed.messages]
+      executedApproval = { toolName: executed.toolName }
+    } else {
+      // LEGACY: free-form escalate-tool escalation - nothing has executed, the
+      // model re-performs the action itself. Kept only to drain in-flight
+      // escalations from ESCALATION-flag tenants; deleted with the escalate
+      // surface in the tail PR.
+      approvalInstructions =
+        "ESCALATION APPROVAL: The user's request in this conversation has been " +
+        "reviewed and APPROVED by an authorised human reviewer. This specific " +
+        "request is already approved - do not escalate or ask for approval again " +
+        "for it. Begin your reply by briefly confirming the request was approved, " +
+        "then CARRY OUT the user's original request: take the action they asked " +
+        "for using your available tools. Actually attempt it. If you cannot " +
+        "complete it because a required tool or capability is missing, say " +
+        "specifically what is missing and that the request could not be " +
+        "completed - never imply it was done when it was not. If doing so " +
+        "surfaces a genuinely new request that needs its own human sign-off, you " +
+        "may escalate that separately."
+
+      // Add in messages to confirm that the request is approved.
+      const escalateCallId = `esc_call_${escalationId}`
+      messages = [
+        ...ctx.messages,
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: escalateCallId,
+              toolName: "escalate",
+              input: {
+                title: doc.title ?? "Escalation",
+                summary: doc.summary ?? "",
+                reason: "Human approval required",
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: escalateCallId,
+              toolName: "escalate",
+              output: {
+                type: "json",
+                value: {
+                  status: "approved",
+                  decision: "approved",
+                  note:
+                    "An authorised human reviewer approved this request. Proceed " +
+                    "to fulfil it and confirm to the user. Do not escalate this " +
+                    "same request again - a genuinely new, different request " +
+                    "can still be escalated separately.",
+                },
+              },
+            },
+          ],
+        },
+      ]
+    }
+
+    const run = await sdk.ai.agents.prepareAgentChatRun({
+      agent,
+      agentId: ctx.agentId,
+      modelMessages: messages,
+      errorLabel: "escalation resume",
+      sessionId: ctx.sessionId,
+      user,
+      operationId: ctx.operationId,
+      additionalInstructions: approvalInstructions,
+      getRequestId: () => doc.requestId,
+      executedApproval,
+    })
+
+    const pendingToolCalls = new Set<string>()
+    const unrecoveredToolFailures = new Set<string>()
+    if (storedCallFailure) {
+      unrecoveredToolFailures.add(storedCallFailure)
+    }
+    await updatePlatformActionSessionStatus("active")
+
     const result = await run.stream({
       pendingToolCalls,
       unrecoveredToolFailures,
@@ -718,7 +735,13 @@ export async function resumeOperation({
 
     // Flush the resumed turn into the session-log index (requestIds collected
     // during the drain) so agent-logs reflect the post-approval turn.
-    await run.sessionLogIndexer.index()
+    await run.sessionLogIndexer.index().catch(error => {
+      console.error("Failed to index agent session after escalation resume", {
+        escalationId,
+        agentId: ctx.agentId,
+        error,
+      })
+    })
 
     if (doc.requestId) {
       events.action.aiAgentExecuted({
@@ -729,6 +752,7 @@ export async function resumeOperation({
         requestId: doc.requestId,
         ...(awaitingEscalation ? { awaitingEscalation: true } : {}),
       })
+      hasEmittedTerminalAction = true
     }
 
     const text = assistantMessage ? messageText(assistantMessage) : ""
@@ -773,17 +797,7 @@ export async function resumeOperation({
   } catch (error) {
     await toolCallChain
     await needsInputUpdate
-    if (doc.requestId) {
-      events.action.aiAgentFailed({
-        agentId: ctx.agentId,
-        sourceType: "agent_session",
-        sourceId: ctx.sessionId,
-        sessionId: ctx.sessionId,
-        requestId: doc.requestId,
-        reason: ActionFailureReason.ERROR,
-        errorMessage: error instanceof Error ? error.message : String(error),
-      })
-    }
+    emitAgentResumeFailure(error)
     await markEscalationRequestResolved({
       status: "failed",
       error: error instanceof Error ? error.message : String(error),

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -6,18 +6,19 @@ import {
   type ModelMessage,
   type UIMessage,
 } from "ai"
-import { context, queue, roles, utils } from "@budibase/backend-core"
+import { context, events, queue, roles, utils } from "@budibase/backend-core"
 import {
+  ActionFailureReason,
   Agent,
   AgentChannelProvider,
   AutomationActionStepId,
   ContextUser,
   DocumentType,
-  ESCALATE_TOOL_NAME,
   EscalationContextDoc,
   EscalationNotificationDoc,
   EscalationRecipient,
   EscalationSource,
+  EscalateToolResultStatus,
   PendingToolCall,
   SEPARATOR,
   SuspendedOperationContext,
@@ -616,14 +617,39 @@ export async function resumeOperation({
     unrecoveredToolFailures.add(storedCallFailure)
   }
   let needsInputUpdate = Promise.resolve()
+  let awaitingEscalation = false
+
+  if (doc.requestId) {
+    await events.platformActions
+      .enqueuePlatformActionSessionLifecycle({
+        sourceType: "agent_session",
+        sourceId: ctx.sessionId,
+        signal: "active",
+      })
+      .catch(error => {
+        console.error(
+          "Failed to mark agent session active on escalation resume",
+          {
+            escalationId,
+            agentId: ctx.agentId,
+            error,
+          }
+        )
+      })
+  }
 
   try {
     const result = await run.stream({
       pendingToolCalls,
       unrecoveredToolFailures,
-      onToolCalls: toolNames => {
+      onToolCallCompleted: ({ toolName, status, input, output }) => {
         const requestId = doc.requestId
-        if (requestId && toolNames.includes(ESCALATE_TOOL_NAME)) {
+        if (!requestId) {
+          return
+        }
+        const outputStatus = (output as { status?: string } | undefined)?.status
+        if (outputStatus === EscalateToolResultStatus.PENDING_APPROVAL) {
+          awaitingEscalation = true
           needsInputUpdate = needsInputUpdate.then(() =>
             sdk.ai.agentRequests
               .updateRequestStatus({ requestId, status: "needs_input" })
@@ -634,12 +660,6 @@ export async function resumeOperation({
                 )
               })
           )
-        }
-      },
-      onToolCallCompleted: ({ toolName, status, input, output }) => {
-        const requestId = doc.requestId
-        if (!requestId) {
-          return
         }
         toolCallChain = toolCallChain.then(() =>
           sdk.ai.agentRequests
@@ -691,6 +711,17 @@ export async function resumeOperation({
     // during the drain) so agent-logs reflect the post-approval turn.
     await run.sessionLogIndexer.index()
 
+    if (doc.requestId) {
+      events.action.aiAgentExecuted({
+        agentId: ctx.agentId,
+        sourceType: "agent_session",
+        sourceId: ctx.sessionId,
+        sessionId: ctx.sessionId,
+        requestId: doc.requestId,
+        ...(awaitingEscalation ? { awaitingEscalation: true } : {}),
+      })
+    }
+
     const text = assistantMessage ? messageText(assistantMessage) : ""
     await persistResumeResult(
       escalationId,
@@ -733,6 +764,17 @@ export async function resumeOperation({
   } catch (error) {
     await toolCallChain
     await needsInputUpdate
+    if (doc.requestId) {
+      events.action.aiAgentFailed({
+        agentId: ctx.agentId,
+        sourceType: "agent_session",
+        sourceId: ctx.sessionId,
+        sessionId: ctx.sessionId,
+        requestId: doc.requestId,
+        reason: ActionFailureReason.ERROR,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      })
+    }
     await markEscalationRequestResolved({
       status: "failed",
       error: error instanceof Error ? error.message : String(error),

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -501,8 +501,8 @@ export async function resumeOperation({
 
     const resumeUserId = ctx.userId ?? "escalation-resume"
 
-    // Linked user check. Retrieve or generate transient. The current user state
-    // determines tool authorization when the operation resumes.
+    // Load the user for tool authorization when resuming.
+    // If loading fails, construct an in-memory user context.
     let user: ContextUser
     try {
       user = await getFullUser(resumeUserId)

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -794,12 +794,24 @@ export async function resumeOperation({
         await markEscalationRequestResolved(judged)
         await updatePlatformActionSessionStatus(judged.status)
       } else {
-        const pendingEscalations = await sdk.escalations.listContextDocs({
-          requestId: doc.requestId,
-          resolution: "pending",
-        })
-        if (pendingEscalations.length > 0) {
-          await updatePlatformActionSessionStatus("waiting")
+        try {
+          const pendingEscalations = await sdk.escalations.listContextDocs({
+            requestId: doc.requestId,
+            resolution: "pending",
+          })
+          if (pendingEscalations.length > 0) {
+            await updatePlatformActionSessionStatus("waiting")
+          }
+        } catch (error) {
+          console.error(
+            "Failed to check pending escalations for session status",
+            {
+              escalationId,
+              agentId: ctx.agentId,
+              requestId: doc.requestId,
+              error,
+            }
+          )
         }
       }
     }

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -793,6 +793,14 @@ export async function resumeOperation({
       if (judged) {
         await markEscalationRequestResolved(judged)
         await updatePlatformActionSessionStatus(judged.status)
+      } else {
+        const pendingEscalations = await sdk.escalations.listContextDocs({
+          requestId: doc.requestId,
+          resolution: "pending",
+        })
+        if (pendingEscalations.length > 0) {
+          await updatePlatformActionSessionStatus("waiting")
+        }
       }
     }
   } catch (error) {

--- a/packages/types/src/sdk/events/action.ts
+++ b/packages/types/src/sdk/events/action.ts
@@ -41,6 +41,7 @@ export interface ActionAiAgentExecuted extends BaseEvent, ActionSourceContext {
   sessionId: string
   requestId?: string
   awaitingEscalation?: boolean
+  finalStatus?: "completed" | "failed"
 }
 
 export interface ActionAiAgentFailed extends BaseEvent, ActionSourceContext {

--- a/packages/types/src/sdk/events/action.ts
+++ b/packages/types/src/sdk/events/action.ts
@@ -40,6 +40,7 @@ export interface ActionAiAgentExecuted extends BaseEvent, ActionSourceContext {
   agentId: string
   sessionId: string
   requestId?: string
+  awaitingEscalation?: boolean
 }
 
 export interface ActionAiAgentFailed extends BaseEvent, ActionSourceContext {

--- a/packages/types/src/sdk/platformActions/index.ts
+++ b/packages/types/src/sdk/platformActions/index.ts
@@ -48,14 +48,11 @@ export interface PlatformActionSessionIndexDoc
   completedAt?: string
 }
 
-export const PLATFORM_ACTION_OUTCOMES = ["success", "failure"] as const
-
-export type PlatformActionOutcome = (typeof PLATFORM_ACTION_OUTCOMES)[number]
-
 export interface PlatformActionSessionIndexJob extends ActionSourceContext {
   workspaceId: string
   platformActionId: string
   eventName: string
-  outcome: PlatformActionOutcome
+  incrementsActionCount: boolean
+  signal: PlatformActionContainerStatus
   timestamp: string
 }

--- a/packages/types/src/sdk/platformActions/index.ts
+++ b/packages/types/src/sdk/platformActions/index.ts
@@ -44,6 +44,7 @@ export interface PlatformActionSessionIndexDoc
   triggeredById?: string
   triggeredByLabel?: string
   startedAt: string
+  statusUpdatedAt: string
   updatedAt: string
   completedAt?: string
 }

--- a/packages/types/src/sdk/platformActions/index.ts
+++ b/packages/types/src/sdk/platformActions/index.ts
@@ -50,8 +50,7 @@ export interface PlatformActionSessionIndexDoc
 
 export interface PlatformActionSessionIndexJob extends ActionSourceContext {
   workspaceId: string
-  platformActionId: string
-  eventName: string
+  indexId: string
   incrementsActionCount: boolean
   signal: PlatformActionContainerStatus
   timestamp: string

--- a/packages/types/src/sdk/platformActions/index.ts
+++ b/packages/types/src/sdk/platformActions/index.ts
@@ -44,7 +44,7 @@ export interface PlatformActionSessionIndexDoc
   triggeredById?: string
   triggeredByLabel?: string
   startedAt: string
-  statusUpdatedAt: string
+  statusUpdatedAt?: string
   updatedAt: string
   completedAt?: string
 }


### PR DESCRIPTION
## Addresses
- https://github.com/Budibase/budibase/issues/18586

## Description
Implements `status-inference` for the Actions/platform-action work: agent-session `PlatformActionSession` documents now track a real container status (`active`, `waiting`, `completed`, `failed`) instead of the naive completed/failed-only materialization from the previous PR.

## Screen recording

https://github.com/user-attachments/assets/791ae0ea-7ebe-4c46-814c-5deb8bec7e39

## Launchcontrol

_Internal groundwork for the upcoming Activity "Actions" tab: agent sessions awaiting human approval or actively running now show the correct status instead of always appearing completed/failed._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agent-session `PlatformActionSession` documents now track `active`, `waiting`, `completed`, or `failed` instead of only materializing as completed or failed. This lets the Actions tab distinguish running sessions, pending approvals, and terminal outcomes.

**Status inference**
- Status transitions follow `statusUpdatedAt`; equal timestamps prefer `failed`, preventing out-of-order Bull jobs from replacing newer status.
- Lifecycle signals update existing sessions without incrementing `actionCount` and cannot create a session index by themselves.
- `ActionAiAgentExecuted` carries optional escalation and final-status data, so only genuine pending approvals become `waiting`.
- Legacy session docs without `statusUpdatedAt` fall back to `completedAt` or `startedAt` when applying new signals.

**Escalation resume flow**
- Agent sessions emit `active` before the stream on both normal chats and approved escalations, while rejected or expired resolutions update the session from the judged outcome.
- Approved turns that leave another escalation pending emit `waiting` instead of `completed`; if that pending-escalation check fails, the session stays `active` and the request stays pending.
- Escalations without an associated request emit no lifecycle status or action.
- Resume failures, including unavailable agents, stream errors, and missing tools, emit one failed action reliably; failures after that action already fired send a `failed` lifecycle signal instead of emitting a second action.
- Fixed `queue.spec.ts` test isolation: replaced the broken getter mock with a partial `jest.mock` and restore spies after each resume test.

<sup>Written for commit 686f8f70fd07859b96d3c533f53b9bd09f7bcade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



