### PR TITLE
fix developer mode navigation in published cloud apps

### DIFF
--- a/packages/client/src/components/app/UserMenu.svelte
+++ b/packages/client/src/components/app/UserMenu.svelte
@@ -64,10 +64,7 @@
   }
 
   const goToPortal = () => {
-    const builderBaseUrl = $environmentStore.accountPortalUrl
-    const targetUrl = isBuilder
-      ? builderWorkspacesUrl(builderBaseUrl)
-      : builderAppsUrl(builderBaseUrl)
+    const targetUrl = isBuilder ? builderWorkspacesUrl() : builderAppsUrl()
     window.location.href = targetUrl
   }
 

--- a/packages/client/src/components/app/UserMenu.svelte
+++ b/packages/client/src/components/app/UserMenu.svelte
@@ -45,8 +45,7 @@
     translationOverrides
   )
 
-  const { accountPortalAccountUrl, builderWorkspacesUrl, builderAppsUrl } =
-    helpers
+  const { accountPortalAccountUrl, builderAppsUrl } = helpers
 
   const getText = (user?: User | ContextUser): string => {
     if (!user) {
@@ -64,7 +63,7 @@
   }
 
   const goToPortal = () => {
-    const targetUrl = isBuilder ? builderWorkspacesUrl() : builderAppsUrl()
+    const targetUrl = isBuilder ? "/builder" : builderAppsUrl()
     window.location.href = targetUrl
   }
 


### PR DESCRIPTION
## Description

opening developer mode from the username menu in a published cloud app sends users to `https://account.budibase.app/builder/apps`. the menu incorrectly uses the account portal URL as the builder host, and its workspace helper points builders at the app launcher rather than developer mode.

<img width="298" height="187" alt="image" src="https://github.com/user-attachments/assets/0ab30713-9f8a-47a3-9aa2-e34ec3b39805" />


send builders to `/builder` on the current tenant, matching the app launcher's developer mode action. other users continue to `/builder/apps` on the current tenant.

verified in a locally published app with sidebar navigation and a separate account portal URL: clicking the username menu's open developer mode action opens the developer workspace home

## Launchcontrol

fixed opening developer mode from published apps
