### PR TITLE
Fixes off-by-one days in calendar week view

### DIFF
--- a/packages/client/src/components/app/Calendar.svelte
+++ b/packages/client/src/components/app/Calendar.svelte
@@ -196,11 +196,6 @@
     onClick?.({ title, start, end, row_id })
   }
 
-  const getTranslatedWeekday = (date: Date, format: WeekdayFormat) => {
-    const key = weekdayTranslationKeys[date.getUTCDay()]
-    return formatTranslatedLabel(calendarLabels[key], format)
-  }
-
   const getTranslatedMonth = (date: Date, format: MonthFormat) => {
     const key = monthTranslationKeys[date.getUTCMonth()]
     return formatTranslatedLabel(calendarLabels[key], format)
@@ -214,6 +209,18 @@
     return !label || label === defaultLabel
       ? calendarLabels[translationKey]
       : label
+  }
+
+  const getTranslatedWeekdayByIndex = (
+    dayIndex: number,
+    format: WeekdayFormat
+  ) => {
+    const key = weekdayTranslationKeys[dayIndex]
+    return formatTranslatedLabel(calendarLabels[key], format)
+  }
+
+  const getTranslatedWeekday = (date: Date, format: WeekdayFormat) => {
+    return getTranslatedWeekdayByIndex(date.getUTCDay(), format)
   }
 
   const replaceTranslatedMonths = (
@@ -282,7 +289,7 @@
   const buildDayHeaderContent =
     (weekdayFormat: WeekdayFormat, dateFormat?: CalendarDateFormat) =>
     (arg: DayHeaderContentArg) => {
-      const weekday = getTranslatedWeekday(arg.date, weekdayFormat)
+      const weekday = getTranslatedWeekdayByIndex(arg.dow, weekdayFormat)
       const date = dateFormat
         ? formatTranslatedDate(arg.date, dateFormat)
         : undefined


### PR DESCRIPTION
## Description
When I added the translations features to the Calendar component there was a mismatch between how days/dates were handled, which meant certain timezones could end up with a day-of-the-week assigned incorrectly as the previous or next day. 

## Addresses
- #19596 

## App Export
[Calendar Week View 19596-export-1788952084989.tar.gz](https://github.com/user-attachments/files/32004810/Calendar.Week.View.19596-export-1788952084989.tar.gz)


## Screenshots
Now - no translations

<img width="1182" height="180" alt="image" src="https://github.com/user-attachments/assets/96182850-8747-45a6-9bf3-918b623072fe" />

Now - translations

<img width="1195" height="193" alt="image" src="https://github.com/user-attachments/assets/69360e26-7023-4767-a411-0f5d5f45c2da" />

Previously:
<img width="1183" height="144" alt="image" src="https://github.com/user-attachments/assets/097fe5e9-6a41-466e-905a-c9fd486d9eae" />

<img width="1189" height="135" alt="image" src="https://github.com/user-attachments/assets/ca5853b0-bea4-4ca8-974d-781499496978" />

"_But Mike, I don't know the days of the week in Welsh._"

Dim broblem o gwbl. Dyma:
Cymraeg | English
-- | --
Dydd Llun | Monday
Dydd Mawrth | Tuesday
Dydd Mercher | Wednesday
Dydd Iau | Thursday
Dydd Gwener | Friday
Dydd Sadwrn | Saturday
Dydd Sul | Sunday

## Launchcontrol

_Fixes days-of-the-week misalignment in the week view of the Calendar component._
