### PR TITLE
Prevent duplicate escalation after approved tool execution

### DIFF
--- a/packages/builder/src/constants/index.ts
+++ b/packages/builder/src/constants/index.ts
@@ -30,11 +30,10 @@ export const ToolBindingPrefix = {
   BUDIBASE: "budibase",
   EXTERNAL: "external",
   SEARCH: "search",
-  ESCALATION: "escalation",
   TOOL: "tool",
 }
 
-export const RETIRED_TOOL_BINDING_NAMESPACES = [ToolBindingPrefix.ESCALATION]
+export const RETIRED_TOOL_BINDING_NAMESPACES = ["escalation"]
 
 // fields on the user table that cannot be edited
 export const UNEDITABLE_USER_FIELDS = [

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -317,6 +317,8 @@ describe("resumeOperation", () => {
         expect.objectContaining({
           executedApproval: {
             toolName: "book_meeting",
+            args: { title: "Procurement review" },
+            sourceId: undefined,
           },
         })
       )

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -634,6 +634,8 @@ export async function resumeOperation({
   let messages = [...ctx.messages, ...executed.messages]
   const executedApproval = {
     toolName: executed.toolName,
+    args: ctx.pendingToolCall.args,
+    sourceId: ctx.pendingToolCall.sourceId,
   }
 
   if (ctx.conversationId && ctx.attachmentIds?.length) {

--- a/packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts
@@ -6,6 +6,7 @@ import {
   Agent,
   AgentOperation,
   AgentMessageMetadata,
+  ApprovedToolCall,
   ChatConversationRequest,
   ContextUser,
   ApprovalToolResultStatus,
@@ -69,7 +70,7 @@ interface PrepareAgentChatRunParams {
   getRequestId?: () => string | undefined
   // Set on escalation-resume runs: the approved call that was just executed.
   // Its gate refuses instead of re-escalating - one approval, one attempt.
-  executedApproval?: { toolName: string }
+  executedApproval?: ApprovedToolCall
   outputSchema?: Record<string, any>
   promptMode?: "interactive" | "automation"
 }

--- a/packages/server/src/sdk/workspace/ai/agents/escalationGate.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/escalationGate.spec.ts
@@ -1,11 +1,42 @@
-import { ApprovalToolResultStatus, type AgentOperation } from "@budibase/types"
+import {
+  ApprovalToolResultStatus,
+  EscalationNotificationChannel,
+  type AgentOperation,
+} from "@budibase/types"
+import { escalationProcessor } from "../../../../escalation/processor"
 import { createEscalationGateRuntime } from "./escalationGate"
+
+jest.mock("@budibase/backend-core", () => {
+  const actual = jest.requireActual("@budibase/backend-core")
+  return {
+    ...actual,
+    context: {
+      ...actual.context,
+      getWorkspaceId: () => "app_1",
+      getTenantId: () => "tenant_1",
+    },
+  }
+})
 
 const operation: AgentOperation = {
   id: "operation_1",
   name: "Test operation",
   live: true,
   allowKnowledgeSourceDownload: false,
+  approvalPolicies: [
+    {
+      id: "policy_1",
+      name: "Manager approval",
+      notifications: {
+        recipients: [
+          {
+            type: EscalationNotificationChannel.SLACK,
+            config: { channelId: "C1" },
+          },
+        ],
+      },
+    },
+  ],
 }
 
 const createGate = (executedApproval: {
@@ -18,7 +49,7 @@ const createGate = (executedApproval: {
     operation,
     toolName: "book_meeting",
     sourceId: "automation_1",
-    rules: [],
+    rules: [{ policyId: "policy_1" }],
     gateContext: {
       sessionId: "session_1",
       getMessages: () => [],
@@ -28,6 +59,17 @@ const createGate = (executedApproval: {
   })
 
 describe("approved tool call identity", () => {
+  beforeEach(() => {
+    jest.spyOn(escalationProcessor, "create").mockResolvedValue({
+      escalationId: "escalation_1",
+      expiresAt: "2026-09-10T12:00:00.000Z",
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it("suppresses an exact repeat even when object key order differs", async () => {
     const gate = createGate({
       toolName: "book_meeting",
@@ -45,6 +87,7 @@ describe("approved tool call identity", () => {
         status: ApprovalToolResultStatus.ALREADY_APPROVED,
       })
     )
+    expect(escalationProcessor.create).not.toHaveBeenCalled()
   })
 
   it("allows a different call to the same tool through the gate", async () => {
@@ -56,7 +99,13 @@ describe("approved tool call identity", () => {
 
     await expect(
       gate.intercept({ title: "Retrospective" }, { toolCallId: "call_2" })
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual(
+      expect.objectContaining({
+        status: ApprovalToolResultStatus.PENDING_APPROVAL,
+        escalationId: "escalation_1",
+      })
+    )
+    expect(escalationProcessor.create).toHaveBeenCalledTimes(1)
   })
 
   it("does not suppress a call backed by a different source", async () => {
@@ -68,6 +117,12 @@ describe("approved tool call identity", () => {
 
     await expect(
       gate.intercept({ title: "Planning" }, { toolCallId: "call_2" })
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual(
+      expect.objectContaining({
+        status: ApprovalToolResultStatus.PENDING_APPROVAL,
+        escalationId: "escalation_1",
+      })
+    )
+    expect(escalationProcessor.create).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/server/src/sdk/workspace/ai/agents/escalationGate.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/escalationGate.spec.ts
@@ -1,0 +1,73 @@
+import { ApprovalToolResultStatus, type AgentOperation } from "@budibase/types"
+import { createEscalationGateRuntime } from "./escalationGate"
+
+const operation: AgentOperation = {
+  id: "operation_1",
+  name: "Test operation",
+  live: true,
+  allowKnowledgeSourceDownload: false,
+}
+
+const createGate = (executedApproval: {
+  toolName: string
+  sourceId?: string
+  args: unknown
+}) =>
+  createEscalationGateRuntime({
+    agentId: "agent_1",
+    operation,
+    toolName: "book_meeting",
+    sourceId: "automation_1",
+    rules: [],
+    gateContext: {
+      sessionId: "session_1",
+      getMessages: () => [],
+      getRequestId: () => undefined,
+      executedApproval,
+    },
+  })
+
+describe("approved tool call identity", () => {
+  it("suppresses an exact repeat even when object key order differs", async () => {
+    const gate = createGate({
+      toolName: "book_meeting",
+      sourceId: "automation_1",
+      args: { title: "Planning", attendees: ["A", "B"] },
+    })
+
+    await expect(
+      gate.intercept(
+        { attendees: ["A", "B"], title: "Planning" },
+        { toolCallId: "call_2" }
+      )
+    ).resolves.toEqual(
+      expect.objectContaining({
+        status: ApprovalToolResultStatus.ALREADY_APPROVED,
+      })
+    )
+  })
+
+  it("allows a different call to the same tool through the gate", async () => {
+    const gate = createGate({
+      toolName: "book_meeting",
+      sourceId: "automation_1",
+      args: { title: "Planning" },
+    })
+
+    await expect(
+      gate.intercept({ title: "Retrospective" }, { toolCallId: "call_2" })
+    ).resolves.toBeUndefined()
+  })
+
+  it("does not suppress a call backed by a different source", async () => {
+    const gate = createGate({
+      toolName: "book_meeting",
+      sourceId: "automation_2",
+      args: { title: "Planning" },
+    })
+
+    await expect(
+      gate.intercept({ title: "Planning" }, { toolCallId: "call_2" })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/server/src/sdk/workspace/ai/agents/escalationGate.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/escalationGate.ts
@@ -5,6 +5,7 @@ import {
   AgentOperation,
   AgentOperationApprovalPolicy,
   AgentRequester,
+  ApprovedToolCall,
   ChatConversationChannel,
   ApprovalToolResultStatus,
   EscalationSource,
@@ -14,6 +15,7 @@ import {
   ToolType,
 } from "@budibase/types"
 import type { ModelMessage } from "ai"
+import isEqual from "lodash/isEqual"
 import type { EscalationGateRuntime } from "../../../../ai/tools"
 import { APPROVAL_REQUIRED_TITLE_PREFIX } from "../../../../escalation/constants"
 import sdk from "../../.."
@@ -31,7 +33,7 @@ export interface EscalationGateContext {
   requester?: AgentRequester
   getMessages: () => ModelMessage[]
   getRequestId: () => string | undefined
-  executedApproval?: { toolName: string }
+  executedApproval?: ApprovedToolCall
   generateCardCopy?: (input: {
     label: string
     args: unknown
@@ -181,7 +183,12 @@ export const createEscalationGateRuntime = ({
   intercept: async (input, { toolCallId, messages }) => {
     const label = readableName ?? toolName
     const executed = gateContext.executedApproval
-    if (executed && executed.toolName === toolName) {
+    if (
+      executed &&
+      executed.toolName === toolName &&
+      executed.sourceId === sourceId &&
+      isEqual(executed.args, input)
+    ) {
       return {
         status: ApprovalToolResultStatus.ALREADY_APPROVED,
         note:

--- a/packages/types/src/documents/workspace/escalation.ts
+++ b/packages/types/src/documents/workspace/escalation.ts
@@ -48,6 +48,11 @@ export interface PendingToolCall {
   sourceId?: string
 }
 
+export type ApprovedToolCall = Pick<
+  PendingToolCall,
+  "toolName" | "args" | "sourceId"
+>
+
 export interface SuspendedOperationContext {
   agentId: string
   operationId: string


### PR DESCRIPTION
## Description
Prevent duplicate escalation after approved tool execution

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the approval gate from suppressing a genuinely new call to the same tool, and removes the legacy escalation surface.

- The gate previously suppressed by tool name only; it now suppresses only when tool name, source, and args all match (deep-equal args, so key order doesn't matter), and a same-tool call with different args or source escalates normally again.
- Removes the deprecated `escalate` tool, `list_session_escalations`, the escalation bindings/icons, and the per-operation `escalation` config; approvals now flow through the gate.
- An expired escalation stays retryable when the pending-check fails, and a request with another approval in flight stays pending rather than closing.

<sup>Written for commit 4bf481c3a32abfc88d2a3d6258c32416ebb0d1ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

