### PR TITLE
Expose errors from escalated tools

### DIFF
--- a/packages/server/src/ai/tools/index.spec.ts
+++ b/packages/server/src/ai/tools/index.spec.ts
@@ -175,6 +175,46 @@ describe("secured AI tool execution", () => {
     )
   })
 
+  it("preserves object-shaped tool failure details", async () => {
+    const execute = jest.fn().mockResolvedValue({
+      error: {
+        code: "VALIDATION_ERROR",
+        field: "supplier",
+      },
+    })
+    const authorize = jest.fn().mockResolvedValue(undefined)
+    const log = jest.spyOn(console, "log").mockImplementation()
+    const tools = toToolSet(
+      [definition(execute)],
+      new Map([
+        [
+          "secured_tool",
+          {
+            executionContext,
+            principal: ToolExecutionPrincipal.REQUESTER,
+            authorize,
+          },
+        ],
+      ])
+    )
+
+    await expect(
+      tools.secured_tool.execute?.(
+        { value: "hello" },
+        { toolCallId: "call_1", messages: [], context: undefined }
+      )
+    ).rejects.toThrow(
+      '{"code":"VALIDATION_ERROR","field":"supplier"}'
+    )
+    expect(log).toHaveBeenCalledWith(
+      "Agent tool execution",
+      expect.objectContaining({
+        outcome: "error",
+        error: '{"code":"VALIDATION_ERROR","field":"supplier"}',
+      })
+    )
+  })
+
   it("does not execute a tool without authorization metadata", async () => {
     const execute = jest.fn()
     const authorize = jest.fn()

--- a/packages/server/src/ai/tools/index.spec.ts
+++ b/packages/server/src/ai/tools/index.spec.ts
@@ -203,9 +203,7 @@ describe("secured AI tool execution", () => {
         { value: "hello" },
         { toolCallId: "call_1", messages: [], context: undefined }
       )
-    ).rejects.toThrow(
-      '{"code":"VALIDATION_ERROR","field":"supplier"}'
-    )
+    ).rejects.toThrow('{"code":"VALIDATION_ERROR","field":"supplier"}')
     expect(log).toHaveBeenCalledWith(
       "Agent tool execution",
       expect.objectContaining({

--- a/packages/server/src/ai/tools/index.spec.ts
+++ b/packages/server/src/ai/tools/index.spec.ts
@@ -140,6 +140,41 @@ describe("secured AI tool execution", () => {
     expect(execute).not.toHaveBeenCalled()
   })
 
+  it("logs the error message when tool execution fails", async () => {
+    const execute = jest
+      .fn()
+      .mockRejectedValue(new Error("row creation failed"))
+    const authorize = jest.fn().mockResolvedValue(undefined)
+    const log = jest.spyOn(console, "log").mockImplementation()
+    const tools = toToolSet(
+      [definition(execute)],
+      new Map([
+        [
+          "secured_tool",
+          {
+            executionContext,
+            principal: ToolExecutionPrincipal.REQUESTER,
+            authorize,
+          },
+        ],
+      ])
+    )
+
+    await expect(
+      tools.secured_tool.execute?.(
+        { value: "hello" },
+        { toolCallId: "call_1", messages: [], context: undefined }
+      )
+    ).rejects.toThrow("row creation failed")
+    expect(log).toHaveBeenCalledWith(
+      "Agent tool execution",
+      expect.objectContaining({
+        outcome: "error",
+        error: "row creation failed",
+      })
+    )
+  })
+
   it("does not execute a tool without authorization metadata", async () => {
     const execute = jest.fn()
     const authorize = jest.fn()

--- a/packages/server/src/ai/tools/index.ts
+++ b/packages/server/src/ai/tools/index.ts
@@ -78,11 +78,7 @@ const getToolFailure = (result: unknown): string | undefined => {
     return
   }
 
-  if (error instanceof Error) {
-    return error.message || "Tool execution failed"
-  }
-
-  return String(error)
+  return getErrorMessage(error) || "Tool execution failed"
 }
 
 const logToolExecution = (

--- a/packages/server/src/ai/tools/index.ts
+++ b/packages/server/src/ai/tools/index.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "@budibase/backend-core"
 import {
   PermissionLevel,
   PermissionType,
@@ -87,7 +88,8 @@ const getToolFailure = (result: unknown): string | undefined => {
 const logToolExecution = (
   outcome: "success" | "error",
   toolDef: AiToolDefinition,
-  runtime: ToolAuthorizationRuntime
+  runtime: ToolAuthorizationRuntime,
+  error?: unknown
 ) =>
   console.log("Agent tool execution", {
     outcome,
@@ -97,6 +99,7 @@ const logToolExecution = (
     agentId: runtime.executionContext.agentId,
     operationId: runtime.executionContext.operationId,
     conversationId: runtime.executionContext.conversationId,
+    ...(error !== undefined && { error: getErrorMessage(error) }),
   })
 
 const wrapTool = (
@@ -149,7 +152,7 @@ const wrapTool = (
       return authorizedResult
     } catch (error) {
       if (runtime) {
-        logToolExecution("error", toolDef, runtime)
+        logToolExecution("error", toolDef, runtime, error)
       }
       throw error
     }

--- a/packages/server/src/escalation/constants.ts
+++ b/packages/server/src/escalation/constants.ts
@@ -1,0 +1,1 @@
+export const APPROVAL_REQUIRED_TITLE_PREFIX = "Approval required:"

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -158,6 +158,7 @@ describe("resumeOperation", () => {
         requestId,
         resolution: "resolved",
         response: { accepted: true },
+        title: "Purchase request for 46 euros",
       })
       await context.getWorkspaceDB().put(escalation)
       getOrThrowMock.mockResolvedValue({
@@ -211,7 +212,9 @@ describe("resumeOperation", () => {
       expect(resumeResult.parts).toEqual([
         {
           type: "text",
-          text: "Sorry, something went wrong and I couldn't complete that.",
+          text:
+            "Your purchase request for 46 euros was approved, but I couldn't " +
+            "complete it. Please try again.",
         },
       ])
       expect(request.actions).toEqual(

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -1,3 +1,4 @@
+import zlib from "zlib"
 import { context } from "@budibase/backend-core"
 import {
   Agent,
@@ -153,6 +154,12 @@ describe("resumeOperation", () => {
   it("reports an approved tool failure without asking the model to narrate it", async () => {
     await config.doInContext(config.getProdWorkspaceId(), async () => {
       const { requestId } = (await createRequest())!
+      const escalation = baseDoc({
+        requestId,
+        resolution: "resolved",
+        response: { accepted: true },
+      })
+      await context.getWorkspaceDB().put(escalation)
       getOrThrowMock.mockResolvedValue({
         _id: "agent_1",
         operations: [{ id: "op_1" }],
@@ -169,7 +176,7 @@ describe("resumeOperation", () => {
       })
 
       await resumeOperation({
-        doc: baseDoc({ requestId, response: { accepted: true } }),
+        doc: escalation,
         escalationId: "esc_primary",
         resolution: "resolved",
         ctx: {
@@ -189,6 +196,24 @@ describe("resumeOperation", () => {
       expect(request.error).toEqual(
         '{"validation":{"Department":"can\'t be blank"}}'
       )
+      const storedEscalation = await context
+        .getWorkspaceDB()
+        .get<EscalationContextDoc>(escalation._id!)
+      const resumeResult = JSON.parse(
+        zlib
+          .inflateSync(
+            Uint8Array.from(
+              Buffer.from(storedEscalation.resumeResultCompressed!, "base64")
+            )
+          )
+          .toString()
+      )
+      expect(resumeResult.parts).toEqual([
+        {
+          type: "text",
+          text: "Sorry, something went wrong and I couldn't complete that.",
+        },
+      ])
       expect(request.actions).toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -201,6 +201,53 @@ describe("resumeOperation", () => {
     })
   })
 
+  it("keeps the request open when another escalation is pending after an approved tool failure", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      await sdk.ai.agentRequests.updateRequestStatus({
+        requestId,
+        status: "needs_input",
+      })
+      await context.getWorkspaceDB().put(
+        baseDoc({
+          _id: `${DocumentType.ESCALATION_CONTEXT}${SEPARATOR}esc_other`,
+          requestId,
+        })
+      )
+      getOrThrowMock.mockResolvedValue({
+        _id: "agent_1",
+        operations: [{ id: "op_1" }],
+      } as Agent)
+      buildPromptAndToolsMock.mockResolvedValue({
+        tools: {
+          create_row: {
+            execute: jest.fn().mockRejectedValue(new Error("DB unavailable")),
+          },
+        },
+        toolSources: {},
+      })
+
+      await resumeOperation({
+        doc: baseDoc({ requestId, response: { accepted: true } }),
+        escalationId: "esc_primary",
+        resolution: "resolved",
+        ctx: {
+          ...baseCtx,
+          pendingToolCall: {
+            toolCallId: "call_1",
+            toolName: "create_row",
+            args: { data: { amount: 46 } },
+          },
+        },
+      })
+
+      const [request] =
+        await sdk.ai.agentRequests.fetchRequestsByAgent("agent_1")
+      expect(request.status).toEqual("needs_input")
+      expect(prepareAgentChatRunMock).not.toHaveBeenCalled()
+    })
+  })
+
   it("passes getRequestId resolving to the escalation's request id", async () => {
     await config.doInContext(config.getProdWorkspaceId(), async () => {
       const { requestId } = (await createRequest())!

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -34,6 +34,7 @@ jest.mock("../sdk/workspace/ai/agents", () => {
   const actual = jest.requireActual("../sdk/workspace/ai/agents")
   return {
     ...actual,
+    buildPromptAndTools: jest.fn(),
     getOrThrow: jest.fn(),
     prepareAgentChatRun: jest.fn(),
   }
@@ -57,6 +58,7 @@ jest.mock("ai", () => {
 
 const prepareAgentChatRunMock = sdk.ai.agents.prepareAgentChatRun as jest.Mock
 const getOrThrowMock = sdk.ai.agents.getOrThrow as jest.Mock
+const buildPromptAndToolsMock = sdk.ai.agents.buildPromptAndTools as jest.Mock
 const recordEscalationResolvedMock = sdk.ai.agentRequests
   .recordEscalationResolved as jest.Mock
 
@@ -113,6 +115,7 @@ describe("resumeOperation", () => {
   beforeEach(async () => {
     prepareAgentChatRunMock.mockReset()
     getOrThrowMock.mockReset()
+    buildPromptAndToolsMock.mockReset()
     await config.newTenant()
   })
 
@@ -141,6 +144,57 @@ describe("resumeOperation", () => {
             escalationId: "esc_primary",
             outcome: "approved",
             sessionId: "session_1",
+          }),
+        ])
+      )
+    })
+  })
+
+  it("reports an approved tool failure without asking the model to narrate it", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      getOrThrowMock.mockResolvedValue({
+        _id: "agent_1",
+        operations: [{ id: "op_1" }],
+      } as Agent)
+      buildPromptAndToolsMock.mockResolvedValue({
+        tools: {
+          create_row: {
+            execute: jest.fn().mockRejectedValue({
+              validation: { Department: "can't be blank" },
+            }),
+          },
+        },
+        toolSources: {},
+      })
+
+      await resumeOperation({
+        doc: baseDoc({ requestId, response: { accepted: true } }),
+        escalationId: "esc_primary",
+        resolution: "resolved",
+        ctx: {
+          ...baseCtx,
+          pendingToolCall: {
+            toolCallId: "call_1",
+            toolName: "create_row",
+            args: { data: { amount: 46 } },
+          },
+        },
+      })
+
+      expect(prepareAgentChatRunMock).not.toHaveBeenCalled()
+      const [request] =
+        await sdk.ai.agentRequests.fetchRequestsByAgent("agent_1")
+      expect(request.status).toEqual("failed")
+      expect(request.error).toEqual(
+        '{"validation":{"Department":"can\'t be blank"}}'
+      )
+      expect(request.actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "tool_call",
+            toolName: "create_row",
+            status: "error",
           }),
         ])
       )

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -609,10 +609,7 @@ export async function resumeOperation({
           ? getErrorMessage(executed.output.error)
           : "Tool execution failed"
       const failureMessage = approvedActionFailureMessage(doc.title)
-      await persistResumeResult(
-        escalationId,
-        textMessage(failureMessage)
-      )
+      await persistResumeResult(escalationId, textMessage(failureMessage))
       await deliverOperationResult(ctx, failureMessage)
       if (doc.requestId) {
         const stillPending = await sdk.escalations.listContextDocs({

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -36,6 +36,7 @@ import {
 import { automationQueue } from "../automations"
 import sdk from "../sdk"
 import { getFullUser } from "../utilities/users"
+import { APPROVAL_REQUIRED_TITLE_PREFIX } from "./constants"
 import * as slack from "./notifications/slack"
 import * as teams from "./notifications/ms-teams"
 import { ProviderResponseError } from "./notifications/utils"
@@ -57,7 +58,7 @@ const GENERIC_APPROVED_ACTION_FAILURE_MESSAGE =
   "Your request was approved, but I couldn't complete it. Please try again."
 
 const approvedActionFailureMessage = (title?: string) => {
-  if (!title || title.startsWith("Approval required:")) {
+  if (!title || title.startsWith(APPROVAL_REQUIRED_TITLE_PREFIX)) {
     return GENERIC_APPROVED_ACTION_FAILURE_MESSAGE
   }
   const requestTitle = `${title.charAt(0).toLowerCase()}${title.slice(1)}`

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -601,10 +601,18 @@ export async function resumeOperation({
       const text = `The approved action failed: ${errorMessage}`
       await persistResumeResult(escalationId, textMessage(text))
       await deliverOperationResult(ctx, text)
-      await markEscalationRequestResolved({
-        status: "failed",
-        error: errorMessage,
-      })
+      if (doc.requestId) {
+        const stillPending = await sdk.escalations.listContextDocs({
+          requestId: doc.requestId,
+          resolution: "pending",
+        })
+        if (stillPending.length === 0) {
+          await markEscalationRequestResolved({
+            status: "failed",
+            error: errorMessage,
+          })
+        }
+      }
       return
     }
     approvalInstructions =

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -9,6 +9,7 @@ import {
 import {
   context,
   db as dbCore,
+  getErrorMessage,
   queue,
   roles,
   utils,
@@ -380,7 +381,7 @@ const executeApprovedToolCall = async ({
   } catch (error) {
     failed = true
     output = {
-      error: error instanceof Error ? error.message : String(error),
+      error: getErrorMessage(error),
     }
   }
 

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -545,7 +545,6 @@ export async function resumeOperation({
   // approval as user input.
   let approvalInstructions: string
   let messages: ModelMessage[]
-  let storedCallFailure: string | undefined
   let executedApproval: { toolName: string } | undefined
   // recordToolCall awaits an LLM summary internally - chain the calls in the
   // background (preserving completion order) and flush the tail (await
@@ -570,9 +569,6 @@ export async function resumeOperation({
       await markEscalationRequestResolved({ status: "failed", error: text })
       return
     }
-    if (executed.failed) {
-      storedCallFailure = executed.toolName
-    }
     if (doc.requestId) {
       const requestId = doc.requestId
       toolCallChain = toolCallChain.then(() =>
@@ -593,6 +589,23 @@ export async function resumeOperation({
             )
           })
       )
+    }
+    if (executed.failed) {
+      await toolCallChain
+      const errorMessage =
+        executed.output &&
+        typeof executed.output === "object" &&
+        "error" in executed.output
+          ? getErrorMessage(executed.output.error)
+          : "Tool execution failed"
+      const text = `The approved action failed: ${errorMessage}`
+      await persistResumeResult(escalationId, textMessage(text))
+      await deliverOperationResult(ctx, text)
+      await markEscalationRequestResolved({
+        status: "failed",
+        error: errorMessage,
+      })
+      return
     }
     approvalInstructions =
       "ESCALATION APPROVAL: The user's request in this conversation was " +
@@ -700,9 +713,6 @@ export async function resumeOperation({
 
   const pendingToolCalls = new Set<string>()
   const unrecoveredToolFailures = new Set<string>()
-  if (storedCallFailure) {
-    unrecoveredToolFailures.add(storedCallFailure)
-  }
   let needsInputUpdate = Promise.resolve()
 
   try {

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -53,6 +53,8 @@ export interface EscalationJob {
 
 const DEFAULT_CONCURRENCY = 1
 const DEFAULT_TIMEOUT_MS = 30000
+const APPROVED_ACTION_FAILURE_MESSAGE =
+  "Sorry, something went wrong and I couldn't complete that."
 
 const updateNotificationOutcome = async (
   notificationDocId: string,
@@ -598,9 +600,11 @@ export async function resumeOperation({
         "error" in executed.output
           ? getErrorMessage(executed.output.error)
           : "Tool execution failed"
-      const text = `The approved action failed: ${errorMessage}`
-      await persistResumeResult(escalationId, textMessage(text))
-      await deliverOperationResult(ctx, text)
+      await persistResumeResult(
+        escalationId,
+        textMessage(APPROVED_ACTION_FAILURE_MESSAGE)
+      )
+      await deliverOperationResult(ctx, APPROVED_ACTION_FAILURE_MESSAGE)
       if (doc.requestId) {
         const stillPending = await sdk.escalations.listContextDocs({
           requestId: doc.requestId,

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -53,8 +53,16 @@ export interface EscalationJob {
 
 const DEFAULT_CONCURRENCY = 1
 const DEFAULT_TIMEOUT_MS = 30000
-const APPROVED_ACTION_FAILURE_MESSAGE =
-  "Sorry, something went wrong and I couldn't complete that."
+const GENERIC_APPROVED_ACTION_FAILURE_MESSAGE =
+  "Your request was approved, but I couldn't complete it. Please try again."
+
+const approvedActionFailureMessage = (title?: string) => {
+  if (!title || title.startsWith("Approval required:")) {
+    return GENERIC_APPROVED_ACTION_FAILURE_MESSAGE
+  }
+  const requestTitle = `${title.charAt(0).toLowerCase()}${title.slice(1)}`
+  return `Your ${requestTitle} was approved, but I couldn't complete it. Please try again.`
+}
 
 const updateNotificationOutcome = async (
   notificationDocId: string,
@@ -600,11 +608,12 @@ export async function resumeOperation({
         "error" in executed.output
           ? getErrorMessage(executed.output.error)
           : "Tool execution failed"
+      const failureMessage = approvedActionFailureMessage(doc.title)
       await persistResumeResult(
         escalationId,
-        textMessage(APPROVED_ACTION_FAILURE_MESSAGE)
+        textMessage(failureMessage)
       )
-      await deliverOperationResult(ctx, APPROVED_ACTION_FAILURE_MESSAGE)
+      await deliverOperationResult(ctx, failureMessage)
       if (doc.requestId) {
         const stillPending = await sdk.escalations.listContextDocs({
           requestId: doc.requestId,

--- a/packages/server/src/sdk/workspace/ai/agents/escalationGate.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/escalationGate.ts
@@ -15,6 +15,7 @@ import {
 } from "@budibase/types"
 import type { ModelMessage } from "ai"
 import type { EscalationGateRuntime } from "../../../../ai/tools"
+import { APPROVAL_REQUIRED_TITLE_PREFIX } from "../../../../escalation/constants"
 import sdk from "../../.."
 import { escalationProcessor } from "../../../../escalation/processor"
 import { resolutionStrategyBinding } from "../../../../escalation/resolutionStrategies"
@@ -217,7 +218,7 @@ export const createEscalationGateRuntime = ({
       throw new Error("escalation gate: missing workspace context")
     }
 
-    let title = `Approval required: ${label}`
+    let title = `${APPROVAL_REQUIRED_TITLE_PREFIX} ${label}`
     let summary = summariseArgs(label, input)
     try {
       const copy = await gateContext.generateCardCopy?.({


### PR DESCRIPTION
## Description
Expose errors from escalated tools

### Before
The agent was claiming everything worked fine, but it failed under the hood
<img width="665" height="235" alt="image" src="https://github.com/user-attachments/assets/35ca9157-d3c1-4424-8ac1-76af7260e637" />
<img width="557" height="315" alt="image" src="https://github.com/user-attachments/assets/e7eaa7b1-8e19-45ea-8b74-6bb1d379152a" />


### After
<img width="566" height="378" alt="image" src="https://github.com/user-attachments/assets/048f24f3-4942-420a-96b2-4e84e02dfc32" />
<img width="701" height="90" alt="image" src="https://github.com/user-attachments/assets/670c69c0-a443-4f72-9dc3-b6670a1a5476" />





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Approved tool failures now surface the real error in logs and failure results, and the user gets a brief apology instead of the model narrating what went wrong; failed requests fail fast unless another escalation is still pending.

**Bug Fixes**
- Tool execution logs now include the error message, including object-shaped failures.
- Failed approved tools immediately persist a failure result and mark the request as failed when no other escalations are pending.
- Requests with another pending escalation stay open instead of being marked failed.
- The apology message references the request title when one is available.

<sup>Written for commit 0f067640f2e7dd39c2587a59bd1d33c98e076fac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





