### PR TITLE
[BUDI-19633] Restore published snippet access

### DIFF
--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -517,14 +517,9 @@ export async function fetchAppPackage(
       : undefined
   }
 
-  const clientApplication = {
-    ...application,
-    snippets: isBuilder ? application.snippets : undefined,
-  }
-
   ctx.body = {
     application: {
-      ...clientApplication,
+      ...application,
       upgradableVersion: envCore.VERSION,
     },
     licenseType: license?.plan.type || PlanType.FREE,

--- a/packages/server/src/api/routes/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/tests/workspace.spec.ts
@@ -11,6 +11,7 @@ import {
   roles,
 } from "@budibase/backend-core"
 import { mocks, structures } from "@budibase/backend-core/tests"
+import { encodeJSBinding } from "@budibase/string-templates"
 import {
   type Workspace,
   AppFontFamily,
@@ -987,15 +988,36 @@ describe("/applications", () => {
       expect(res.application.appId).toEqual(config.getDevWorkspaceId())
     })
 
-    it("should reject users from another tenant", async () => {
-      await config.newTenant()
-
-      await config.withHeaders({ [Header.WORKSPACE_ID]: workspace.appId }, () =>
-        config.api.workspace.getAppPackage(workspace.appId, {
-          expectations: { status: 401 },
+    it.each([
+      { published: false, requestType: "client" },
+      { published: true, requestType: "client" },
+      { published: false, requestType: "builder" },
+      { published: true, requestType: "builder" },
+    ])(
+      "should reject cross-tenant access to snippets (published: $published, type: $requestType)",
+      async ({ published, requestType }) => {
+        await config.api.workspace.update(workspace.appId, {
+          snippets: [{ name: "MySnippet", code: "return value => value" }],
         })
-      )
-    })
+        await config.publish()
+        const appId = published
+          ? config.getProdWorkspaceId()
+          : config.getDevWorkspaceId()
+        await config.newTenant()
+
+        await config.withHeaders(
+          {
+            [Header.WORKSPACE_ID]: appId,
+            [Header.TYPE]: requestType,
+            referer: `https://example.com/app${workspace.url}`,
+          },
+          () =>
+            config.api.workspace.getAppPackage(appId, {
+              expectations: { status: 401 },
+            })
+        )
+      }
+    )
 
     it("should retrieve all the screens for builder calls", async () => {
       await config.api.screen.save(basicScreen())
@@ -1034,28 +1056,50 @@ describe("/applications", () => {
       )
     })
 
-    it("should not expose snippets to public calls", async () => {
-      const snippets = [{ name: "PrivateSnippet", code: "return 'secret'" }]
-      await config.api.workspace.update(workspace.appId, {
-        snippets,
-      })
-
-      const builderPackage = await config.api.workspace.getAppPackage(
-        workspace.appId
-      )
-      expect(builderPackage.application.snippets).toEqual(snippets)
-
-      await config.publish()
-
-      const res = await config.withHeaders(
-        { referer: `http://localhost:10000/app${workspace.url}` },
-        () =>
+    it.each([roles.BUILTIN_ROLE_IDS.PUBLIC, roles.BUILTIN_ROLE_IDS.BASIC])(
+      "should provide published snippets to %s clients",
+      async roleId => {
+        const snippets = [{ name: "MySnippet", code: "return value => value" }]
+        await config.api.workspace.update(workspace.appId, {
+          snippets,
+        })
+        const screen = customScreen({ roleId, route: "/" })
+        screen.props.text = encodeJSBinding(
+          'return snippets.MySnippet("apple")'
+        )
+        await config.api.screen.save(screen)
+        await config.publish()
+        await config.api.workspace.update(workspace.appId, {
+          snippets: [{ name: "MySnippet", code: "return 'unpublished'" }],
+        })
+        mocks.licenses.useCloudFree()
+        const user = await config.createUser({
+          builder: { global: false },
+          admin: { global: false },
+          roles: { [config.getProdWorkspaceId()]: roleId },
+        })
+        const res = await config.withUser(user, () =>
           config.api.workspace.getAppPackage(config.getProdWorkspaceId(), {
-            publicUser: true,
+            useProdApp: true,
+            publicUser: roleId === roles.BUILTIN_ROLE_IDS.PUBLIC,
+            headers: {
+              [Header.TYPE]: "client",
+              referer: `https://example.com/app${workspace.url}`,
+            },
           })
-      )
+        )
+        expect(res.application.snippets).toEqual(snippets)
+        expect(res.screens).toEqual([
+          expect.objectContaining({ props: screen.props }),
+        ])
+      }
+    )
 
-      expect(res.application.snippets).toBeUndefined()
+    it("should provide snippets to builder calls", async () => {
+      const snippets = [{ name: "MySnippet", code: "return value => value" }]
+      await config.api.workspace.update(workspace.appId, { snippets })
+      const res = await config.api.workspace.getAppPackage(workspace.appId)
+      expect(res.application.snippets).toEqual(snippets)
     })
 
     it("should expose recaptcha availability to public app packages", async () => {


### PR DESCRIPTION
## Description
Published app packages were stripping snippets from non-builder requests, so public and signed-in end users could not use snippets created by the app builder. This restores the published snippet payload while retaining tenant authorization on the app-package route.

## Addresses
- https://github.com/Budibase/budibase/issues/19633
- https://github.com/Budibase/budibase/pull/19588

## Screenshots
<img width="260" height="129" alt="Screenshot 2026-09-07 at 15 13 30" src="https://github.com/user-attachments/assets/dd5ceb7d-626b-43c0-929a-cc0b563204a7" />

## Launchcontrol
Published apps can use existing snippets for end users. Cross-tenant app-package access remains blocked.
