### PR TITLE
fix: graceful logout on invalidated session instead of workspace crash

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/_layout.workspace.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/_layout.workspace.svelte
@@ -50,6 +50,16 @@
       await deploymentStore.load()
     } catch (error: any) {
       console.error(`Error initialising app: ${error?.message}`)
+
+      // Initialisation can fail because the session was invalidated
+      // elsewhere, e.g. by visiting another cloud tenant. In that case log
+      // out gracefully (preserving a return URL) instead of leaving the
+      // user stuck on a crash page until they refresh.
+      await auth.getSelf()
+      if (!$auth.user) {
+        return auth.logout()
+      }
+
       sideNav.show()
 
       throw error


### PR DESCRIPTION
## Description

Re-opening of #19643 at @melohagan's request ([comment](https://github.com/Budibase/budibase/issues/19420#issuecomment-5614424720)) - GitHub would not reopen the original PR after the ticket-check bot closed it (issue was unassigned at first open; it is now assigned to breken-ai).

Root cause: the builder only treats 401 (`clearSession` -> layout redirect) and 403 (reload) as session-death signals; everything else renders the "Something went wrong" dead end. `GET /api/applications/:appId/appPackage` sits on `publicRoutes` guarded only by `ensureUserBelongsToWorkspaceTenant` (middleware `ensureUserBelongsToWorkspaceTenant.ts:11-18`), which 401s ONLY for an existing wrong-tenant session - a fully invalidated session (no `ctx.user`) passes straight through. So after switching cloud tenants, the workspace switch surfaces an unhandled error instead of a graceful logout. A full refresh works because the bootstrap self-call does 401.

Fix: the workspace layout's init catch probes the session via `auth.getSelf()` (non-throwing) before showing the crash page: session gone -> normal `auth.logout()` with the return URL preserved; genuine errors with a valid session still render the error page. Mirrors the tenant-mismatch precedent in `stores/portal/auth.ts:240`. Frontend-only, +10 lines.

Verification honesty: this fix is NOT execution-verified - the cloud multi-tenant repro needs the closed-source account portal, and we could not build a harness for it. The change is small, frontend-only, and mirrors an existing pattern in the same codebase. Builder lint/typecheck left to CI.

## Addresses
- #19420

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the builder workspace crashing when the session is invalidated elsewhere, such as after switching cloud tenants. Initialization failures now probe the session with `auth.getSelf()` and run the normal logout (preserving the return URL) when the session is gone, instead of leaving users on the error page until they refresh; genuine errors with a valid session still show the error page.

<sup>Written for commit d7e20c306eefce1dff64e0d70ba490c8c169dfce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

