### PR TITLE
Automation run lifecycle status signalling

### DIFF
--- a/packages/backend-core/src/events/processors/platformActions/platformActionsPersistProcessor.ts
+++ b/packages/backend-core/src/events/processors/platformActions/platformActionsPersistProcessor.ts
@@ -36,6 +36,13 @@ function getSessionSignal(
   event: Event,
   properties: Record<string, unknown>
 ): PlatformActionSessionIndexJob["signal"] {
+  if (properties.sourceType === "automation_run") {
+    // A step succeeding or failing mid-run isn't the run's terminal state
+    // (continueOnError can keep the run going past a failure). The
+    // orchestrator signals active/completed/failed explicitly from the run's
+    // own global outcome instead
+    return undefined
+  }
   if (event.endsWith(":failed")) {
     return "failed"
   }

--- a/packages/backend-core/src/events/processors/platformActions/sessionIndex.ts
+++ b/packages/backend-core/src/events/processors/platformActions/sessionIndex.ts
@@ -17,20 +17,22 @@ const TERMINAL_STATUSES: ReadonlySet<PlatformActionContainerStatus> = new Set([
   "failed",
 ])
 
-function isTerminalSignal(signal: PlatformActionContainerStatus): boolean {
-  return TERMINAL_STATUSES.has(signal)
+function isTerminalSignal(
+  signal: PlatformActionContainerStatus | undefined
+): boolean {
+  return signal != null && TERMINAL_STATUSES.has(signal)
 }
 
 export interface UpsertPlatformActionSessionInput extends ActionSourceContext {
   incrementsActionCount: boolean
-  signal: PlatformActionContainerStatus
+  signal?: PlatformActionContainerStatus
   timestamp: string
 }
 
 function nextStatus(
   existingStatus: PlatformActionContainerStatus | undefined,
   existingStatusUpdatedAt: string | undefined,
-  signal: PlatformActionContainerStatus,
+  signal: PlatformActionContainerStatus | undefined,
   timestamp: string
 ): {
   status: PlatformActionContainerStatus
@@ -38,7 +40,23 @@ function nextStatus(
   updated: boolean
 } {
   if (!existingStatus || !existingStatusUpdatedAt) {
-    return { status: signal, statusUpdatedAt: timestamp, updated: true }
+    // Nothing recorded this session's status yet. A signal-less action (a
+    // step succeeding or failing mid-run isn't the run's terminal state)
+    // still needs a status to be visible at all, default to active, the
+    // same state an explicit start signal would have set.
+    return {
+      status: signal ?? "active",
+      statusUpdatedAt: timestamp,
+      updated: true,
+    }
+  }
+
+  if (!signal) {
+    return {
+      status: existingStatus,
+      statusUpdatedAt: existingStatusUpdatedAt,
+      updated: false,
+    }
   }
 
   if (new Date(timestamp) > new Date(existingStatusUpdatedAt)) {
@@ -88,7 +106,9 @@ export async function upsertPlatformActionSession(
         const existing =
           await db.tryGet<PlatformActionSessionIndexDoc>(sessionId)
         if (!existing && !input.incrementsActionCount) {
-          return
+          throw new Error(
+            `Platform action session ${sessionId} not indexed yet for lifecycle-only signal`
+          )
         }
         const existingStatusUpdatedAt = existing
           ? (existing.statusUpdatedAt ??

--- a/packages/backend-core/src/events/processors/platformActions/tests/platformActionsPersistProcessor.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/platformActionsPersistProcessor.spec.ts
@@ -189,10 +189,35 @@ describe("PlatformActionPersistProcessor", () => {
         undefined
       )
 
+      // automation_run step events never assert a container status
+      // themselves (see getSessionSignal) - the orchestrator signals
+      // active/completed/failed explicitly from the run's own outcome, so an
+      // AI_AGENT-specific property like awaitingEscalation has no effect here.
       expect(mockEnqueue).toHaveBeenCalledWith(
         expect.objectContaining({
           incrementsActionCount: true,
-          signal: "completed",
+          signal: undefined,
+        })
+      )
+    })
+  })
+
+  it("does not assert failed for a mid-run automation step failure either", async () => {
+    await run(async () => {
+      await processor.processEvent(
+        Event.ACTION_AUTOMATION_STEP_FAILED,
+        identity,
+        { sourceType: "automation_run", sourceId: "run-1" },
+        undefined
+      )
+
+      // A step failing under continueOnError doesn't clear the runner's
+      // recorded error, but it also doesn't decide the container's status by
+      // itself - only the orchestrator's own terminal signal does.
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          incrementsActionCount: true,
+          signal: undefined,
         })
       )
     })

--- a/packages/backend-core/src/events/processors/platformActions/tests/platformActionsPersistProcessor.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/platformActionsPersistProcessor.spec.ts
@@ -190,9 +190,9 @@ describe("PlatformActionPersistProcessor", () => {
       )
 
       // automation_run step events never assert a container status
-      // themselves (see getSessionSignal) - the orchestrator signals
-      // active/completed/failed explicitly from the run's own outcome, so an
-      // AI_AGENT-specific property like awaitingEscalation has no effect here.
+      // themselves. The orchestrator signals active/completed/failed
+      // explicitly from the run's own outcome, so an AI_AGENT-specific
+      // property like awaitingEscalation has no effect here.
       expect(mockEnqueue).toHaveBeenCalledWith(
         expect.objectContaining({
           incrementsActionCount: true,

--- a/packages/backend-core/src/events/processors/platformActions/tests/sessionIndex.spec.ts
+++ b/packages/backend-core/src/events/processors/platformActions/tests/sessionIndex.spec.ts
@@ -62,6 +62,54 @@ describe("upsertPlatformActionSession", () => {
     })
   })
 
+  it("defaults a signal-less first action to active", async () => {
+    await run(async () => {
+      const sourceId = generator.guid()
+
+      await upsertPlatformActionSession({
+        sourceType: "agent_session",
+        sourceId,
+        incrementsActionCount: true,
+        signal: undefined,
+        timestamp: "2026-08-31T00:00:00.000Z",
+      })
+
+      const doc = await getSessionDoc(sourceId)
+
+      expect(doc.status).toBe("active")
+      expect(doc.actionCount).toBe(1)
+      expect(doc.completedAt).toBeUndefined()
+    })
+  })
+
+  it("leaves the existing status untouched for a signal-less later action", async () => {
+    await run(async () => {
+      const sourceId = generator.guid()
+
+      await upsertPlatformActionSession({
+        sourceType: "agent_session",
+        sourceId,
+        incrementsActionCount: true,
+        signal: "active",
+        timestamp: "2026-08-31T00:00:00.000Z",
+      })
+
+      // A step succeeding mid-run must not assert "completed" on its own.
+      await upsertPlatformActionSession({
+        sourceType: "agent_session",
+        sourceId,
+        incrementsActionCount: true,
+        signal: undefined,
+        timestamp: "2026-08-31T00:05:00.000Z",
+      })
+
+      const doc = await getSessionDoc(sourceId)
+
+      expect(doc.status).toBe("active")
+      expect(doc.actionCount).toBe(2)
+    })
+  })
+
   it("increments actionCount and refreshes updatedAt/completedAt on later events", async () => {
     await run(async () => {
       const sourceId = generator.guid()
@@ -200,17 +248,23 @@ describe("upsertPlatformActionSession", () => {
     })
   })
 
-  it("does not create a session index for a lifecycle signal without an action", async () => {
+  it("throws for a lifecycle signal with no action indexed yet, without creating an orphan session", async () => {
     await run(async () => {
       const sourceId = generator.guid()
       const input = { sourceType: "agent_session" as const, sourceId }
 
-      await upsertPlatformActionSession({
-        ...input,
-        incrementsActionCount: false,
-        signal: "active",
-        timestamp: "2026-08-31T00:00:00.000Z",
-      })
+      // Bull retries a thrown job instead of silently dropping it - by the
+      // time retries exhaust, the run's first action should have indexed the
+      // session for this signal to apply to. If it never does (no action
+      // ever occurs), the retries are exhausted and no orphan session exists.
+      await expect(
+        upsertPlatformActionSession({
+          ...input,
+          incrementsActionCount: false,
+          signal: "active",
+          timestamp: "2026-08-31T00:00:00.000Z",
+        })
+      ).rejects.toThrow()
 
       const doc = await context
         .getWorkspaceDB()

--- a/packages/server/src/automations/automationUtils.ts
+++ b/packages/server/src/automations/automationUtils.ts
@@ -8,6 +8,7 @@ import {
   Automation,
   AutomationActionStepId,
   AutomationAttachment,
+  AutomationStatus,
   AutomationStep,
   AutomationStepResult,
   AutomationStepResultOutputs,
@@ -18,6 +19,7 @@ import {
   FieldType,
   LoopStorage,
   LoopV2Step,
+  PlatformActionContainerStatus,
   Row,
 } from "@budibase/types"
 import { cloneDeep, isPlainObject } from "lodash"
@@ -119,6 +121,24 @@ export function getError(err: any) {
     return JSON.stringify(err)
   }
   return typeof err !== "string" ? err.toString() : err
+}
+
+export function inferAutomationRunActionStatus(
+  status: AutomationStatus
+): PlatformActionContainerStatus {
+  switch (status) {
+    case AutomationStatus.SUCCESS:
+    case AutomationStatus.STOPPED:
+      return "completed"
+    case AutomationStatus.ERROR:
+    case AutomationStatus.STOPPED_ERROR:
+    case AutomationStatus.TIMED_OUT:
+      return "failed"
+    case AutomationStatus.SUSPENDED:
+      return "waiting"
+    default:
+      throw new Error(`Unexpected automation run status: ${status}`)
+  }
 }
 
 export function guardAttachment(

--- a/packages/server/src/automations/tests/automationUtils.spec.ts
+++ b/packages/server/src/automations/tests/automationUtils.spec.ts
@@ -1,5 +1,9 @@
-import { AutomationIOType } from "@budibase/types"
-import { cleanInputValues, substituteLoopStep } from "../automationUtils"
+import { AutomationIOType, AutomationStatus } from "@budibase/types"
+import {
+  cleanInputValues,
+  inferAutomationRunActionStatus,
+  substituteLoopStep,
+} from "../automationUtils"
 
 describe("automationUtils", () => {
   describe("substituteLoopStep", () => {
@@ -110,6 +114,25 @@ describe("automationUtils", () => {
       expect(two.b).toBe(true)
       expect(two.c).toBe(false)
       expect(two.d).toBe(1)
+    })
+  })
+
+  describe("inferAutomationRunActionStatus", () => {
+    it.each([
+      [AutomationStatus.SUCCESS, "completed"],
+      [AutomationStatus.STOPPED, "completed"],
+      [AutomationStatus.ERROR, "failed"],
+      [AutomationStatus.STOPPED_ERROR, "failed"],
+      [AutomationStatus.TIMED_OUT, "failed"],
+      [AutomationStatus.SUSPENDED, "waiting"],
+    ])("maps %s to %s", (status, expected) => {
+      expect(inferAutomationRunActionStatus(status)).toBe(expected)
+    })
+
+    it("throws for a status that is never a whole-run result", () => {
+      expect(() =>
+        inferAutomationRunActionStatus(AutomationStatus.NO_CONDITION_MET)
+      ).toThrow()
     })
   })
 })

--- a/packages/server/src/threads/automation.spec.ts
+++ b/packages/server/src/threads/automation.spec.ts
@@ -46,7 +46,7 @@ import { Job } from "bull"
 import { BUILTIN_ACTION_DEFINITIONS, TRIGGER_DEFINITIONS } from "../automations"
 import TestConfiguration from "../tests/utilities/TestConfiguration"
 import { basicAutomation } from "../tests/utilities/structures"
-import { executeInThread, removeStalled } from "./automation"
+import { execute, executeInThread, removeStalled } from "./automation"
 import sdk from "../sdk"
 import { automations } from "@budibase/shared-core"
 import { storeLog } from "../automations/logging"
@@ -175,6 +175,42 @@ describe("automation thread", () => {
       })
     )
   })
+
+  it.each([undefined, "original-run"])(
+    "signals a missing automation ID in the workspace context (runId: %s)",
+    async runId => {
+      jest.clearAllMocks()
+      const appId = config.getProdWorkspaceId()
+      const job = {
+        id: "missing-automation-id-job",
+        data: {
+          automation: basicAutomation({ appId, _id: undefined }),
+          event: { appId, runId },
+        },
+      } as Job<AutomationData>
+      const callback = jest.fn()
+      const enqueue = jest.mocked(
+        events.platformActions.enqueuePlatformActionSessionLifecycle
+      )
+      let signalledWorkspaceId: string | undefined
+      enqueue.mockImplementationOnce(async () => {
+        signalledWorkspaceId = context.getWorkspaceId()
+      })
+
+      await expect(execute(job, callback)).rejects.toThrow(
+        "Unable to execute, event doesn't contain automation ID."
+      )
+
+      expect(signalledWorkspaceId).toBe(appId)
+      expect(enqueue).toHaveBeenCalledTimes(1)
+      expect(enqueue).toHaveBeenCalledWith({
+        sourceType: "automation_run",
+        sourceId: runId ?? job.id,
+        signal: "failed",
+      })
+      expect(callback).not.toHaveBeenCalled()
+    }
+  )
 
   it("signals the run failed when preparation fails before execution starts", async () => {
     jest.clearAllMocks()

--- a/packages/server/src/threads/automation.spec.ts
+++ b/packages/server/src/threads/automation.spec.ts
@@ -592,6 +592,25 @@ describe("automation thread", () => {
       automationId: "automation_server_log",
     })
     expect(events.action.automationStepFailed).not.toHaveBeenCalled()
+    expect(
+      jest.mocked(events.platformActions.enqueuePlatformActionSessionLifecycle)
+        .mock.calls
+    ).toEqual([
+      [
+        {
+          sourceType: "automation_run",
+          sourceId: "server-log-job",
+          signal: "active",
+        },
+      ],
+      [
+        {
+          sourceType: "automation_run",
+          sourceId: "server-log-job",
+          signal: "completed",
+        },
+      ],
+    ])
   })
 
   it("uses an explicit event.runId as sourceId instead of the job id", async () => {

--- a/packages/server/src/threads/automation.spec.ts
+++ b/packages/server/src/threads/automation.spec.ts
@@ -481,6 +481,57 @@ describe("automation thread", () => {
     expect(events.action.automationStepFailed).not.toHaveBeenCalled()
   })
 
+  it("uses an explicit event.runId as sourceId instead of the job id", async () => {
+    jest.clearAllMocks()
+
+    const appId = config.getDevWorkspaceId()
+
+    const { id: _ignored, ...serverLogDefinition } =
+      BUILTIN_ACTION_DEFINITIONS.SERVER_LOG as AutomationStep
+    const serverLogStep: AutomationStep = {
+      ...serverLogDefinition,
+      id: "server-log-step",
+      stepId: AutomationActionStepId.SERVER_LOG,
+      inputs: { text: "hello" },
+    }
+
+    const job = {
+      id: "new-transport-job-id",
+      data: {
+        automation: basicAutomation({
+          _id: "automation_server_log_runid",
+          appId,
+          definition: {
+            trigger: {
+              stepId: AutomationTriggerStepId.APP,
+              name: "test",
+              tagline: "test",
+              icon: "test",
+              description: "test",
+              type: AutomationStepType.TRIGGER,
+              inputs: {},
+              id: "trigger",
+              schema: {
+                inputs: { properties: {} },
+                outputs: { properties: {} },
+              },
+            },
+            steps: [serverLogStep],
+          },
+        }),
+        event: { appId, runId: "original-run-id" },
+      },
+    } as Job<AutomationData>
+
+    await executeInThread(job)
+
+    expect(events.action.automationStepExecuted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: "original-run-id",
+      })
+    )
+  })
+
   it("emits automationStepFailed with ERROR when a step fails", async () => {
     jest.clearAllMocks()
 

--- a/packages/server/src/threads/automation.spec.ts
+++ b/packages/server/src/threads/automation.spec.ts
@@ -15,6 +15,12 @@ jest.mock("@budibase/backend-core", () => {
         automationStepExecuted: jest.fn(),
         automationStepFailed: jest.fn(),
       },
+      platformActions: {
+        ...actual.events.platformActions,
+        enqueuePlatformActionSessionLifecycle: jest
+          .fn()
+          .mockResolvedValue(undefined),
+      },
     },
   }
 })
@@ -140,6 +146,77 @@ describe("automation thread", () => {
     } finally {
       getBullQueue.mockRestore()
     }
+  })
+
+  it("signals the run failed when a job stalls", async () => {
+    jest.clearAllMocks()
+    const prodAppId = config.getProdWorkspaceId()
+
+    const job = {
+      id: "stalled-job",
+      data: {
+        automation: basicAutomation({
+          _id: "automation_stalled",
+          appId: prodAppId,
+        }),
+        event: { appId: prodAppId },
+      },
+    } as Job<AutomationData>
+
+    await removeStalled(job)
+
+    expect(
+      events.platformActions.enqueuePlatformActionSessionLifecycle
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceType: "automation_run",
+        sourceId: "stalled-job",
+        signal: "failed",
+      })
+    )
+  })
+
+  it("signals the run failed when preparation fails before execution starts", async () => {
+    jest.clearAllMocks()
+    const appId = config.getDevWorkspaceId()
+
+    const job = {
+      id: "prep-failure-job",
+      data: {
+        automation: basicAutomation({
+          _id: "automation_does_not_exist",
+          appId,
+          definition: {
+            trigger: {
+              id: "cron-trigger",
+              type: AutomationStepType.TRIGGER,
+              name: TRIGGER_DEFINITIONS.CRON.name,
+              tagline: TRIGGER_DEFINITIONS.CRON.tagline,
+              description: TRIGGER_DEFINITIONS.CRON.description,
+              icon: TRIGGER_DEFINITIONS.CRON.icon,
+              schema: TRIGGER_DEFINITIONS.CRON.schema,
+              stepId: AutomationTriggerStepId.CRON,
+              event: AutomationEventType.CRON_TRIGGER,
+              inputs: { cron: "* * * * *" },
+            },
+            steps: [],
+          },
+        }),
+        event: { appId },
+      },
+    } as Job<AutomationData>
+
+    await expect(executeInThread(job)).rejects.toThrow()
+
+    expect(
+      events.platformActions.enqueuePlatformActionSessionLifecycle
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceType: "automation_run",
+        sourceId: "prep-failure-job",
+        signal: "failed",
+      })
+    )
   })
 
   it("executes the latest automation definition for cron jobs", async () => {

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -40,6 +40,7 @@ import {
   LoopV2Step,
   LoopV2StepInputs,
   ActionSourceContext,
+  PlatformActionContainerStatus,
 } from "@budibase/types"
 import { Job } from "bull"
 import tracer from "dd-trace"
@@ -384,6 +385,22 @@ class Orchestrator {
     }
   }
 
+  // Signals the run's Actions container status directly. Not a persisted
+  // action, and must not increment actionCount.
+  private async signalRunStatus(
+    signal: PlatformActionContainerStatus
+  ): Promise<void> {
+    const { sourceType, sourceId } = this.actionSourceContext
+    await events.platformActions
+      .enqueuePlatformActionSessionLifecycle({ sourceType, sourceId, signal })
+      .catch(error => {
+        logging.logWarn(
+          `Failed to signal automation run ${signal} - ${this.appId}/${this.automation._id}`,
+          error
+        )
+      })
+  }
+
   isCron(): boolean {
     return this.automation.definition.trigger.stepId === CRON_STEP_ID
   }
@@ -546,6 +563,8 @@ class Orchestrator {
       const timeout =
         this.job.data.event.timeout || env.AUTOMATION_THREAD_TIMEOUT
 
+      await this.signalRunStatus("active")
+
       let stepResults: AutomationStepResult[] = []
 
       try {
@@ -586,6 +605,10 @@ class Orchestrator {
       } else {
         await this.logResult(result)
       }
+
+      await this.signalRunStatus(
+        automationUtils.inferAutomationRunActionStatus(result.status)
+      )
 
       // Return any content pushed to state.
       if (Object.keys(ctx?.state || {}).length > 0) {

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -333,6 +333,7 @@ async function reloadAutomation(job: Job<AutomationData>) {
 
 class Orchestrator {
   private readonly job: AutomationJob
+  private readonly runId: string
   private emitter: ContextEmitter
   private stopped: boolean
   private readonly onProgress?: (event: AutomationTestProgressEvent) => void
@@ -346,6 +347,10 @@ class Orchestrator {
     } = {}
   ) {
     this.job = job
+    // A fresh run has no runId yet. Job id is its first and only execution
+    // identifier. Only a resumed run would carry its original runId forward
+    // explicitly
+    this.runId = job.data.event.runId ?? String(job.id)
     this.stopped = false
     this.onProgress = opts.onProgress
     this.isTestRun = Boolean(opts.isTestRun)
@@ -374,7 +379,7 @@ class Orchestrator {
   } {
     return {
       sourceType: "automation_run",
-      sourceId: `${this.job.id}`,
+      sourceId: this.runId,
       automationId: this.automation._id!,
     }
   }

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -1183,6 +1183,10 @@ export async function execute(
 
   const automationId = job.data.automation._id
   if (!automationId) {
+    await context.doInWorkspaceContext(workspaceId, () =>
+      signalAutomationRunFailure(job)
+    )
+
     throw new Error("Unable to execute, event doesn't contain automation ID.")
   }
 

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -314,6 +314,27 @@ function setTriggerOutput(result: AutomationResults, outputs: any) {
   result.steps[0] = result.trigger
 }
 
+function getAutomationRunId(job: Readonly<AutomationJob>): string {
+  return job.data.event.runId ?? String(job.id)
+}
+
+async function signalAutomationRunFailure(
+  job: Readonly<AutomationJob>
+): Promise<void> {
+  await events.platformActions
+    .enqueuePlatformActionSessionLifecycle({
+      sourceType: "automation_run",
+      sourceId: getAutomationRunId(job),
+      signal: "failed",
+    })
+    .catch(error => {
+      logging.logWarn(
+        `Failed to signal automation run failed - ${job.data.event.appId}/${job.data.automation?._id}`,
+        error
+      )
+    })
+}
+
 async function reloadAutomation(job: Job<AutomationData>) {
   const trigger = job.data.automation?.definition?.trigger
   if (!trigger || (!isCronTrigger(trigger) && !isEmailTrigger(trigger))) {
@@ -348,10 +369,7 @@ class Orchestrator {
     } = {}
   ) {
     this.job = job
-    // A fresh run has no runId yet. Job id is its first and only execution
-    // identifier. Only a resumed run would carry its original runId forward
-    // explicitly
-    this.runId = job.data.event.runId ?? String(job.id)
+    this.runId = getAutomationRunId(job)
     this.stopped = false
     this.onProgress = opts.onProgress
     this.isTestRun = Boolean(opts.isTestRun)
@@ -1194,6 +1212,7 @@ export async function execute(
                 { _logKey: "bull", jobId: job.id },
                 { _logKey: "error", ...getErrorLogDetails(err) }
               )
+              await signalAutomationRunFailure(job)
               callback(err)
             }
           }
@@ -1222,13 +1241,18 @@ export async function executeInThread(
       return await context.doInFeatureFlagOverrideContext(
         job.data.featureFlagOverrides || {},
         async () => {
-          await reloadAutomation(job)
-          await context.ensureSnippetContext()
-          const envVars = await sdkUtils.getEnvironmentVariables()
-          return await context.doInEnvironmentContext(envVars, async () => {
-            const orchestrator = new Orchestrator(job, opts)
-            return orchestrator.execute()
-          })
+          try {
+            await reloadAutomation(job)
+            await context.ensureSnippetContext()
+            const envVars = await sdkUtils.getEnvironmentVariables()
+            return await context.doInEnvironmentContext(envVars, async () => {
+              const orchestrator = new Orchestrator(job, opts)
+              return orchestrator.execute()
+            })
+          } catch (err) {
+            await signalAutomationRunFailure(job)
+            throw err
+          }
         }
       )
     })
@@ -1245,5 +1269,6 @@ export const removeStalled = async (job: Job<AutomationData>) => {
       `Automation job stalled - ${appId}/${job.data.automation._id}`,
       getAutomationLogContext(job)
     )
+    await signalAutomationRunFailure(job)
   })
 }

--- a/packages/types/src/sdk/automations/index.ts
+++ b/packages/types/src/sdk/automations/index.ts
@@ -27,6 +27,10 @@ export interface AutomationDataEvent {
   // Carries suspended state for resumed automations - restored into context
   // before executeSteps runs so prior bindings remain available.
   resumeContext?: AutomationResumeContext
+  // Logical run identity used to group this run's platform actions, kept
+  // distinct from the job id (transport identity). Only a resumed run needs
+  // to carry it explicitly
+  runId?: string
 }
 
 export interface AutomationData {

--- a/packages/types/src/sdk/platformActions/index.ts
+++ b/packages/types/src/sdk/platformActions/index.ts
@@ -53,6 +53,8 @@ export interface PlatformActionSessionIndexJob extends ActionSourceContext {
   workspaceId: string
   indexId: string
   incrementsActionCount: boolean
-  signal: PlatformActionContainerStatus
+  // Absent for a step-level action that isn't the run's terminal state. It
+  // should record the action without asserting a container status.
+  signal?: PlatformActionContainerStatus
   timestamp: string
 }


### PR DESCRIPTION
## Addresses
https://github.com/Budibase/budibase/issues/18586

## Description
Implements the non-blocked parts of the automation run lifecycle work: a logical `runId` for automation runs, a pure status-mapping function from an `AutomationStatus` to the Actions container status, and wiring that signals `active` when a run starts, the inferred terminal status (`completed`/`failed`) when it finishes, and `failed` for preparation failures, unexpected exceptions escaping execution, and stalled jobs.

Step-level `automation_run` action events no longer assert the container status themselves - only the run's own lifecycle signal does. A lifecycle-only signal that arrives before the first action has indexed the session now retries via Bull instead of being silently dropped, preserving the invariant that a session index is never created without a persisted action.

Suspension/resume identity propagation (`waiting` on authorization, resume-to-active) is intentionally out of scope here: there is currently no automation-triggered escalation producer in the codebase, so that plumbing has no real consumer yet.

## Screen recording
https://github.com/user-attachments/assets/4e7ebd21-d2a5-4298-9c89-3224c403d752

## Launchcontrol
Automation runs now report their live status (running, completed, failed) to the Actions activity feed, in addition to individual step outcomes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automation runs now use a logical `runId` and report their own lifecycle to the Actions activity feed. Previously, step-level `automation_run` events could set the container status; they now only record actions, while the run emits `active` and an inferred terminal status (`completed`, `failed`, or `waiting`).

**Signals**
- Falls back to the Bull job ID when `event.runId` is missing.
- Reports `failed` for preparation errors, uncaught execution errors, stalled jobs, and missing automation IDs.
- Retries lifecycle signals that arrive before the first action instead of dropping them or creating an orphan session.
- Suspension/resume identity propagation remains out of scope because no automation-triggered escalation producer exists yet.

<sup>Written for commit 5839e92978a37fc4bd7e41c7dbed7c32d9d66fbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



