### PR TITLE
Rename appStore to workspaceStore in builder package

### DIFF
--- a/packages/builder/src/api.ts
+++ b/packages/builder/src/api.ts
@@ -3,7 +3,7 @@ import {
   CookieUtils,
   createAPIClient,
 } from "@budibase/frontend-core"
-import { appStore } from "@/stores/builder"
+import { workspaceStore } from "@/stores/builder"
 import { get } from "svelte/store"
 import { auth, navigation } from "./stores/portal"
 import { sdk, Header, ClientHeader } from "@budibase/shared-core"
@@ -16,7 +16,7 @@ const newClient = (opts?: { production?: boolean }) =>
         /^\/api\/applications\/app_dev_/.test(request.url)
 
       // Attach the workspace ID header from the store.
-      const workspaceId = get(appStore).appId
+      const workspaceId = get(workspaceStore).appId
       if (workspaceId) {
         if (!isWorkspaceDeleteRequest) {
           headers[Header.WORKSPACE_ID] = opts?.production

--- a/packages/builder/src/components/automation/AutomationBuilder/BranchStepPanel.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/BranchStepPanel.test.ts
@@ -39,7 +39,7 @@ const mocks = vi.hoisted(() => {
         branchIdx: 0,
       },
     }),
-    appStore: store({ appId: "app" }),
+    workspaceStore: store({ appId: "app" }),
     componentStore: store({}),
     deploymentStore: store({}),
     environment: store({ variables: [] }),
@@ -111,7 +111,7 @@ Object.assign(mocks.automationStore, {
 })
 
 vi.mock("@/stores/builder", () => ({
-  appStore: mocks.appStore,
+  workspaceStore: mocks.workspaceStore,
   automationStore: mocks.automationStore,
   componentStore: mocks.componentStore,
   deploymentStore: mocks.deploymentStore,

--- a/packages/builder/src/components/automation/AutomationPanel/CreateAutomationModal.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/CreateAutomationModal.svelte
@@ -1,7 +1,7 @@
 <script>
   import { getErrorMessage } from "@/helpers/errors"
   import { goto as gotoStore } from "@roxi/routify"
-  import { appStore, automationStore } from "@/stores/builder"
+  import { workspaceStore, automationStore } from "@/stores/builder"
   import {
     notifications,
     Input,
@@ -31,7 +31,7 @@
 
   async function createAutomation() {
     try {
-      const workspaceId = $appStore.appId
+      const workspaceId = $workspaceStore.appId
       const trigger = automationStore.actions.constructBlock(
         "TRIGGER",
         triggerVal.stepId,

--- a/packages/builder/src/components/automation/SetupPanel/BlockData.spec.ts
+++ b/packages/builder/src/components/automation/SetupPanel/BlockData.spec.ts
@@ -41,7 +41,7 @@ const mocks = vi.hoisted(() => {
 
   return {
     automationStore,
-    appStore: createStore({}),
+    workspaceStore: createStore({}),
     deploymentStore: createStore({}),
     permissions: createStore({}),
     selectedAutomation: createStore({
@@ -65,7 +65,7 @@ Object.assign(mocks.automationStore, {
 })
 
 vi.mock("@/stores/builder", () => ({
-  appStore: mocks.appStore,
+  workspaceStore: mocks.workspaceStore,
   automationStore: mocks.automationStore,
   deploymentStore: mocks.deploymentStore,
   permissions: mocks.permissions,

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridAutomationsButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridAutomationsButton.svelte
@@ -2,7 +2,7 @@
   import { ActionButton, List, ListItem, Button } from "@budibase/bbui"
   import DetailPopover from "@/components/common/DetailPopover.svelte"
   import { TriggerStepID } from "@/constants/backend/automations"
-  import { automationStore, appStore } from "@/stores/builder"
+  import { automationStore, workspaceStore } from "@/stores/builder"
   import { createEventDispatcher, getContext } from "svelte"
 
   const dispatch = createEventDispatcher()
@@ -61,7 +61,7 @@
             ? "var(--spectrum-global-color-gray-600)"
             : "var(--spectrum-global-color-green-600)"}
           title={automation.name}
-          url={`/builder/workspace/${$appStore.appId}/automation/${automation._id}`}
+          url={`/builder/workspace/${$workspaceStore.appId}/automation/${automation._id}`}
           showArrow
         />
       {/each}

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridRowActionsButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridRowActionsButton.svelte
@@ -34,13 +34,16 @@
   $: actionCount = isView ? viewRowActions.length : tableRowActions.length
   $: newNameInvalid = newName && tableRowActions.some(x => x.name === newName)
 
-  const rowActionUrl = derived([url, workspaceStore], ([$url, $workspaceStore]) => {
-    return ({ automationId }) => {
-      return $url(
-        `/builder/workspace/${$workspaceStore.appId}/automation/${automationId}`
-      )
+  const rowActionUrl = derived(
+    [url, workspaceStore],
+    ([$url, $workspaceStore]) => {
+      return ({ automationId }) => {
+        return $url(
+          `/builder/workspace/${$workspaceStore.appId}/automation/${automationId}`
+        )
+      }
     }
-  })
+  )
 
   const toggleAction = async (action, enabled) => {
     if (enabled) {

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridRowActionsButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridRowActionsButton.svelte
@@ -12,7 +12,7 @@
   } from "@budibase/bbui"
   import DetailPopover from "@/components/common/DetailPopover.svelte"
   import { getContext } from "svelte"
-  import { appStore, rowActions } from "@/stores/builder"
+  import { workspaceStore, rowActions } from "@/stores/builder"
   import { goto as gotoStore, url } from "@roxi/routify"
   import { derived } from "svelte/store"
 
@@ -34,10 +34,10 @@
   $: actionCount = isView ? viewRowActions.length : tableRowActions.length
   $: newNameInvalid = newName && tableRowActions.some(x => x.name === newName)
 
-  const rowActionUrl = derived([url, appStore], ([$url, $appStore]) => {
+  const rowActionUrl = derived([url, workspaceStore], ([$url, $workspaceStore]) => {
     return ({ automationId }) => {
       return $url(
-        `/builder/workspace/${$appStore.appId}/automation/${automationId}`
+        `/builder/workspace/${$workspaceStore.appId}/automation/${automationId}`
       )
     }
   })

--- a/packages/builder/src/components/backend/DatasourceNavigator/DatasourceNavItem/DatasourceNavItem.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/DatasourceNavItem/DatasourceNavItem.svelte
@@ -2,7 +2,7 @@
   import { isActive, goto, params } from "@roxi/routify"
   import { BUDIBASE_INTERNAL_DB_ID } from "@/constants/backend"
   import {
-    appStore,
+    workspaceStore,
     contextMenuStore,
     datasources,
     integrations,
@@ -77,7 +77,7 @@
 
   const refreshDataStores = async () => {
     try {
-      await appStore.refresh()
+      await workspaceStore.refresh()
     } catch (error) {
       console.error(error)
       notifications.warning(

--- a/packages/builder/src/components/backend/TableNavigator/TableNavItem/TableNavItem.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/TableNavItem/TableNavItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {
-    appStore,
+    workspaceStore,
     tables as tablesStore,
     userSelectedResourceMap,
     contextMenuStore,
@@ -86,7 +86,7 @@
     assignProjectModal?.hide()
 
     try {
-      await appStore.refresh()
+      await workspaceStore.refresh()
     } catch (error) {
       console.error(error)
       notifications.warning(

--- a/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
+++ b/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Link, notifications } from "@budibase/bbui"
   import {
-    appStore,
+    workspaceStore,
     datasources,
     queries,
     screenStore,
@@ -84,7 +84,7 @@
   ): { text: string; url: string }[] {
     return screens.map(({ url, _id }) => ({
       text: url,
-      url: `/builder/workspace/${$appStore.appId}/design/${_id}`,
+      url: `/builder/workspace/${$workspaceStore.appId}/design/${_id}`,
     }))
   }
 
@@ -120,7 +120,7 @@
         await viewsV2.delete(viewV2)
         if (isSelected) {
           goto(
-            `/builder/workspace/${$appStore.appId}/data/table/${viewV2.tableId}`
+            `/builder/workspace/${$workspaceStore.appId}/data/table/${viewV2.tableId}`
           )
         }
       } else {
@@ -159,7 +159,7 @@
       // Go back to the datasource if we are deleting the active query
       if ($queries.selectedQueryId === query._id) {
         markSkipUnsavedPrompt(query._id)
-        const appId = $appStore.appId
+        const appId = $workspaceStore.appId
         const datasource = $datasources.list.find(
           ds => ds._id === query.datasourceId
         )

--- a/packages/builder/src/components/commandPalette/CommandPalette.svelte
+++ b/packages/builder/src/components/commandPalette/CommandPalette.svelte
@@ -13,7 +13,7 @@
     automationStore,
     previewStore,
     sortedScreens,
-    appStore,
+    workspaceStore,
     datasources,
     queries,
     tables,
@@ -67,7 +67,7 @@
       type: "Preview",
       name: "Published App",
       icon: "play",
-      action: () => window.open(`/app${$appStore.url}`),
+      action: () => window.open(`/app${$workspaceStore.url}`),
       requiresApp: true,
     },
     {
@@ -364,7 +364,7 @@
 
   async function deployApp() {
     try {
-      await API.publishAppChanges($appStore.appId)
+      await API.publishAppChanges($workspaceStore.appId)
       notifications.success("App published successfully")
     } catch (error) {
       notifications.error("Error publishing app")

--- a/packages/builder/src/components/commandPalette/CommandPalette.test.ts
+++ b/packages/builder/src/components/commandPalette/CommandPalette.test.ts
@@ -60,7 +60,7 @@ vi.mock("@/stores/builder", async () => {
       showPreview: mocks.showPreview,
     },
     sortedScreens: writable([]),
-    appStore: writable({
+    workspaceStore: writable({
       appId: "app_1",
       url: "/test-app",
     }),

--- a/packages/builder/src/components/common/Dropzone.spec.js
+++ b/packages/builder/src/components/common/Dropzone.spec.js
@@ -15,7 +15,7 @@ vi.mock("@/stores/portal", async () => {
 vi.mock("@/stores/builder", async () => {
   return {
     workspaceAppStore: writable({}),
-    appStore: writable({}),
+    workspaceStore: writable({}),
   }
 })
 

--- a/packages/builder/src/components/common/ProjectSelect.svelte
+++ b/packages/builder/src/components/common/ProjectSelect.svelte
@@ -2,7 +2,7 @@
   import { Multiselect, type LabelPosition } from "@budibase/bbui"
   import { FeatureFlag } from "@budibase/types"
   import { featureFlags, projectsStore } from "@/stores/portal"
-  import { appStore } from "@/stores/builder"
+  import { workspaceStore } from "@/stores/builder"
 
   interface ProjectOption {
     label: string
@@ -27,7 +27,7 @@
   let fetchError: string | undefined = $state()
 
   const projectsEnabled = $derived($featureFlags[FeatureFlag.PROJECTS])
-  const workspaceId = $derived($appStore.appId)
+  const workspaceId = $derived($workspaceStore.appId)
   const options: ProjectOption[] = $derived(
     $projectsStore.map(project => ({
       label: project.name,

--- a/packages/builder/src/components/common/PublishMenu.svelte
+++ b/packages/builder/src/components/common/PublishMenu.svelte
@@ -11,7 +11,7 @@
     deploymentStore,
     automationStore,
     workspaceAppStore,
-    appStore,
+    workspaceStore,
   } from "@/stores/builder"
   import { agentsStore } from "@/stores/portal"
   import { PluginType, type Plugin } from "@budibase/types"
@@ -34,7 +34,7 @@
     return getPluginSvelteMajor(plugin) ?? LEGACY_SVELTE_MAJOR
   }
 
-  $: incompatiblePlugins = ($appStore.usedPlugins || []).filter(plugin => {
+  $: incompatiblePlugins = ($workspaceStore.usedPlugins || []).filter(plugin => {
     const major = getPluginSvelteMajor(plugin)
     const isComponentPlugin = plugin?.schema?.type === PluginType.COMPONENT
     return major !== CURRENT_SVELTE_MAJOR && isComponentPlugin
@@ -65,11 +65,11 @@
   }
 
   let hasAcknowledgedWarning = hasAcknowledgedSvelte4PluginWarning(
-    $appStore.appId
+    $workspaceStore.appId
   )
 
   $: hasAcknowledgedWarning = hasAcknowledgedSvelte4PluginWarning(
-    $appStore.appId
+    $workspaceStore.appId
   )
 
   const showPluginWarningModal = () => {
@@ -95,7 +95,7 @@
   }
 
   const publishAnyway = async () => {
-    acknowledgeSvelte4PluginWarning($appStore.appId)
+    acknowledgeSvelte4PluginWarning($workspaceStore.appId)
     hasAcknowledgedWarning = true
     actionMenu?.hide?.()
     pluginWarningModal?.hide()

--- a/packages/builder/src/components/common/PublishMenu.svelte
+++ b/packages/builder/src/components/common/PublishMenu.svelte
@@ -34,11 +34,13 @@
     return getPluginSvelteMajor(plugin) ?? LEGACY_SVELTE_MAJOR
   }
 
-  $: incompatiblePlugins = ($workspaceStore.usedPlugins || []).filter(plugin => {
-    const major = getPluginSvelteMajor(plugin)
-    const isComponentPlugin = plugin?.schema?.type === PluginType.COMPONENT
-    return major !== CURRENT_SVELTE_MAJOR && isComponentPlugin
-  })
+  $: incompatiblePlugins = ($workspaceStore.usedPlugins || []).filter(
+    plugin => {
+      const major = getPluginSvelteMajor(plugin)
+      const isComponentPlugin = plugin?.schema?.type === PluginType.COMPONENT
+      return major !== CURRENT_SVELTE_MAJOR && isComponentPlugin
+    }
+  )
 
   const hasAcknowledgedSvelte4PluginWarning = (appId?: string) => {
     const key = `bb:publish:svelte4-plugin-warning-ack:${appId}`

--- a/packages/builder/src/components/common/ScreensPopover.svelte
+++ b/packages/builder/src/components/common/ScreensPopover.svelte
@@ -6,7 +6,7 @@
     PopoverAlignment,
   } from "@budibase/bbui"
   import DetailPopover from "@/components/common/DetailPopover.svelte"
-  import { appStore, workspaceAppStore } from "@/stores/builder"
+  import { workspaceStore, workspaceAppStore } from "@/stores/builder"
   import type { ScreenUsage } from "@budibase/types"
 
   export let screens: ScreenUsage[] = []
@@ -65,7 +65,7 @@
         {#each appScreens as screen}
           <ListItem
             title={screen.url}
-            url={`/builder/workspace/${$appStore.appId}/design/${screen._id}`}
+            url={`/builder/workspace/${$workspaceStore.appId}/design/${screen._id}`}
             showArrow
           />
         {/each}

--- a/packages/builder/src/components/common/UpdateWorkspaceForm.svelte
+++ b/packages/builder/src/components/common/UpdateWorkspaceForm.svelte
@@ -9,7 +9,7 @@
   } from "@budibase/bbui"
   import { AppStatus } from "@/constants"
   import { initialise } from "@/stores/builder"
-  import { appStore } from "@/stores/builder/workspace"
+  import { workspaceStore } from "@/stores/builder/workspace"
   import { workspacesStore } from "@/stores/portal/workspaces"
   import { API } from "@/api"
   import { writable } from "svelte/store"
@@ -50,15 +50,15 @@
   let initialised = false
 
   $: filteredApps = $workspacesStore.apps.filter(
-    app => app.devId === $appStore.appId
+    app => app.devId === $workspaceStore.appId
   )
   $: app = filteredApps[0]
   $: appDeployed = app?.status === AppStatus.DEPLOYED
 
-  $: appName = $appStore.name
-  $: appURL = $appStore.url
-  $: appIconName = $appStore.icon?.name
-  $: appIconColor = $appStore.icon?.color
+  $: appName = $workspaceStore.name
+  $: appURL = $workspaceStore.url
+  $: appIconName = $workspaceStore.icon?.name
+  $: appIconColor = $workspaceStore.icon?.color
 
   $: appMeta = {
     name: appName,
@@ -139,7 +139,7 @@
 
   async function updateApp() {
     try {
-      await workspacesStore.save($appStore.appId, {
+      await workspacesStore.save($workspaceStore.appId, {
         name: $values.name?.trim(),
         url: $values.url?.trim(),
         icon: {
@@ -157,7 +157,7 @@
   }
 
   const initialiseApp = async () => {
-    const applicationPkg = await API.fetchAppPackage($appStore.appId)
+    const applicationPkg = await API.fetchAppPackage($workspaceStore.appId)
     await initialise(applicationPkg)
   }
 </script>

--- a/packages/builder/src/components/common/UsagePopover.svelte
+++ b/packages/builder/src/components/common/UsagePopover.svelte
@@ -6,7 +6,7 @@
     PopoverAlignment,
   } from "@budibase/bbui"
   import DetailPopover from "@/components/common/DetailPopover.svelte"
-  import { appStore, workspaceAppStore } from "@/stores/builder"
+  import { workspaceStore, workspaceAppStore } from "@/stores/builder"
   import type { ScreenUsage, AutomationUsage } from "@budibase/types"
 
   interface Props {
@@ -81,7 +81,7 @@
           {#each appScreens as screen}
             <ListItem
               title={screen.url}
-              url={`/builder/workspace/${$appStore.appId}/design/${screen._id}`}
+              url={`/builder/workspace/${$workspaceStore.appId}/design/${screen._id}`}
               showArrow
             />
           {/each}
@@ -98,7 +98,7 @@
               ? "var(--spectrum-global-color-gray-600)"
               : "var(--spectrum-global-color-green-600)"}
             title={automation.name}
-            url={`/builder/workspace/${$appStore.appId}/automation/${automation._id}`}
+            url={`/builder/workspace/${$workspaceStore.appId}/automation/${automation._id}`}
             showArrow
           />
         {/each}

--- a/packages/builder/src/components/common/WorkspaceSelect.svelte
+++ b/packages/builder/src/components/common/WorkspaceSelect.svelte
@@ -6,7 +6,7 @@
   import { processStringSync } from "@budibase/string-templates"
   import WorkspaceContextMenuModals from "@/components/start/WorkspaceContextMenuModals.svelte"
   import getWorkspaceContextMenuItems from "@/components/start/getWorkspaceContextMenuItems"
-  import { appStore } from "@/stores/builder"
+  import { workspaceStore } from "@/stores/builder"
   import { contextMenuStore } from "@/stores/builder/contextMenu"
   import { bb } from "@/stores/bb"
   import { enrichedApps, auth, licensing } from "@/stores/portal"
@@ -48,7 +48,7 @@
     | undefined
 
   $: apps = $enrichedApps
-  $: appId = $appStore.appId
+  $: appId = $workspaceStore.appId
   $: currentSort = $sortBy
   $: canManageWorkspaceCreation =
     !!$auth.user && sdk.users.canCreateApps($auth.user)
@@ -237,11 +237,11 @@
         role="button"
         tabindex="0"
         class="workspace-menu-text"
-        title={$appStore.name}
+        title={$workspaceStore.name}
         aria-haspopup="menu"
         aria-expanded={open}
       >
-        <span>{$appStore.name}</span>
+        <span>{$workspaceStore.name}</span>
         <Icon size="M" name={!open ? "caret-down" : "caret-up"} />
       </div>
     </div>

--- a/packages/builder/src/components/deploy/DeleteModal.svelte
+++ b/packages/builder/src/components/deploy/DeleteModal.svelte
@@ -2,7 +2,7 @@
   import { Input, notifications } from "@budibase/bbui"
   import { goto as gotoStore } from "@roxi/routify"
   import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
-  import { appStore } from "@/stores/builder"
+  import { workspaceStore } from "@/stores/builder"
   import { workspacesStore, enrichedApps } from "@/stores/portal"
   import { API } from "@/api"
   import { get } from "svelte/store"
@@ -49,14 +49,14 @@
       return
     }
     deleting = true
-    const deletedCurrentWorkspace = $appStore.appId === appId
+    const deletedCurrentWorkspace = $workspaceStore.appId === appId
     let deletedSuccessfully = false
     try {
       await API.deleteApp(appId)
       deletedSuccessfully = true
 
       if (deletedCurrentWorkspace) {
-        appStore.reset()
+        workspaceStore.reset()
       }
       notifications.success("Workspace deleted successfully")
       try {

--- a/packages/builder/src/components/deploy/RevertModal.svelte
+++ b/packages/builder/src/components/deploy/RevertModal.svelte
@@ -1,6 +1,6 @@
 <script>
   import { Input, Modal, notifications, ModalContent } from "@budibase/bbui"
-  import { appStore, initialise } from "@/stores/builder"
+  import { workspaceStore, initialise } from "@/stores/builder"
   import { API } from "@/api"
 
   export let onComplete = () => {}
@@ -8,7 +8,7 @@
   let revertModal
   let appName
 
-  $: appId = $appStore.appId
+  $: appId = $workspaceStore.appId
 
   const revert = async () => {
     try {
@@ -38,7 +38,7 @@
     title="Revert changes"
     confirmText="Revert"
     onConfirm={revert}
-    disabled={appName !== $appStore.name}
+    disabled={appName !== $workspaceStore.name}
   >
     <span>
       The changes you have made will be deleted and the workspace reverted back

--- a/packages/builder/src/components/deploy/VersionModal.svelte
+++ b/packages/builder/src/components/deploy/VersionModal.svelte
@@ -107,8 +107,8 @@
       <Body size="S">
         This workspace is currently using version
         <b>{$workspaceStore.version}</b>, but version
-        <b>{$workspaceStore.upgradableVersion}</b> is available. Updates can contain new
-        features, performance improvements and bug fixes.
+        <b>{$workspaceStore.upgradableVersion}</b> is available. Updates can contain
+        new features, performance improvements and bug fixes.
       </Body>
     {:else}
       <Body size="S">

--- a/packages/builder/src/components/deploy/VersionModal.svelte
+++ b/packages/builder/src/components/deploy/VersionModal.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { appStore, initialise } from "@/stores/builder"
+  import { workspaceStore, initialise } from "@/stores/builder"
   import {
     Body,
     Button,
@@ -28,13 +28,13 @@
 
   let updateModal
 
-  $: appId = $appStore.appId
+  $: appId = $workspaceStore.appId
   $: updateAvailable =
-    ($appStore.upgradableVersion &&
-      $appStore.version &&
-      $appStore.upgradableVersion !== $appStore.version) ||
+    ($workspaceStore.upgradableVersion &&
+      $workspaceStore.version &&
+      $workspaceStore.upgradableVersion !== $workspaceStore.version) ||
     $admin.isDev
-  $: revertAvailable = $appStore.revertableVersion != null
+  $: revertAvailable = $workspaceStore.revertableVersion != null
 
   const refreshAppPackage = async () => {
     try {
@@ -52,7 +52,7 @@
       // Don't wait for the async refresh, since this causes modal flashing
       refreshAppPackage()
       notifications.success(
-        `App updated successfully to version ${$appStore.upgradableVersion}`
+        `App updated successfully to version ${$workspaceStore.upgradableVersion}`
       )
       onComplete()
     } catch (err) {
@@ -70,7 +70,7 @@
       // Don't wait for the async refresh, since this causes modal flashing
       refreshAppPackage()
       notifications.success(
-        `Workspace reverted successfully to version ${$appStore.revertableVersion}`
+        `Workspace reverted successfully to version ${$workspaceStore.revertableVersion}`
       )
     } catch (err) {
       notifications.error(err?.message || err || "Error reverting app")
@@ -106,14 +106,14 @@
     {#if updateAvailable}
       <Body size="S">
         This workspace is currently using version
-        <b>{$appStore.version}</b>, but version
-        <b>{$appStore.upgradableVersion}</b> is available. Updates can contain new
+        <b>{$workspaceStore.version}</b>, but version
+        <b>{$workspaceStore.upgradableVersion}</b> is available. Updates can contain new
         features, performance improvements and bug fixes.
       </Body>
     {:else}
       <Body size="S">
         This workspace is currently using version
-        <b>{$appStore.version}</b> which is the latest version available.
+        <b>{$workspaceStore.version}</b> which is the latest version available.
       </Body>
     {/if}
     <Body size="S">
@@ -125,7 +125,7 @@
     {#if revertAvailable}
       <Body size="S">
         You can revert this workspace to client version
-        <b>{$appStore.revertableVersion}</b>
+        <b>{$workspaceStore.revertableVersion}</b>
         if you're experiencing issues with the current version.
       </Body>
     {/if}

--- a/packages/builder/src/components/design/ScreenDetailsModal.svelte
+++ b/packages/builder/src/components/design/ScreenDetailsModal.svelte
@@ -2,7 +2,7 @@
   import { ModalContent, Input, keepOpen } from "@budibase/bbui"
   import sanitizeUrl from "@/helpers/sanitizeUrl"
   import { get } from "svelte/store"
-  import { screenStore, workspaceAppStore, appStore } from "@/stores/builder"
+  import { screenStore, workspaceAppStore, workspaceStore } from "@/stores/builder"
   import { buildLiveUrl } from "@/helpers/urls"
 
   export let onConfirm: (data: { route: string }) => Promise<void>
@@ -19,7 +19,7 @@
 
   $: workspacePrefix = selectedWorkspaceApp ? selectedWorkspaceApp.url : ""
 
-  $: liveUrl = buildLiveUrl($appStore, workspacePrefix, true)
+  $: liveUrl = buildLiveUrl($workspaceStore, workspacePrefix, true)
 
   $: hashRoute = !route ? "" : `#${route}`
 

--- a/packages/builder/src/components/design/ScreenDetailsModal.svelte
+++ b/packages/builder/src/components/design/ScreenDetailsModal.svelte
@@ -2,7 +2,11 @@
   import { ModalContent, Input, keepOpen } from "@budibase/bbui"
   import sanitizeUrl from "@/helpers/sanitizeUrl"
   import { get } from "svelte/store"
-  import { screenStore, workspaceAppStore, workspaceStore } from "@/stores/builder"
+  import {
+    screenStore,
+    workspaceAppStore,
+    workspaceStore,
+  } from "@/stores/builder"
   import { buildLiveUrl } from "@/helpers/urls"
 
   export let onConfirm: (data: { route: string }) => Promise<void>

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/index.js
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/index.js
@@ -18,7 +18,9 @@ export const getAvailableActions = (getAllActions = false) => {
       if (getAllActions || !action.dependsOnFeature) {
         return true
       }
-      return get(workspaceStore).clientFeatures?.[action.dependsOnFeature] === true
+      return (
+        get(workspaceStore).clientFeatures?.[action.dependsOnFeature] === true
+      )
     })
     .map(action => {
       // Then enrich the actions with real components

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/index.js
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/index.js
@@ -1,6 +1,6 @@
 import * as ActionComponents from "./actions"
 import { get } from "svelte/store"
-import { appStore } from "@/stores/builder"
+import { workspaceStore } from "@/stores/builder"
 // @ts-ignore
 import ActionDefinitions from "./manifest.json"
 
@@ -18,7 +18,7 @@ export const getAvailableActions = (getAllActions = false) => {
       if (getAllActions || !action.dependsOnFeature) {
         return true
       }
-      return get(appStore).clientFeatures?.[action.dependsOnFeature] === true
+      return get(workspaceStore).clientFeatures?.[action.dependsOnFeature] === true
     })
     .map(action => {
       // Then enrich the actions with real components

--- a/packages/builder/src/components/design/settings/controls/Explanation/Explanation.svelte
+++ b/packages/builder/src/components/design/settings/controls/Explanation/Explanation.svelte
@@ -16,7 +16,7 @@
     DateAsNumber,
   } from "./lines"
   import subjects from "./subjects"
-  import { appStore } from "@/stores/builder"
+  import { workspaceStore } from "@/stores/builder"
 
   export let tableHref = () => {}
   export let schema
@@ -26,7 +26,7 @@
 
   $: explanationWithPresets = getExplanationWithPresets(
     explanation,
-    $appStore.typeSupportPresets
+    $workspaceStore.typeSupportPresets
   )
   let support
   let messages = []

--- a/packages/builder/src/components/integration/APIEndpointViewer.spec.ts
+++ b/packages/builder/src/components/integration/APIEndpointViewer.spec.ts
@@ -184,7 +184,7 @@ vi.mock("@/stores/builder", async () => {
     tables: writable({ list: [] }),
     datasources,
     flags: writable({}),
-    appStore: writable({ appId: "app_test" }),
+    workspaceStore: writable({ appId: "app_test" }),
     workspaceAppStore: writable({
       selectedWorkspaceAppId: null,
       selectedWorkspaceApp: null,

--- a/packages/builder/src/components/integration/APIEndpointViewer.svelte
+++ b/packages/builder/src/components/integration/APIEndpointViewer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { goto as gotoStore, beforeUrlChange } from "@roxi/routify"
-  import { flags, appStore } from "@/stores/builder"
+  import { flags, workspaceStore } from "@/stores/builder"
   import {
     datasources,
     hasRestTemplate,
@@ -692,7 +692,7 @@
       if (isNew && redirectIfNew && !saveAndClose) {
         markSkipUnsavedPrompt(_id)
         workspaceConnections.discardDraft()
-        goto(`/builder/workspace/${$appStore.appId}/apis/query/${_id}`)
+        goto(`/builder/workspace/${$workspaceStore.appId}/apis/query/${_id}`)
         return { ok: true }
       }
 

--- a/packages/builder/src/components/integration/RequestPanel.spec.ts
+++ b/packages/builder/src/components/integration/RequestPanel.spec.ts
@@ -9,7 +9,7 @@ vi.mock("@/stores/builder", async () => {
     tables: writable({ list: [] }),
     datasources: writable({ list: [] }),
     flags: writable({}),
-    appStore: writable({ appId: "app_test" }),
+    workspaceStore: writable({ appId: "app_test" }),
   }
 })
 

--- a/packages/builder/src/components/integration/ResponsePanel.spec.ts
+++ b/packages/builder/src/components/integration/ResponsePanel.spec.ts
@@ -9,7 +9,7 @@ vi.mock("@/stores/builder", async () => {
     tables: writable({ list: [] }),
     datasources: writable({ list: [] }),
     flags: writable({}),
-    appStore: writable({ appId: "app_test" }),
+    workspaceStore: writable({ appId: "app_test" }),
   }
 })
 

--- a/packages/builder/src/dataBinding.test.ts
+++ b/packages/builder/src/dataBinding.test.ts
@@ -101,7 +101,7 @@ function createBuilderStores() {
   const queries = createMockStore({ list: [] })
   const roles = createMockStore({ list: [] })
   const screenStore = createMockStore({ screens: [] })
-  const appStore = createMockStore({})
+  const workspaceStore = createMockStore({})
   const layoutStore = createMockStore({})
   const selectedScreen = createMockStore(null)
   const componentStore: MockComponentStore = {
@@ -136,12 +136,12 @@ function createBuilderStores() {
       queries,
       roles,
       screenStore,
-      appStore,
+      workspaceStore,
       layoutStore,
       selectedScreen,
       componentStore,
     },
-    appStore,
+    workspaceStore,
     layoutStore,
     roles,
     screenStore,
@@ -166,7 +166,7 @@ function createPortalStores() {
 vi.mock("@/stores/portal", () => createPortalStores().module)
 
 import {
-  appStore,
+  workspaceStore,
   componentStore,
   layoutStore,
   roles as rolesStore,
@@ -182,7 +182,7 @@ const getTablesStore = () =>
 const getQueriesStore = () =>
   queriesStore as unknown as MockStore<{ list: unknown[] }>
 const getAppStore = () =>
-  appStore as unknown as MockStore<Record<string, unknown>>
+  workspaceStore as unknown as MockStore<Record<string, unknown>>
 const getLayoutStore = () =>
   layoutStore as unknown as MockStore<Record<string, unknown>>
 const getRolesStore = () => rolesStore as unknown as MockStore<unknown[]>

--- a/packages/builder/src/dataBinding.ts
+++ b/packages/builder/src/dataBinding.ts
@@ -11,7 +11,7 @@ import {
 import {
   componentStore,
   screenStore,
-  appStore,
+  workspaceStore,
   layoutStore,
   queries as queriesStores,
   tables as tablesStore,
@@ -986,7 +986,7 @@ export const getUserBindings = (): EnrichedDataBinding[] => {
  */
 const getDeviceBindings = (): EnrichedDataBinding[] => {
   let bindings: EnrichedDataBinding[] = []
-  if (get(appStore).clientFeatures?.deviceAwareness) {
+  if (get(workspaceStore).clientFeatures?.deviceAwareness) {
     const safeDevice = makePropSafe("device")
 
     bindings = [
@@ -1060,7 +1060,7 @@ export const getSettingBindings = (): SettingBinding[] => {
  */
 const getSelectedRowsBindings = (asset: unknown): EnrichedDataBinding[] => {
   let bindings: EnrichedDataBinding[] = []
-  if (get(appStore).clientFeatures?.rowSelection) {
+  if (get(workspaceStore).clientFeatures?.rowSelection) {
     // Add bindings for table components
     const props = getAssetProps(asset)
     let tables = props
@@ -1130,7 +1130,7 @@ export const makeStateBinding = (
  */
 const getStateBindings = (): EnrichedDataBinding[] => {
   let bindings: EnrichedDataBinding[] = []
-  if (get(appStore).clientFeatures?.state) {
+  if (get(workspaceStore).clientFeatures?.state) {
     bindings = getAllStateVariables().map(makeStateBinding)
   }
   return bindings

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/_components/InviteUsersModal.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/_components/InviteUsersModal.spec.ts
@@ -17,7 +17,7 @@ vi.mock("svelte", async importOriginal => {
 })
 
 const {
-  appStore,
+  workspaceStore,
   rolesStore,
   groupsStore,
   adminStore,
@@ -60,7 +60,7 @@ const {
   }
 
   return {
-    appStore: createStore({ appId: "app_dev_123" }),
+    workspaceStore: createStore({ appId: "app_dev_123" }),
     rolesStore: {
       ...createStore([] as any[]),
       fetch: vi.fn(),
@@ -169,7 +169,7 @@ vi.mock(
 )
 
 vi.mock("@/stores/builder", () => ({
-  appStore,
+  workspaceStore,
   roles: rolesStore,
 }))
 
@@ -226,7 +226,7 @@ describe("InviteUsersModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    appStore.set({ appId: "app_dev_123" })
+    workspaceStore.set({ appId: "app_dev_123" })
     groupsStore.set([])
     adminStore.set({
       loaded: true,

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/_components/InviteUsersModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/_components/InviteUsersModal.svelte
@@ -13,7 +13,7 @@
     dedupeUsersByEmail,
     type UserData,
   } from "@/settings/pages/people/users/workspaceInviteUtils"
-  import { appStore, roles } from "@/stores/builder"
+  import { workspaceStore, roles } from "@/stores/builder"
   import { users } from "@/stores/portal"
   import { sdk } from "@budibase/shared-core"
 
@@ -36,8 +36,8 @@
   let addedToWorkspaceEmails: string[] = []
   let createdUsers: UserData["users"] = []
 
-  $: currentWorkspaceId = $appStore.appId
-    ? sdk.workspaces.getProdWorkspaceID($appStore.appId)
+  $: currentWorkspaceId = $workspaceStore.appId
+    ? sdk.workspaces.getProdWorkspaceID($workspaceStore.appId)
     : ""
 
   const removeDuplicates = (userData: UserData): UserData => {

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/_components/SideNav/SideNav.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/_components/SideNav/SideNav.svelte
@@ -20,7 +20,7 @@
   import { url, goto } from "@roxi/routify"
   import BBLogo from "assets/BBLogo.svelte"
   import {
-    appStore,
+    workspaceStore,
     workspaceFavouriteStore,
     workspaceAppStore,
     automationStore,
@@ -137,7 +137,7 @@
   let createTableModal: ModalAPI
   let tableName = ""
 
-  $: workspaceId = $appStore.appId
+  $: workspaceId = $workspaceStore.appId
   $: !$pinned && unPin()
 
   // keep sidebar expanded when workspace selector is open
@@ -372,7 +372,7 @@
       return null
     }
 
-    const liveUrl = buildLiveUrl($appStore, workspaceApp.url ?? "", true)
+    const liveUrl = buildLiveUrl($workspaceStore, workspaceApp.url ?? "", true)
 
     return liveUrl || null
   }
@@ -490,7 +490,7 @@
             }}
           />
         {:else}
-          <h1>{$appStore.name}</h1>
+          <h1>{$workspaceStore.name}</h1>
         {/if}
       </div>
       <Icon

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/_layout.workspace.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/_layout.workspace.svelte
@@ -6,7 +6,7 @@
     builderStore,
     previewStore,
     deploymentStore,
-    appStore,
+    workspaceStore,
   } from "@/stores/builder"
   import { workspacesStore, admin, aiConfigsStore, auth } from "@/stores/portal"
   import { bb } from "@/stores/bb"
@@ -42,7 +42,7 @@
         await workspacesStore.load()
       } else {
         reset()
-        appStore.update(state => ({ ...state, appId }))
+        workspaceStore.update(state => ({ ...state, appId }))
         const pkg = await API.fetchAppPackage(appId)
 
         await initialise(pkg)

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/AgentModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/AgentModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getErrorMessage } from "@/helpers/errors"
-  import { appStore } from "@/stores/builder"
+  import { workspaceStore } from "@/stores/builder"
   import { agentsStore, aiConfigsStore } from "@/stores/portal"
   import {
     Input,
@@ -44,7 +44,7 @@
     }
 
     loading = true
-    const workspaceId = $appStore.appId
+    const workspaceId = $workspaceStore.appId
     try {
       const newAgent = await agentsStore.createAgent({
         name: trimmedName,

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/data/_components/CreateExternalDatasourceModal/GoogleButton.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/data/_components/CreateExternalDatasourceModal/GoogleButton.svelte
@@ -1,7 +1,7 @@
 <script>
   import GoogleLogo from "assets/google-logo.png"
   import { auth } from "@/stores/portal"
-  import { appStore } from "@/stores/builder"
+  import { workspaceStore } from "@/stores/builder"
 
   export let disabled
   export let samePage
@@ -13,7 +13,7 @@
   class:disabled
   {disabled}
   on:click={async () => {
-    let appId = $appStore.appId
+    let appId = $workspaceStore.appId
     const url = `/api/global/auth/${tenantId}/datasource/google?appId=${appId}`
     if (samePage) {
       window.location = url

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/data/table/[tableId]/_components/ViewNavBar.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/data/table/[tableId]/_components/ViewNavBar.svelte
@@ -4,7 +4,7 @@
     datasources,
     userSelectedResourceMap,
     contextMenuStore,
-    appStore,
+    workspaceStore,
     workspaceFavouriteStore,
     dataEnvironmentStore,
   } from "@/stores/builder"
@@ -231,7 +231,7 @@
 <div class="nav">
   {#if !isUsersTable}
     <a
-      href={`/builder/workspace/${$appStore.appId}/data/datasource/${datasource?._id}`}
+      href={`/builder/workspace/${$workspaceStore.appId}/data/datasource/${datasource?._id}`}
     >
       <IntegrationIcon
         integrationType={datasource?.source}

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/data/table/[tableId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/data/table/[tableId]/index.svelte
@@ -4,7 +4,7 @@
     datasources,
     tables,
     integrations,
-    appStore,
+    workspaceStore,
     rowActions,
     roles,
     dataEnvironmentStore,
@@ -128,7 +128,7 @@
     missingProductionDefinition = false
     previousTableId = id
   }
-  $: if (!isUsersTable || !$appStore.features.disableUserMetadata) {
+  $: if (!isUsersTable || !$workspaceStore.features.disableUserMetadata) {
     highlightUsersAccessButton = false
   }
   $: hasStaticFormulas = Object.values($tables.selected?.schema || {}).some(
@@ -258,7 +258,7 @@
   }
 
   const handleGridRowClick = () => {
-    if (isUsersTable && $appStore.features.disableUserMetadata) {
+    if (isUsersTable && $workspaceStore.features.disableUserMetadata) {
       highlightUsersAccessButton = true
     }
   }
@@ -331,9 +331,9 @@
         datasource={gridDatasource}
         canAddRows={!isUsersTable}
         canDeleteRows={!isUsersTable}
-        canEditRows={!isUsersTable || !$appStore.features.disableUserMetadata}
+        canEditRows={!isUsersTable || !$workspaceStore.features.disableUserMetadata}
         canEditColumns={!isProductionMode &&
-          (!isUsersTable || !$appStore.features.disableUserMetadata)}
+          (!isUsersTable || !$workspaceStore.features.disableUserMetadata)}
         canSaveSchema={!isProductionMode}
         schemaOverrides={isUsersTable ? userSchemaOverrides : null}
         showAvatars={false}
@@ -350,7 +350,7 @@
         <!-- Controls -->
         <svelte:fragment slot="controls">
           {#if !isProductionMode}
-            {#if isUsersTable && $appStore.features.disableUserMetadata}
+            {#if isUsersTable && $workspaceStore.features.disableUserMetadata}
               <GridUsersTableButton
                 highlighted={highlightUsersAccessButton}
                 on:manage={() => {

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/data/table/[tableId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/data/table/[tableId]/index.svelte
@@ -331,7 +331,8 @@
         datasource={gridDatasource}
         canAddRows={!isUsersTable}
         canDeleteRows={!isUsersTable}
-        canEditRows={!isUsersTable || !$workspaceStore.features.disableUserMetadata}
+        canEditRows={!isUsersTable ||
+          !$workspaceStore.features.disableUserMetadata}
         canEditColumns={!isProductionMode &&
           (!isUsersTable || !$workspaceStore.features.disableUserMetadata)}
         canSaveSchema={!isProductionMode}

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Screen/GeneralPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Screen/GeneralPanel.svelte
@@ -10,7 +10,7 @@
   } from "@budibase/bbui"
   import PropertyControl from "@/components/design/settings/controls/PropertyControl.svelte"
   import RoleSelect from "@/components/design/settings/controls/RoleSelect.svelte"
-  import { selectedScreen, screenStore, appStore } from "@/stores/builder"
+  import { selectedScreen, screenStore, workspaceStore } from "@/stores/builder"
   import sanitizeUrl from "@/helpers/sanitizeUrl"
   import ButtonActionEditor from "@/components/design/settings/controls/ButtonActionEditor/ButtonActionEditor.svelte"
   import { getBindableProperties } from "@/dataBinding"
@@ -102,7 +102,7 @@
         props: {
           text: "Set as home screen",
         },
-        onChange: () => appStore.refresh(),
+        onChange: () => workspaceStore.refresh(),
       },
       {
         key: "routing.route",

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/[workspaceAppId]/[screenId]/_components/AppPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/[workspaceAppId]/[screenId]/_components/AppPanel.svelte
@@ -2,7 +2,7 @@
   import AppPreview from "./AppPreview.svelte"
   import {
     screenStore,
-    appStore,
+    workspaceStore,
     selectedScreen,
     previewStore,
     selectedAppUrls,
@@ -85,7 +85,7 @@
         </div>
         <div class="actions">
           {#if !isPDF}
-            {#if $appStore.clientFeatures.devicePreview}
+            {#if $workspaceStore.clientFeatures.devicePreview}
               <ActionButton
                 quiet
                 icon={deviceIcon}
@@ -115,7 +115,7 @@
       </div>
     </div>
     <div class="content">
-      {#key $appStore.version}
+      {#key $workspaceStore.version}
         <AppPreview />
       {/key}
     </div>

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/[workspaceAppId]/[screenId]/_components/AppPreview.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/[workspaceAppId]/[screenId]/_components/AppPreview.svelte
@@ -2,7 +2,7 @@
   import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
   import { findComponent, findComponentPath } from "@/helpers/components"
   import {
-    appStore,
+    workspaceStore,
     builderStore,
     componentStore,
     componentTreeNodesStore,
@@ -49,17 +49,17 @@
   $: selectedComponentId = $componentStore.selectedComponentId
 
   $: previewData = {
-    appId: $appStore.appId,
+    appId: $workspaceStore.appId,
     layout,
     screen,
     selectedComponentId,
-    theme: $appStore.clientFeatures.unifiedThemes
+    theme: $workspaceStore.clientFeatures.unifiedThemes
       ? $themeStore.theme
       : `${ThemeClassPrefix}${$themeStore.theme}`,
     customTheme: $themeStore.customTheme,
     previewDevice: $previewStore.previewDevice,
     previewModalDevice: $previewStore.modalDevice,
-    messagePassing: $appStore.clientFeatures.messagePassing,
+    messagePassing: $workspaceStore.clientFeatures.messagePassing,
     navigation: $navigationStore,
     hiddenComponentIds:
       $componentStore.componentToPaste?._id &&
@@ -67,7 +67,7 @@
         ? [$componentStore.componentToPaste?._id]
         : [],
     isBudibaseEvent: true,
-    usedPlugins: $appStore.usedPlugins,
+    usedPlugins: $workspaceStore.usedPlugins,
     location: {
       protocol: window.location.protocol,
       hostname: window.location.hostname,
@@ -286,7 +286,7 @@
   <iframe
     title="componentPreview"
     bind:this={iframe}
-    src={`/app/${$appStore.appId}/preview`}
+    src={`/app/${$workspaceStore.appId}/preview`}
     class:hidden={loading || error}
   ></iframe>
   <div class="underlay"></div>

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/[workspaceAppId]/[screenId]/_components/WorkspaceApp/WorkspaceAppModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/[workspaceAppId]/[screenId]/_components/WorkspaceApp/WorkspaceAppModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getErrorMessage } from "@/helpers/errors"
   import { buildLiveUrl } from "@/helpers/urls"
-  import { appStore, screenStore, workspaceAppStore } from "@/stores/builder"
+  import { workspaceStore, screenStore, workspaceAppStore } from "@/stores/builder"
   import * as screenTemplating from "@/templates/screenTemplating"
   import {
     Body,
@@ -119,7 +119,7 @@
 
     try {
       if (isNew) {
-        const workspaceId = $appStore.appId
+        const workspaceId = $workspaceStore.appId
         const workspaceApp = await workspaceAppStore.add({
           ...workspaceAppData,
           disabled: true,
@@ -208,7 +208,7 @@
       disabled={editingPublishedApp}
     />
     <div class="live-url-display">
-      {buildLiveUrl($appStore, data.url, false)}
+      {buildLiveUrl($workspaceStore, data.url, false)}
     </div>
 
     {#if editingPublishedApp}

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/[workspaceAppId]/[screenId]/_components/WorkspaceApp/WorkspaceAppModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/[workspaceAppId]/[screenId]/_components/WorkspaceApp/WorkspaceAppModal.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { getErrorMessage } from "@/helpers/errors"
   import { buildLiveUrl } from "@/helpers/urls"
-  import { workspaceStore, screenStore, workspaceAppStore } from "@/stores/builder"
+  import {
+    workspaceStore,
+    screenStore,
+    workspaceAppStore,
+  } from "@/stores/builder"
   import * as screenTemplating from "@/templates/screenTemplating"
   import {
     Body,

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/CreateScreenModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/CreateScreenModal.svelte
@@ -10,7 +10,7 @@
     screenStore,
     permissions as permissionsStore,
     datasources,
-    appStore,
+    workspaceStore,
     workspaceAppStore,
   } from "@/stores/builder"
   import { goto as gotoStore } from "@roxi/routify"
@@ -105,7 +105,7 @@
   const ensureWorkspaceApp = async () => {
     if (!workspaceAppId) {
       const workspaceApp = await workspaceAppStore.add({
-        name: $appStore.name,
+        name: $workspaceStore.name,
         url: "/",
       })
       workspaceAppId = workspaceApp._id
@@ -204,11 +204,11 @@
       // Focus on the main component for the screen type
       const mainComponent = screen.props?._children?.[0]._id
       goto(
-        `/builder/workspace/${$appStore.appId}/design/${workspaceAppId}/${screen._id}/${mainComponent}`
+        `/builder/workspace/${$workspaceStore.appId}/design/${workspaceAppId}/${screen._id}/${mainComponent}`
       )
     } else {
       goto(
-        `/builder/workspace/${$appStore.appId}/design/${workspaceAppId}/${screen._id}`
+        `/builder/workspace/${$workspaceStore.appId}/design/${workspaceAppId}/${screen._id}`
       )
     }
 

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/DatasourceModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/DatasourceModal.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { Body, ModalContent, Layout, Link } from "@budibase/bbui"
-  import { workspaceStore, datasources as datasourcesStore } from "@/stores/builder"
+  import {
+    workspaceStore,
+    datasources as datasourcesStore,
+  } from "@/stores/builder"
   import ICONS from "@/components/backend/DatasourceNavigator/icons"
   import { IntegrationNames } from "@/constants"
   import { createEventDispatcher } from "svelte"

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/DatasourceModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/DatasourceModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Body, ModalContent, Layout, Link } from "@budibase/bbui"
-  import { appStore, datasources as datasourcesStore } from "@/stores/builder"
+  import { workspaceStore, datasources as datasourcesStore } from "@/stores/builder"
   import ICONS from "@/components/backend/DatasourceNavigator/icons"
   import { IntegrationNames } from "@/constants"
   import { createEventDispatcher } from "svelte"
@@ -77,8 +77,8 @@
   }
 
   let dataUrl = ""
-  $: dataUrl = $appStore.appId
-    ? `/builder/workspace/${$appStore.appId}/data`
+  $: dataUrl = $workspaceStore.appId
+    ? `/builder/workspace/${$workspaceStore.appId}/data`
     : ""
 </script>
 

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/index.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import CreationPage from "@/components/common/CreationPage.svelte"
   import { AutoScreenTypes } from "@/constants"
-  import { appStore, screenStore, workspaceAppStore } from "@/stores/builder"
+  import { workspaceStore, screenStore, workspaceAppStore } from "@/stores/builder"
   import { licensing } from "@/stores/portal"
   import {
     Body,
@@ -58,7 +58,7 @@
     rootModal.hide()
     if (!workspaceAppId) {
       const workspaceApp = await workspaceAppStore.add({
-        name: $appStore.name,
+        name: $workspaceStore.name,
         url: "/",
       })
       workspaceAppId = workspaceApp._id

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/index.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import CreationPage from "@/components/common/CreationPage.svelte"
   import { AutoScreenTypes } from "@/constants"
-  import { workspaceStore, screenStore, workspaceAppStore } from "@/stores/builder"
+  import {
+    workspaceStore,
+    screenStore,
+    workspaceAppStore,
+  } from "@/stores/builder"
   import { licensing } from "@/stores/portal"
   import {
     Body,

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/home/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/home/index.svelte
@@ -18,7 +18,7 @@
   import HomeTable from "./_components/HomeTable.svelte"
   import ImportProjectModal from "./_components/ImportProjectModal.svelte"
   import {
-    appStore,
+    workspaceStore,
     automationStore,
     contextMenuStore,
     datasources,
@@ -300,7 +300,7 @@
       return null
     }
 
-    const liveUrl = buildLiveUrl($appStore, workspaceApp.url ?? "", true)
+    const liveUrl = buildLiveUrl($workspaceStore, workspaceApp.url ?? "", true)
 
     return liveUrl || null
   }
@@ -327,7 +327,7 @@
     } finally {
       isDuplicatingWorkspaceApp = false
     }
-    await appStore.refresh()
+    await workspaceStore.refresh()
   }
 
   const deleteWorkspaceApp = async () => {
@@ -451,7 +451,7 @@
       assignProjectModal?.hide()
 
       try {
-        await Promise.all([appStore.refresh(), agentsStore.fetchAgents()])
+        await Promise.all([workspaceStore.refresh(), agentsStore.fetchAgents()])
       } catch (error) {
         console.error(error)
         notifications.warning(
@@ -512,7 +512,7 @@
       notifications.success(`Project '${projectName}' deleted successfully`)
 
       try {
-        await Promise.all([appStore.refresh(), agentsStore.fetchAgents()])
+        await Promise.all([workspaceStore.refresh(), agentsStore.fetchAgents()])
       } catch (error) {
         console.error(error)
         notifications.warning(
@@ -574,7 +574,7 @@
       notifications.success(`Imported project '${response.project.name}'`)
       notifyImportFollowUps(response)
 
-      const refreshes = await Promise.allSettled([appStore.refresh()])
+      const refreshes = await Promise.allSettled([workspaceStore.refresh()])
       if (refreshes.some(result => result.status === "rejected")) {
         notifications.warning(
           "Project imported, but some resources could not be refreshed. Reload the workspace to see all imported resources."
@@ -812,7 +812,7 @@
       await projectsStore.ensureFetched(workspaceId)
     } catch (error) {
       projectsRequestedForWorkspace = ""
-      if ($appStore.appId === workspaceId && projectsEnabled) {
+      if ($workspaceStore.appId === workspaceId && projectsEnabled) {
         notifications.error(getErrorMessage(error) || "Unable to load projects")
       }
     }
@@ -870,7 +870,7 @@
       row.projectIds?.includes(selectedProjectId)
   )
   $: targetApp = $workspacesStore.apps.find(
-    app => app.devId === $appStore.appId
+    app => app.devId === $workspaceStore.appId
   )
   $: automationErrorEntries = Object.entries(targetApp?.automationErrors || {})
     .filter(([, logIds]) => logIds.length > 0)
@@ -898,10 +898,10 @@
   $: if (
     hasMounted &&
     projectsEnabled &&
-    $appStore.appId &&
-    projectsRequestedForWorkspace !== $appStore.appId
+    $workspaceStore.appId &&
+    projectsRequestedForWorkspace !== $workspaceStore.appId
   ) {
-    loadProjects($appStore.appId)
+    loadProjects($workspaceStore.appId)
   }
 
   $: if (hasMounted) {
@@ -923,7 +923,7 @@
     try {
       await automationStore.actions.clearLogErrors({
         automationId,
-        appId: $appStore.appId,
+        appId: $workspaceStore.appId,
       })
       await workspacesStore.load()
     } catch (err) {
@@ -946,7 +946,7 @@
   }
 
   onMount(async () => {
-    const workspaceId = $appStore.appId
+    const workspaceId = $workspaceStore.appId
     if (!workspaceId) {
       return
     }
@@ -994,7 +994,7 @@
           weight="500"
           color="var(--spectrum-global-color-gray-900)"
         >
-          {$appStore.name || "Workspace"}
+          {$workspaceStore.name || "Workspace"}
         </Body>
       </div>
 

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/settings/embed.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/settings/embed.svelte
@@ -12,12 +12,12 @@
   } from "@budibase/bbui"
   import { AppStatus } from "@/constants"
   import { workspacesStore } from "@/stores/portal"
-  import { appStore, workspaceAppStore } from "@/stores/builder"
+  import { workspaceStore, workspaceAppStore } from "@/stores/builder"
 
   let selectedApp
 
   $: filteredApps = $workspacesStore.apps.filter(
-    app => app.devId == $appStore.appId
+    app => app.devId == $workspaceStore.appId
   )
   $: workspace = filteredApps.length ? filteredApps[0] : {}
   $: workspaceBaseUrl = `${window.origin}/embed${workspace?.url}`

--- a/packages/builder/src/pages/builder/workspace/updating/[workspaceId].svelte
+++ b/packages/builder/src/pages/builder/workspace/updating/[workspaceId].svelte
@@ -4,14 +4,14 @@
   import { get } from "svelte/store"
 
   import { API } from "@/api"
-  import { appStore } from "@/stores/builder"
+  import { workspaceStore } from "@/stores/builder"
 
   export let workspaceId: string
 
   // Set appId immediately so API calls have the correct context
   // Only update if it's different to avoid unnecessary re-renders
-  if (get(appStore).appId !== workspaceId) {
-    appStore.update(state => ({ ...state, appId: workspaceId }))
+  if (get(workspaceStore).appId !== workspaceId) {
+    workspaceStore.update(state => ({ ...state, appId: workspaceId }))
   }
 
   $params

--- a/packages/builder/src/settings/_components/CloneResourcesModal.svelte
+++ b/packages/builder/src/settings/_components/CloneResourcesModal.svelte
@@ -2,7 +2,7 @@
   import { API } from "@/api"
   import { TableNames } from "@/constants"
   import {
-    appStore,
+    workspaceStore,
     automationStore,
     datasources,
     queries,
@@ -69,7 +69,7 @@
   }
 
   $: otherWorkspaces = $workspacesStore.apps.filter(
-    a => a.devId !== $appStore.appId
+    a => a.devId !== $workspaceStore.appId
   )
 
   async function onConfirm() {

--- a/packages/builder/src/settings/pages/automations/automations.svelte
+++ b/packages/builder/src/settings/pages/automations/automations.svelte
@@ -4,7 +4,8 @@
   import { admin } from "@/stores/portal/admin"
 
   $: isCloud = $admin.cloud
-  $: chainAutomations = $workspaceStore.automations?.chainAutomations ?? !isCloud
+  $: chainAutomations =
+    $workspaceStore.automations?.chainAutomations ?? !isCloud
 
   async function save({ detail }: CustomEvent<boolean>) {
     try {

--- a/packages/builder/src/settings/pages/automations/automations.svelte
+++ b/packages/builder/src/settings/pages/automations/automations.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   import { Layout, Body, Heading, Toggle, notifications } from "@budibase/bbui"
-  import { appStore } from "@/stores/builder"
+  import { workspaceStore } from "@/stores/builder"
   import { admin } from "@/stores/portal/admin"
 
   $: isCloud = $admin.cloud
-  $: chainAutomations = $appStore.automations?.chainAutomations ?? !isCloud
+  $: chainAutomations = $workspaceStore.automations?.chainAutomations ?? !isCloud
 
   async function save({ detail }: CustomEvent<boolean>) {
     try {
-      await appStore.updateApp({
+      await workspaceStore.updateApp({
         automations: {
           chainAutomations: detail,
         },

--- a/packages/builder/src/settings/pages/backups/index.svelte
+++ b/packages/builder/src/settings/pages/backups/index.svelte
@@ -111,7 +111,10 @@
     try {
       loading = true
       const backupIds = selectedRows.map(row => row._id)
-      const response = await backups.deleteBackups($workspaceStore.appId, backupIds)
+      const response = await backups.deleteBackups(
+        $workspaceStore.appId,
+        backupIds
+      )
 
       if (response.failureCount > 0) {
         notifications.warning(response.message)

--- a/packages/builder/src/settings/pages/backups/index.svelte
+++ b/packages/builder/src/settings/pages/backups/index.svelte
@@ -12,7 +12,7 @@
   } from "@budibase/bbui"
   import { backups } from "@/stores/portal/backups"
   import { licensing } from "@/stores/portal/licensing"
-  import { appStore } from "@/stores/builder"
+  import { workspaceStore } from "@/stores/builder"
   import { createPaginationStore } from "@/helpers/pagination"
   import TimeAgoRenderer from "./_components/TimeAgoRenderer.svelte"
   import WorkspaceSizeRenderer from "./_components/WorkspaceSizeRenderer.svelte"
@@ -111,7 +111,7 @@
     try {
       loading = true
       const backupIds = selectedRows.map(row => row._id)
-      const response = await backups.deleteBackups($appStore.appId, backupIds)
+      const response = await backups.deleteBackups($workspaceStore.appId, backupIds)
 
       if (response.failureCount > 0) {
         notifications.warning(response.message)
@@ -142,7 +142,7 @@
     if (endDate) {
       opts.endDate = endDate
     }
-    const response = await backups.searchBackups($appStore.appId, opts)
+    const response = await backups.searchBackups($workspaceStore.appId, opts)
     pageInfo.fetched(response.hasNextPage, response.nextPage)
 
     // flatten so we have an easier structure to use for the table schema
@@ -155,7 +155,7 @@
   async function createManualBackup() {
     try {
       loading = true
-      let response = await backups.createManualBackup($appStore.appId)
+      let response = await backups.createManualBackup($workspaceStore.appId)
       await fetchBackups(filterOpt, page)
       notifications.success(response.message)
     } catch (err) {
@@ -179,11 +179,11 @@
 
   async function handleButtonClick({ detail }) {
     if (detail.type === "backupDelete") {
-      await backups.deleteBackup($appStore.appId, detail.backupId)
+      await backups.deleteBackup($workspaceStore.appId, detail.backupId)
       await fetchBackups(filterOpt, page)
     } else if (detail.type === "backupRestore") {
       await backups.restoreBackup(
-        $appStore.appId,
+        $workspaceStore.appId,
         detail.backupId,
         detail.restoreBackupName
       )

--- a/packages/builder/src/settings/pages/connections/APIEditor.svelte
+++ b/packages/builder/src/settings/pages/connections/APIEditor.svelte
@@ -9,7 +9,7 @@
     EnrichedBinding,
   } from "@budibase/types"
   import { type UIWorkspaceConnection, AUTH_TYPE_OPTIONS } from "@/types"
-  import { appStore } from "@/stores/builder/workspace"
+  import { workspaceStore } from "@/stores/builder/workspace"
   import {
     datasources,
     hasRestTemplate,
@@ -534,8 +534,8 @@
       q => q.datasourceId === datasource!._id
     )
     const targetPath = firstQuery?._id
-      ? `/builder/workspace/${$appStore.appId}/apis/query/${firstQuery._id}`
-      : `/builder/workspace/${$appStore.appId}/apis/query/new/${datasource._id}`
+      ? `/builder/workspace/${$workspaceStore.appId}/apis/query/${firstQuery._id}`
+      : `/builder/workspace/${$workspaceStore.appId}/apis/query/new/${datasource._id}`
     if ($isActive(targetPath)) {
       bb.hideSettings()
       return
@@ -940,7 +940,7 @@
                 onRowClick={(dv: DynamicVariable) => {
                   bb.hideSettings()
                   $goto(
-                    `/builder/workspace/${$appStore.appId}/apis/query/${dv.queryId}`
+                    `/builder/workspace/${$workspaceStore.appId}/apis/query/${dv.queryId}`
                   )
                 }}
               />

--- a/packages/builder/src/settings/pages/embed.svelte
+++ b/packages/builder/src/settings/pages/embed.svelte
@@ -15,18 +15,18 @@
   import { PASSWORD_REPLACEMENT } from "@budibase/types"
   import { AppStatus } from "@/constants"
   import { workspacesStore } from "@/stores/portal/workspaces"
-  import { appStore, workspaceAppStore } from "@/stores/builder"
+  import { workspaceStore, workspaceAppStore } from "@/stores/builder"
   import { licensing } from "@/stores/portal/licensing"
   import LockedFeature from "@/pages/builder/_components/LockedFeature.svelte"
   import { onMount } from "svelte"
 
   let selectedApp
 
-  $: allowedOrigins = $appStore.embedAllowedOrigins || []
+  $: allowedOrigins = $workspaceStore.embedAllowedOrigins || []
 
   const updateAllowedOrigins = async origins => {
     try {
-      await appStore.updateApp({ embedAllowedOrigins: origins })
+      await workspaceStore.updateApp({ embedAllowedOrigins: origins })
       notifications.success("Allowed domains updated")
     } catch (error) {
       notifications.error("Error updating allowed domains")
@@ -50,7 +50,7 @@
   let originalAlgorithm = "ES256"
 
   onMount(() => {
-    const config = $appStore.embedSSO
+    const config = $workspaceStore.embedSSO
     if (config) {
       ssoEnabled = config.enabled
       ssoAlgorithm = config.algorithm || "ES256"
@@ -95,7 +95,7 @@
         issuer: ssoIssuer || undefined,
         emailClaim: ssoEmailClaim || undefined,
       }
-      await appStore.updateApp({ embedSSO: config })
+      await workspaceStore.updateApp({ embedSSO: config })
       originalAlgorithm = ssoAlgorithm
       if (ssoKey) {
         ssoKeySet = true
@@ -108,7 +108,7 @@
   }
 
   $: filteredApps = $workspacesStore.apps.filter(
-    app => app.devId == $appStore.appId
+    app => app.devId == $workspaceStore.appId
   )
   $: workspace = filteredApps.length ? filteredApps[0] : {}
   $: workspaceBaseUrl = `${window.origin}/embed${workspace?.url}`

--- a/packages/builder/src/settings/pages/general.svelte
+++ b/packages/builder/src/settings/pages/general.svelte
@@ -38,7 +38,8 @@
   let deleteModal: DeleteModal
   let cloneResourcesModal: CloneResourcesModal
 
-  $: updateAvailable = $workspaceStore.upgradableVersion !== $workspaceStore.version
+  $: updateAvailable =
+    $workspaceStore.upgradableVersion !== $workspaceStore.version
   $: revertAvailable = $workspaceStore.revertableVersion != null
   $: appRecaptchaEnabled = $recaptchaStore.enabled
   $: hasOnlyOneWorkspace = $workspacesStore.apps.length <= 1
@@ -142,7 +143,8 @@
       <Body size="S">
         The workspace is currently using version
         <strong>{$workspaceStore.version}</strong>
-        but version <strong>{$workspaceStore.upgradableVersion}</strong> is available.
+        but version <strong>{$workspaceStore.upgradableVersion}</strong> is
+        available.
         <br />
         Updates can contain new features, performance improvements and bug fixes.
       </Body>

--- a/packages/builder/src/settings/pages/general.svelte
+++ b/packages/builder/src/settings/pages/general.svelte
@@ -7,7 +7,7 @@
   import ExportWorkspaceModal from "@/components/start/ExportWorkspaceModal.svelte"
   import ImportWorkspaceModal from "@/components/start/ImportWorkspaceModal.svelte"
   import {
-    appStore,
+    workspaceStore,
     deploymentStore,
     isOnlyUser,
     recaptchaStore,
@@ -38,13 +38,13 @@
   let deleteModal: DeleteModal
   let cloneResourcesModal: CloneResourcesModal
 
-  $: updateAvailable = $appStore.upgradableVersion !== $appStore.version
-  $: revertAvailable = $appStore.revertableVersion != null
+  $: updateAvailable = $workspaceStore.upgradableVersion !== $workspaceStore.version
+  $: revertAvailable = $workspaceStore.revertableVersion != null
   $: appRecaptchaEnabled = $recaptchaStore.enabled
   $: hasOnlyOneWorkspace = $workspacesStore.apps.length <= 1
   $: disableDeleteWorkspace = !$isOnlyUser || hasOnlyOneWorkspace
   $: suppressErrorNotifications =
-    !!$appStore.features?.suppressErrorNotifications
+    !!$workspaceStore.features?.suppressErrorNotifications
   $: deleteWorkspaceTooltip = hasOnlyOneWorkspace
     ? "At least one workspace is required."
     : !$isOnlyUser
@@ -69,7 +69,7 @@
   const updateSuppressErrorNotifications = async () => {
     try {
       const newState = !suppressErrorNotifications
-      await appStore.updateApp({
+      await workspaceStore.updateApp({
         features: {
           suppressErrorNotifications: newState,
         },
@@ -141,8 +141,8 @@
     {:else if updateAvailable}
       <Body size="S">
         The workspace is currently using version
-        <strong>{$appStore.version}</strong>
-        but version <strong>{$appStore.upgradableVersion}</strong> is available.
+        <strong>{$workspaceStore.version}</strong>
+        but version <strong>{$workspaceStore.upgradableVersion}</strong> is available.
         <br />
         Updates can contain new features, performance improvements and bug fixes.
       </Body>
@@ -180,7 +180,7 @@
     {:else}
       <Body size="S">
         The workspace is currently using version
-        <strong>{$appStore.version}</strong>.
+        <strong>{$workspaceStore.version}</strong>.
         <br />
         You're running the latest!
       </Body>
@@ -301,13 +301,13 @@
 
 <Modal bind:this={exportModal}>
   <ExportWorkspaceModal
-    appId={$appStore.appId}
+    appId={$workspaceStore.appId}
     published={exportPublishedVersion}
   />
 </Modal>
 
 <Modal bind:this={importModal}>
-  <ImportWorkspaceModal app={$appStore} />
+  <ImportWorkspaceModal app={$workspaceStore} />
 </Modal>
 
 <ConfirmDialog
@@ -317,7 +317,7 @@
   onOk={deploymentStore.unpublishApp}
 >
   Are you sure you want to unpublish the workspace
-  <b>{$appStore.name}</b>?
+  <b>{$workspaceStore.name}</b>?
 
   <p>This will make all apps and automations in this workspace unavailable</p>
 </ConfirmDialog>
@@ -326,8 +326,8 @@
 
 <DeleteModal
   bind:this={deleteModal}
-  appId={$appStore.appId}
-  appName={$appStore.name}
+  appId={$workspaceStore.appId}
+  appName={$workspaceStore.name}
 />
 
 <style>

--- a/packages/builder/src/settings/pages/people/users/index.svelte
+++ b/packages/builder/src/settings/pages/people/users/index.svelte
@@ -17,7 +17,7 @@
   import { licensing } from "@/stores/portal/licensing"
   import { organisation } from "@/stores/portal/organisation"
   import { admin } from "@/stores/portal/admin"
-  import { appStore } from "@/stores/builder/workspace"
+  import { workspaceStore } from "@/stores/builder/workspace"
   import { onMount } from "svelte"
   import DeleteRowsButton from "@/components/backend/DataTable/buttons/DeleteRowsButton.svelte"
   import UpgradeModal from "@/components/common/users/UpgradeModal.svelte"
@@ -87,7 +87,7 @@
   const PAGE_SIZE = 8
   const TABLE_MIN_HEIGHT = 36 + 55 * PAGE_SIZE
   const initialWorkspaceId = (() => {
-    const id = get(appStore).appId
+    const id = get(workspaceStore).appId
     return id ? sdk.workspaces.getProdWorkspaceID(id) : ""
   })()
 
@@ -533,7 +533,7 @@
   }
 
   const currentWorkspaceId = $derived(
-    $appStore.appId ? sdk.workspaces.getProdWorkspaceID($appStore.appId) : ""
+    $workspaceStore.appId ? sdk.workspaces.getProdWorkspaceID($workspaceStore.appId) : ""
   )
   const workspaceReady = $derived(!isWorkspaceOnly || !!currentWorkspaceId)
   const isWorkspaceQueryReady = $derived(

--- a/packages/builder/src/settings/pages/people/users/index.svelte
+++ b/packages/builder/src/settings/pages/people/users/index.svelte
@@ -533,7 +533,9 @@
   }
 
   const currentWorkspaceId = $derived(
-    $workspaceStore.appId ? sdk.workspaces.getProdWorkspaceID($workspaceStore.appId) : ""
+    $workspaceStore.appId
+      ? sdk.workspaces.getProdWorkspaceID($workspaceStore.appId)
+      : ""
   )
   const workspaceReady = $derived(!isWorkspaceOnly || !!currentWorkspaceId)
   const isWorkspaceQueryReady = $derived(

--- a/packages/builder/src/settings/pages/pwa.svelte
+++ b/packages/builder/src/settings/pages/pwa.svelte
@@ -14,7 +14,7 @@
     Select,
     Helpers,
   } from "@budibase/bbui"
-  import { appStore } from "@/stores/builder"
+  import { workspaceStore } from "@/stores/builder"
   import { licensing } from "@/stores/portal/licensing"
   import { API } from "@/api"
   import LockedFeature from "@/pages/builder/_components/LockedFeature.svelte"
@@ -29,7 +29,7 @@
   let pwaEnabled = $licensing.pwaEnabled
   let uploadingIcons = false
 
-  let pwaConfig = $appStore.pwa || {
+  let pwaConfig = $workspaceStore.pwa || {
     name: "",
     short_name: "",
     description: "",
@@ -98,8 +98,8 @@
         theme_color: getCssVariableValue(pwaConfig.theme_color),
       }
 
-      await API.saveAppMetadata($appStore.appId, { pwa: pwaConfigToSave })
-      appStore.update(state => ({ ...state, pwa: pwaConfigToSave }))
+      await API.saveAppMetadata($workspaceStore.appId, { pwa: pwaConfigToSave })
+      workspaceStore.update(state => ({ ...state, pwa: pwaConfigToSave }))
 
       notifications.success("PWA settings saved successfully")
     } catch (error) {

--- a/packages/builder/src/settings/pages/scripts.svelte
+++ b/packages/builder/src/settings/pages/scripts.svelte
@@ -15,7 +15,7 @@
     notifications,
     ButtonGroup,
   } from "@budibase/bbui"
-  import { appStore } from "@/stores/builder"
+  import { workspaceStore } from "@/stores/builder"
   import { type AppScript } from "@budibase/types"
   import { getSequentialName } from "@/helpers/duplicate"
   import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
@@ -45,7 +45,7 @@
   $: enabled = $licensing.customAppScriptsEnabled
 
   const addScript = () => {
-    const name = getSequentialName($appStore.scripts, "Script ", {
+    const name = getSequentialName($workspaceStore.scripts, "Script ", {
       getName: script => script.name,
       numberFirstItem: true,
     })
@@ -66,10 +66,10 @@
     if (!selectedScript) {
       return
     }
-    const newScripts = $appStore.scripts
+    const newScripts = $workspaceStore.scripts
       .filter(script => script.id !== selectedScript!.id)
       .concat([selectedScript])
-    await appStore.updateApp({ scripts: newScripts })
+    await workspaceStore.updateApp({ scripts: newScripts })
     notifications.success("Script saved successfully")
     selectedScript = undefined
   }
@@ -82,10 +82,10 @@
     if (!selectedScript) {
       return
     }
-    const newScripts = $appStore.scripts.filter(
+    const newScripts = $workspaceStore.scripts.filter(
       script => script.id !== selectedScript!.id
     )
-    await appStore.updateApp({ scripts: newScripts })
+    await workspaceStore.updateApp({ scripts: newScripts })
     notifications.success("Script deleted successfully")
     selectedScript = undefined
   }
@@ -181,7 +181,7 @@
       <Table
         on:click={editScript}
         {schema}
-        data={$appStore.scripts}
+        data={$workspaceStore.scripts}
         allowSelectRows={false}
         allowEditColumns={false}
         allowEditRows={false}

--- a/packages/builder/src/settings/routes.ts
+++ b/packages/builder/src/settings/routes.ts
@@ -5,7 +5,7 @@ import { UserAvatar } from "@budibase/frontend-core"
 import { Target, type Route } from "@/types/routing"
 import { Pages } from "./pages"
 import { AdminState } from "@/stores/portal/admin"
-import { AppMetaState } from "@/stores/builder/workspace"
+import { WorkspaceMetaState } from "@/stores/builder/workspace"
 import { PortalWorkspacesStore } from "@/stores/portal/workspaces"
 import { StoreApp } from "@/types"
 import { aiConfigsStore } from "@/stores/portal"
@@ -232,11 +232,11 @@ export const orgRoutes = (
 }
 
 export const workspaceRoutes = (
-  appStore: AppMetaState,
+  workspaceStore: WorkspaceMetaState,
   workspacesStore: PortalWorkspacesStore,
   user: GetGlobalSelfResponse
 ): Route[] => {
-  if (!appStore?.appId) {
+  if (!workspaceStore?.appId) {
     return []
   }
   const isCreator = user != null && sdk.users.canCreateApps(user)
@@ -247,7 +247,7 @@ export const workspaceRoutes = (
 
   const backupErrors = getBackupErrors(
     workspacesStore.apps || [],
-    appStore?.appId
+    workspaceStore?.appId
   )
   const backupErrorCount = Object.keys(backupErrors).length
 

--- a/packages/builder/src/stores/builder/appUrls.ts
+++ b/packages/builder/src/stores/builder/appUrls.ts
@@ -11,7 +11,12 @@ export const selectedAppUrls = derived(
     const route = $selectedScreen?.routing.route || ""
     const workspacePrefix = selectedWorkspaceApp ? selectedWorkspaceApp.url : ""
 
-    const previewUrl = buildPreviewUrl($workspaceStore, workspacePrefix, route, true)
+    const previewUrl = buildPreviewUrl(
+      $workspaceStore,
+      workspacePrefix,
+      route,
+      true
+    )
 
     const liveUrl = buildLiveUrl($workspaceStore, workspacePrefix, true)
     return { previewUrl, liveUrl }

--- a/packages/builder/src/stores/builder/appUrls.ts
+++ b/packages/builder/src/stores/builder/appUrls.ts
@@ -1,19 +1,19 @@
 import { derived } from "svelte/store"
-import { appStore, selectedScreen, workspaceAppStore } from "."
+import { workspaceStore, selectedScreen, workspaceAppStore } from "."
 
 import { buildLiveUrl, buildPreviewUrl } from "@/helpers/urls"
 
 export const selectedAppUrls = derived(
-  [workspaceAppStore, selectedScreen, appStore],
-  ([$workspaceAppStore, $selectedScreen, $appStore]) => {
+  [workspaceAppStore, selectedScreen, workspaceStore],
+  ([$workspaceAppStore, $selectedScreen, $workspaceStore]) => {
     const selectedWorkspaceApp = $workspaceAppStore.selectedWorkspaceApp
 
     const route = $selectedScreen?.routing.route || ""
     const workspacePrefix = selectedWorkspaceApp ? selectedWorkspaceApp.url : ""
 
-    const previewUrl = buildPreviewUrl($appStore, workspacePrefix, route, true)
+    const previewUrl = buildPreviewUrl($workspaceStore, workspacePrefix, route, true)
 
-    const liveUrl = buildLiveUrl($appStore, workspacePrefix, true)
+    const liveUrl = buildLiveUrl($workspaceStore, workspacePrefix, true)
     return { previewUrl, liveUrl }
   }
 )

--- a/packages/builder/src/stores/builder/automations.ts
+++ b/packages/builder/src/stores/builder/automations.ts
@@ -14,7 +14,7 @@ import { getNewStepName } from "@/helpers/automations/nameHelpers"
 import { getSequentialName } from "@/helpers/duplicate"
 import { DerivedBudiStore } from "@/stores/BudiStore"
 import {
-  appStore,
+  workspaceStore,
   deploymentStore,
   permissions,
   tables,
@@ -2300,7 +2300,7 @@ const automationActions = (store: AutomationStore) => ({
     const automation: Automation = {
       name,
       type: "automation",
-      appId: get(appStore).appId,
+      appId: get(workspaceStore).appId,
       definition: {
         steps: [],
         trigger,

--- a/packages/builder/src/stores/builder/components.ts
+++ b/packages/builder/src/stores/builder/components.ts
@@ -131,7 +131,9 @@ export class ComponentStore extends BudiStore<ComponentState> {
 
     // Sync client features to app store
     workspaceStore.syncClientFeatures(components.features)
-    workspaceStore.syncClientTypeSupportPresets(components?.typeSupportPresets ?? {})
+    workspaceStore.syncClientTypeSupportPresets(
+      components?.typeSupportPresets ?? {}
+    )
 
     return components
   }

--- a/packages/builder/src/stores/builder/components.ts
+++ b/packages/builder/src/stores/builder/components.ts
@@ -19,7 +19,7 @@ import { getComponentFieldOptions } from "@/helpers/formFields"
 import { selectedScreen } from "./screens"
 import {
   screenStore,
-  appStore,
+  workspaceStore,
   previewStore,
   tables,
   componentTreeNodesStore,
@@ -130,8 +130,8 @@ export class ComponentStore extends BudiStore<ComponentState> {
     }))
 
     // Sync client features to app store
-    appStore.syncClientFeatures(components.features)
-    appStore.syncClientTypeSupportPresets(components?.typeSupportPresets ?? {})
+    workspaceStore.syncClientFeatures(components.features)
+    workspaceStore.syncClientTypeSupportPresets(components?.typeSupportPresets ?? {})
 
     return components
   }

--- a/packages/builder/src/stores/builder/deployment.ts
+++ b/packages/builder/src/stores/builder/deployment.ts
@@ -5,7 +5,7 @@ import { DeploymentProgressResponse, DeploymentStatus } from "@budibase/types"
 import analytics, { Events, EventSource } from "@/analytics"
 import { workspacesStore } from "@/stores/portal/workspaces"
 import { DerivedBudiStore } from "@/stores/BudiStore"
-import { appStore } from "./workspace"
+import { workspaceStore } from "./workspace"
 import { processStringSync } from "@budibase/string-templates"
 import { selectedAppUrls } from "./appUrls"
 import { workspaceDeploymentStore } from "@/stores/builder/workspaceDeployment"
@@ -34,11 +34,11 @@ class DeploymentStore extends DerivedBudiStore<
       store: Writable<DeploymentState>
     ): Readable<DerivedDeploymentState> => {
       return derived(
-        [store, appStore, workspacesStore],
-        ([$store, $appStore, $workspacesStore]) => {
+        [store, workspaceStore, workspacesStore],
+        ([$store, $workspaceStore, $workspacesStore]) => {
           // Determine whether the app is published
           const app = $workspacesStore.apps.find(
-            app => app.devId === $appStore.appId
+            app => app.devId === $workspaceStore.appId
           )
           const deployments = $store.deployments.filter(
             x => x.status === DeploymentStatus.SUCCESS
@@ -95,7 +95,7 @@ class DeploymentStore extends DerivedBudiStore<
   async publishApp(opts?: { seedProductionTables: boolean }) {
     try {
       this.update(state => ({ ...state, isPublishing: true }))
-      await API.publishAppChanges(get(appStore).appId, opts)
+      await API.publishAppChanges(get(workspaceStore).appId, opts)
       await this.completePublish()
     } catch (error: any) {
       analytics.captureException(error)
@@ -131,7 +131,7 @@ class DeploymentStore extends DerivedBudiStore<
       return
     }
     try {
-      await API.unpublishApp(get(appStore).appId)
+      await API.unpublishApp(get(workspaceStore).appId)
       await Promise.all([
         workspaceDeploymentStore.fetch(),
         workspaceAppStore.refresh(),
@@ -148,7 +148,7 @@ class DeploymentStore extends DerivedBudiStore<
   }
 
   viewPublishedApp() {
-    const app = get(appStore)
+    const app = get(workspaceStore)
     const { liveUrl } = get(selectedAppUrls)
     analytics.captureEvent(Events.APP_VIEW_PUBLISHED, {
       appId: app.appId,

--- a/packages/builder/src/stores/builder/index.ts
+++ b/packages/builder/src/stores/builder/index.ts
@@ -1,7 +1,7 @@
 import { layoutStore } from "./layouts"
 import { workspaceAppStore } from "./workspaceApps"
 import { workspaceFavouriteStore } from "./workspaceFavourites"
-import { appStore } from "./workspace"
+import { workspaceStore } from "./workspace"
 import { componentStore, selectedComponent } from "./components"
 import { navigationStore } from "./navigation"
 import { themeStore } from "./theme"
@@ -54,7 +54,7 @@ export {
   componentTreeNodesStore,
   componentTreeSearchStore,
   layoutStore,
-  appStore,
+  workspaceStore,
   componentStore,
   navigationStore,
   themeStore,
@@ -103,7 +103,7 @@ export {
 }
 
 export const reset = () => {
-  appStore.reset()
+  workspaceStore.reset()
   builderStore.reset()
   screenStore.reset()
   componentStore.reset()
@@ -137,9 +137,9 @@ const resetBuilderHistory = () => {
 export const initialise = async (pkg: FetchAppPackageResponse) => {
   const { application, recaptchaKey } = pkg
   // must be first operation to make sure subsequent requests have correct app ID
-  appStore.syncAppPackage(pkg)
+  workspaceStore.syncAppPackage(pkg)
   await Promise.all([
-    appStore.syncAppRoutes(),
+    workspaceStore.syncAppRoutes(),
     componentStore.refreshDefinitions(application?.appId),
   ])
   builderStore.init(application)

--- a/packages/builder/src/stores/builder/navigation.ts
+++ b/packages/builder/src/stores/builder/navigation.ts
@@ -1,6 +1,6 @@
 import { derived, get, Writable } from "svelte/store"
 import { API } from "@/api"
-import { appStore, workspaceAppStore } from "@/stores/builder"
+import { workspaceStore, workspaceAppStore } from "@/stores/builder"
 import { DerivedBudiStore } from "../BudiStore"
 import { AppNavigation, AppNavigationLink, UIObject } from "@budibase/types"
 import { notifications } from "@budibase/bbui"
@@ -129,7 +129,7 @@ export class NavigationStore extends DerivedBudiStore<
   }
 
   async refresh() {
-    const appId = get(appStore).appId
+    const appId = get(workspaceStore).appId
     const appPackage = await API.fetchAppPackage(appId)
 
     this.syncAppNavigation(appPackage.application.navigation)

--- a/packages/builder/src/stores/builder/recaptcha.ts
+++ b/packages/builder/src/stores/builder/recaptcha.ts
@@ -1,5 +1,5 @@
 import { API } from "@/api"
-import { appStore } from "@/stores/builder"
+import { workspaceStore } from "@/stores/builder"
 import { Workspace } from "@budibase/types"
 import { get } from "svelte/store"
 import { BudiStore } from "../BudiStore"
@@ -33,7 +33,7 @@ export class RecaptchaStore extends BudiStore<RecaptchaState> {
   }
 
   async setState(enabled: boolean) {
-    const appId = get(appStore).appId
+    const appId = get(workspaceStore).appId
     await API.saveAppMetadata(appId, {
       features: { recaptchaEnabled: enabled },
     })

--- a/packages/builder/src/stores/builder/screens.ts
+++ b/packages/builder/src/stores/builder/screens.ts
@@ -4,7 +4,7 @@ import { Helpers } from "@budibase/bbui"
 import { RoleUtils, Utils } from "@budibase/frontend-core"
 import { findAllMatchingComponents } from "@/helpers/components"
 import {
-  appStore,
+  workspaceStore,
   componentStore,
   layoutStore,
   previewStore,
@@ -239,7 +239,7 @@ export class ScreenStore extends BudiStore<ScreenState> {
    */
   async saveScreen(screenRequest: SaveScreenRequest) {
     const { navigationLinkLabel, ...screen } = screenRequest
-    const appState = get(appStore)
+    const appState = get(workspaceStore)
 
     // Validate screen structure if the app supports it
     if (appState.features?.componentValidation) {
@@ -277,10 +277,10 @@ export class ScreenStore extends BudiStore<ScreenState> {
     })
 
     if (savedScreen.pluginAdded) {
-      await appStore.refresh()
+      await workspaceStore.refresh()
     }
 
-    await appStore.refreshAppNav()
+    await workspaceStore.refreshAppNav()
 
     return savedScreen
   }
@@ -404,7 +404,7 @@ export class ScreenStore extends BudiStore<ScreenState> {
       })
     await Promise.all(promises)
 
-    await appStore.refreshAppNav()
+    await workspaceStore.refreshAppNav()
     await workspaceAppStore.refresh()
     const deletedIds = screensToDelete.map(screen => screen._id)
     const routesResponse = await API.fetchAppRoutes()
@@ -427,7 +427,7 @@ export class ScreenStore extends BudiStore<ScreenState> {
       }
 
       // Update routing
-      appStore.update(state => ({
+      workspaceStore.update(state => ({
         ...state,
         routes: routesResponse.routes,
       }))

--- a/packages/builder/src/stores/builder/snippets.ts
+++ b/packages/builder/src/stores/builder/snippets.ts
@@ -2,7 +2,7 @@ import { API } from "@/api"
 import { Snippet, UpdateWorkspaceResponse } from "@budibase/types"
 import { get } from "svelte/store"
 import { BudiStore } from "../BudiStore"
-import { appStore } from "./workspace"
+import { workspaceStore } from "./workspace"
 
 export class SnippetStore extends BudiStore<Snippet[]> {
   constructor() {
@@ -18,13 +18,13 @@ export class SnippetStore extends BudiStore<Snippet[]> {
       ...get(this).filter(snippet => snippet.name !== updatedSnippet.name),
       updatedSnippet,
     ]
-    const app = await API.saveAppMetadata(get(appStore).appId, { snippets })
+    const app = await API.saveAppMetadata(get(workspaceStore).appId, { snippets })
     this.syncMetadata(app)
   }
 
   deleteSnippet = async (snippetName: string) => {
     const snippets = get(this).filter(snippet => snippet.name !== snippetName)
-    const app = await API.saveAppMetadata(get(appStore).appId, { snippets })
+    const app = await API.saveAppMetadata(get(workspaceStore).appId, { snippets })
     this.syncMetadata(app)
   }
 }

--- a/packages/builder/src/stores/builder/snippets.ts
+++ b/packages/builder/src/stores/builder/snippets.ts
@@ -18,13 +18,17 @@ export class SnippetStore extends BudiStore<Snippet[]> {
       ...get(this).filter(snippet => snippet.name !== updatedSnippet.name),
       updatedSnippet,
     ]
-    const app = await API.saveAppMetadata(get(workspaceStore).appId, { snippets })
+    const app = await API.saveAppMetadata(get(workspaceStore).appId, {
+      snippets,
+    })
     this.syncMetadata(app)
   }
 
   deleteSnippet = async (snippetName: string) => {
     const snippets = get(this).filter(snippet => snippet.name !== snippetName)
-    const app = await API.saveAppMetadata(get(workspaceStore).appId, { snippets })
+    const app = await API.saveAppMetadata(get(workspaceStore).appId, {
+      snippets,
+    })
     this.syncMetadata(app)
   }
 }

--- a/packages/builder/src/stores/builder/tests/automationProgress.test.ts
+++ b/packages/builder/src/stores/builder/tests/automationProgress.test.ts
@@ -14,7 +14,7 @@ import { type AutomationTestProgressEvent } from "@budibase/types"
 
 vi.mock("@/stores/builder", () => {
   return {
-    appStore: writable({}),
+    workspaceStore: writable({}),
     deploymentStore: writable({}),
     permissions: writable({}),
     tables: writable({ list: [] }),

--- a/packages/builder/src/stores/builder/tests/automations.test.ts
+++ b/packages/builder/src/stores/builder/tests/automations.test.ts
@@ -33,7 +33,7 @@ import { automations } from "@budibase/shared-core"
 
 vi.mock("@/stores/builder", () => {
   return {
-    appStore: writable({}),
+    workspaceStore: writable({}),
     deploymentStore: writable({}),
     permissions: writable({}),
     tables: writable({ list: [] }),

--- a/packages/builder/src/stores/builder/tests/component.test.js
+++ b/packages/builder/src/stores/builder/tests/component.test.js
@@ -58,12 +58,12 @@ vi.mock("@/stores/preferences", () => {
 })
 
 vi.mock("@/stores/builder", async () => {
-  const mockAppStore = writable()
+  const mockWorkspaceStore = writable()
   const mockScreenComponentsList = writable([])
   const workspaceStore = {
-    subscribe: mockAppStore.subscribe,
-    update: mockAppStore.update,
-    set: mockAppStore.set,
+    subscribe: mockWorkspaceStore.subscribe,
+    update: mockWorkspaceStore.update,
+    set: mockWorkspaceStore.set,
     syncClientFeatures: vi.fn(),
     syncClientTypeSupportPresets: vi.fn(),
   }

--- a/packages/builder/src/stores/builder/tests/component.test.js
+++ b/packages/builder/src/stores/builder/tests/component.test.js
@@ -8,7 +8,7 @@ import { DatasourceStore } from "@/stores/builder/datasources"
 import { QueryStore } from "@/stores/builder/queries"
 import { API } from "@/api"
 import {
-  appStore,
+  workspaceStore,
   tables,
   setComponentStore,
   setDatasourcesStore,
@@ -60,7 +60,7 @@ vi.mock("@/stores/preferences", () => {
 vi.mock("@/stores/builder", async () => {
   const mockAppStore = writable()
   const mockScreenComponentsList = writable([])
-  const appStore = {
+  const workspaceStore = {
     subscribe: mockAppStore.subscribe,
     update: mockAppStore.update,
     set: mockAppStore.set,
@@ -74,7 +74,7 @@ vi.mock("@/stores/builder", async () => {
   let queryStore
 
   return {
-    appStore,
+    workspaceStore,
     tables: writable(),
     screenComponentsList: mockScreenComponentsList,
     get datasources() {
@@ -188,7 +188,7 @@ describe("Component store", () => {
     expect(ctx.test.store.components).toStrictEqual(mockAPIResponse)
 
     expect(apiDefRequest).toBeCalled()
-    expect(appStore.syncClientFeatures).toBeCalledWith(clientFeaturesResp)
+    expect(workspaceStore.syncClientFeatures).toBeCalledWith(clientFeaturesResp)
   })
 
   it("Refresh and sync component and plugin definitions", async ctx => {
@@ -212,7 +212,7 @@ describe("Component store", () => {
     expect(ctx.test.store.components).toStrictEqual(mockAPIResponse)
 
     expect(apiDefRequest).toBeCalled()
-    expect(appStore.syncClientFeatures).toBeCalledWith(clientFeaturesResp)
+    expect(workspaceStore.syncClientFeatures).toBeCalledWith(clientFeaturesResp)
 
     expect(ctx.test.store.customComponents).toStrictEqual(
       Object.keys(pluginDefs)

--- a/packages/builder/src/stores/builder/tests/navigation.test.js
+++ b/packages/builder/src/stores/builder/tests/navigation.test.js
@@ -5,7 +5,7 @@ import {
   INITIAL_NAVIGATION_STATE,
   NavigationStore,
 } from "@/stores/builder/navigation"
-import { appStore, workspaceAppStore } from "@/stores/builder"
+import { workspaceStore, workspaceAppStore } from "@/stores/builder"
 
 vi.mock("@/api", () => {
   return {
@@ -19,7 +19,7 @@ vi.mock("@/api", () => {
 
 vi.mock("@/stores/builder", async () => {
   const mockAppStore = writable()
-  const appStore = {
+  const workspaceStore = {
     subscribe: mockAppStore.subscribe,
     update: mockAppStore.update,
     set: mockAppStore.set,
@@ -43,7 +43,7 @@ vi.mock("@/stores/builder", async () => {
   }
 
   return {
-    appStore,
+    workspaceStore,
     workspaceAppStore,
   }
 })
@@ -243,7 +243,7 @@ describe("Navigation store", () => {
 
   it("Should save the navigation against the currently loaded builder app", async ctx => {
     // Set a fake appId to resolve
-    appStore.update(state => ({
+    workspaceStore.update(state => ({
       ...state,
       appId: "testing_123",
     }))

--- a/packages/builder/src/stores/builder/tests/navigation.test.js
+++ b/packages/builder/src/stores/builder/tests/navigation.test.js
@@ -18,11 +18,11 @@ vi.mock("@/api", () => {
 })
 
 vi.mock("@/stores/builder", async () => {
-  const mockAppStore = writable()
+  const mockWorkspaceStore = writable()
   const workspaceStore = {
-    subscribe: mockAppStore.subscribe,
-    update: mockAppStore.update,
-    set: mockAppStore.set,
+    subscribe: mockWorkspaceStore.subscribe,
+    update: mockWorkspaceStore.update,
+    set: mockWorkspaceStore.set,
   }
 
   const mockWorkspaceApp = {

--- a/packages/builder/src/stores/builder/tests/screens.test.js
+++ b/packages/builder/src/stores/builder/tests/screens.test.js
@@ -2,7 +2,11 @@ import { it, expect, describe, beforeEach, vi } from "vitest"
 import { get, writable } from "svelte/store"
 import { API } from "@/api"
 import { Constants } from "@budibase/frontend-core"
-import { componentStore, workspaceStore, workspaceAppStore } from "@/stores/builder"
+import {
+  componentStore,
+  workspaceStore,
+  workspaceAppStore,
+} from "@/stores/builder"
 import { initialScreenState, ScreenStore } from "@/stores/builder/screens"
 import {
   getScreenFixture,

--- a/packages/builder/src/stores/builder/tests/screens.test.js
+++ b/packages/builder/src/stores/builder/tests/screens.test.js
@@ -2,7 +2,7 @@ import { it, expect, describe, beforeEach, vi } from "vitest"
 import { get, writable } from "svelte/store"
 import { API } from "@/api"
 import { Constants } from "@budibase/frontend-core"
-import { componentStore, appStore, workspaceAppStore } from "@/stores/builder"
+import { componentStore, workspaceStore, workspaceAppStore } from "@/stores/builder"
 import { initialScreenState, ScreenStore } from "@/stores/builder/screens"
 import {
   getScreenFixture,
@@ -27,7 +27,7 @@ vi.mock("@/stores/builder", async () => {
     subscribe: mockComponentStore.subscribe,
   }
 
-  const appStore = {
+  const workspaceStore = {
     subscribe: mockAppStore.subscribe,
     update: mockAppStore.update,
     set: mockAppStore.set,
@@ -45,7 +45,7 @@ vi.mock("@/stores/builder", async () => {
 
   return {
     componentStore,
-    appStore,
+    workspaceStore,
     navigationStore,
     layoutStore: {
       update: mockLayoutStore.update,
@@ -233,7 +233,7 @@ describe("Screens store", () => {
 
     coreScreen.addChild(formOne)
 
-    appStore.set({ features: { componentValidation: false } })
+    workspaceStore.set({ features: { componentValidation: false } })
 
     expect(bb.store.screens.length).toBe(0)
 
@@ -289,7 +289,7 @@ describe("Screens store", () => {
     // Saved the existing screen having modified it.
     await bb.screenStore.save(existingScreens[2].json())
 
-    expect(appStore.refreshAppNav).toHaveBeenCalledOnce()
+    expect(workspaceStore.refreshAppNav).toHaveBeenCalledOnce()
     expect(saveSpy).toHaveBeenCalled()
 
     // On save, the screen is spliced back into the store with the saved content
@@ -453,7 +453,7 @@ describe("Screens store", () => {
     expect(bb.store.screens.length).toBe(2)
 
     // Just confirm that the routes at are being initialised
-    expect(get(appStore).routes).toEqual([])
+    expect(get(workspaceStore).routes).toEqual([])
   })
 
   it("Upon delete, reset selected screen and component ids if the screen was selected", async ({

--- a/packages/builder/src/stores/builder/tests/screens.test.js
+++ b/packages/builder/src/stores/builder/tests/screens.test.js
@@ -20,7 +20,7 @@ import {
 const COMP_PREFIX = "@budibase/standard-components"
 
 vi.mock("@/stores/builder", async () => {
-  const mockAppStore = writable()
+  const mockWorkspaceStore = writable()
   const mockComponentStore = writable()
   const mockLayoutStore = writable()
 
@@ -32,9 +32,9 @@ vi.mock("@/stores/builder", async () => {
   }
 
   const workspaceStore = {
-    subscribe: mockAppStore.subscribe,
-    update: mockAppStore.update,
-    set: mockAppStore.set,
+    subscribe: mockWorkspaceStore.subscribe,
+    update: mockWorkspaceStore.update,
+    set: mockWorkspaceStore.set,
     refresh: vi.fn(),
     refreshAppNav: vi.fn(),
   }

--- a/packages/builder/src/stores/builder/tests/workspace.test.js
+++ b/packages/builder/src/stores/builder/tests/workspace.test.js
@@ -1,8 +1,8 @@
 import { it, expect, describe, beforeEach, vi } from "vitest"
 import { get } from "svelte/store"
 import {
-  INITIAL_APP_META_STATE,
-  AppMetaStore,
+  INITIAL_WORKSPACE_META_STATE,
+  WorkspaceMetaStore,
 } from "@/stores/builder/workspace"
 import {
   clientFeaturesResp,
@@ -37,28 +37,28 @@ describe("Application Meta Store", () => {
   beforeEach(async ctx => {
     vi.clearAllMocks()
 
-    const appStore = new AppMetaStore()
+    const workspaceStore = new WorkspaceMetaStore()
     ctx.test = {
       get store() {
-        return get(appStore)
+        return get(workspaceStore)
       },
-      appStore,
+      workspaceStore,
     }
   })
 
   it("Create base store with defaults", ctx => {
-    expect(ctx.test.store).toStrictEqual(INITIAL_APP_META_STATE)
+    expect(ctx.test.store).toStrictEqual(INITIAL_WORKSPACE_META_STATE)
   })
 
   it("Reset the app metadata to default", ctx => {
     const pkg = generateAppPackage({})
-    ctx.test.appStore.syncAppPackage(pkg)
+    ctx.test.workspaceStore.syncAppPackage(pkg)
 
-    expect(ctx.test.store).not.toStrictEqual(INITIAL_APP_META_STATE)
+    expect(ctx.test.store).not.toStrictEqual(INITIAL_WORKSPACE_META_STATE)
 
-    ctx.test.appStore.reset()
+    ctx.test.workspaceStore.reset()
 
-    expect(ctx.test.store).toStrictEqual(INITIAL_APP_META_STATE)
+    expect(ctx.test.store).toStrictEqual(INITIAL_WORKSPACE_META_STATE)
   })
 
   it("Sync app metadata from a new app package", async ctx => {
@@ -86,10 +86,10 @@ describe("Application Meta Store", () => {
       componentLibraries,
     } = app
 
-    ctx.test.appStore.syncAppPackage(pkg)
+    ctx.test.workspaceStore.syncAppPackage(pkg)
 
     expect(ctx.test.store).toStrictEqual({
-      ...INITIAL_APP_META_STATE,
+      ...INITIAL_WORKSPACE_META_STATE,
       name,
       appId,
       url,
@@ -111,7 +111,7 @@ describe("Application Meta Store", () => {
   })
 
   it("Sync type support information to state", async ctx => {
-    ctx.test.appStore.syncClientTypeSupportPresets({ preset: "information" })
+    ctx.test.workspaceStore.syncClientTypeSupportPresets({ preset: "information" })
 
     expect(ctx.test.store.typeSupportPresets).toStrictEqual({
       preset: "information",
@@ -119,7 +119,7 @@ describe("Application Meta Store", () => {
   })
 
   it("Sync component feature flags to state", async ctx => {
-    ctx.test.appStore.syncClientFeatures(clientFeaturesResp)
+    ctx.test.workspaceStore.syncClientFeatures(clientFeaturesResp)
 
     expect(ctx.test.store.clientFeatures).toStrictEqual(clientFeaturesResp)
   })
@@ -134,7 +134,7 @@ describe("Application Meta Store", () => {
       .spyOn(API, "fetchAppRoutes")
       .mockResolvedValue({ routes: fakeRoutes })
 
-    await ctx.test.appStore.syncAppRoutes()
+    await ctx.test.workspaceStore.syncAppRoutes()
 
     expect(routeSpy).toBeCalled()
 
@@ -151,10 +151,10 @@ describe("Application Meta Store", () => {
       },
     }
 
-    ctx.test.appStore.syncMetadata(fakeMetadata)
+    ctx.test.workspaceStore.syncMetadata(fakeMetadata)
 
     expect(ctx.test.store).toStrictEqual({
-      ...INITIAL_APP_META_STATE,
+      ...INITIAL_WORKSPACE_META_STATE,
       ...fakeMetadata,
     })
   })

--- a/packages/builder/src/stores/builder/tests/workspace.test.js
+++ b/packages/builder/src/stores/builder/tests/workspace.test.js
@@ -111,7 +111,9 @@ describe("Application Meta Store", () => {
   })
 
   it("Sync type support information to state", async ctx => {
-    ctx.test.workspaceStore.syncClientTypeSupportPresets({ preset: "information" })
+    ctx.test.workspaceStore.syncClientTypeSupportPresets({
+      preset: "information",
+    })
 
     expect(ctx.test.store.typeSupportPresets).toStrictEqual({
       preset: "information",

--- a/packages/builder/src/stores/builder/websocket.ts
+++ b/packages/builder/src/stores/builder/websocket.ts
@@ -2,7 +2,7 @@ import { createWebsocket } from "@budibase/frontend-core"
 import {
   automationStore,
   userStore,
-  appStore,
+  workspaceStore,
   themeStore,
   navigationStore,
   deploymentStore,
@@ -63,7 +63,7 @@ export const createBuilderWebsocket = (appId: string) => {
     BuilderSocketEvent.LockTransfer,
     ({ userId }: { userId: string }) => {
       if (userId === get(auth)?.user?._id) {
-        appStore.update(state => ({
+        workspaceStore.update(state => ({
           ...state,
           hasLock: true,
         }))
@@ -112,7 +112,7 @@ export const createBuilderWebsocket = (appId: string) => {
   socket.onOther(
     BuilderSocketEvent.AppMetadataChange,
     ({ metadata }: { metadata: any }) => {
-      appStore.syncMetadata(metadata)
+      workspaceStore.syncMetadata(metadata)
       themeStore.syncMetadata(metadata)
       navigationStore.syncMetadata(metadata)
       snippets.syncMetadata(metadata)

--- a/packages/builder/src/stores/builder/workspace.ts
+++ b/packages/builder/src/stores/builder/workspace.ts
@@ -32,7 +32,7 @@ interface TypeSupportPresets {
   [key: string]: any
 }
 
-export interface AppMetaState {
+export interface WorkspaceMetaState {
   appId: string
   name: string
   url: string
@@ -58,7 +58,7 @@ export interface AppMetaState {
   embedSSO?: EmbedSSOConfig
 }
 
-export const INITIAL_APP_META_STATE: AppMetaState = {
+export const INITIAL_WORKSPACE_META_STATE: WorkspaceMetaState = {
   appId: "",
   name: "",
   url: "",
@@ -105,13 +105,13 @@ export const INITIAL_APP_META_STATE: AppMetaState = {
   embedAllowedOrigins: [],
 }
 
-export class AppMetaStore extends BudiStore<AppMetaState> {
+export class WorkspaceMetaStore extends BudiStore<WorkspaceMetaState> {
   constructor() {
-    super(INITIAL_APP_META_STATE)
+    super(INITIAL_WORKSPACE_META_STATE)
   }
 
   reset() {
-    this.store.set({ ...INITIAL_APP_META_STATE })
+    this.store.set({ ...INITIAL_WORKSPACE_META_STATE })
   }
 
   syncApp(workspace: Workspace) {
@@ -128,7 +128,7 @@ export class AppMetaStore extends BudiStore<AppMetaState> {
       usedPlugins: workspace.usedPlugins || [],
       icon: workspace.icon,
       features: {
-        ...INITIAL_APP_META_STATE.features,
+        ...INITIAL_WORKSPACE_META_STATE.features,
         ...workspace.features,
       },
       initialised: true,
@@ -159,7 +159,7 @@ export class AppMetaStore extends BudiStore<AppMetaState> {
     this.update(state => ({
       ...state,
       clientFeatures: {
-        ...INITIAL_APP_META_STATE.clientFeatures,
+        ...INITIAL_WORKSPACE_META_STATE.clientFeatures,
         ...features,
       },
     }))
@@ -227,4 +227,4 @@ export class AppMetaStore extends BudiStore<AppMetaState> {
   }
 }
 
-export const appStore = new AppMetaStore()
+export const workspaceStore = new WorkspaceMetaStore()

--- a/packages/builder/src/stores/builder/workspaceApps.ts
+++ b/packages/builder/src/stores/builder/workspaceApps.ts
@@ -8,7 +8,7 @@ import {
   WorkspaceApp,
 } from "@budibase/types"
 import { derived, get, Readable } from "svelte/store"
-import { appStore } from "./workspace"
+import { workspaceStore } from "./workspace"
 import { sortedScreens } from "./screens"
 import { workspaceDeploymentStore } from "./workspaceDeployment"
 
@@ -173,7 +173,7 @@ export class WorkspaceAppStore extends DerivedBudiStore<
     const { deploymentStore } = await import("./deployment")
 
     await deploymentStore.publishApp()
-    appStore.refresh()
+    workspaceStore.refresh()
   }
 
   async toggleDisabled(workspaceAppId: string, state: boolean) {

--- a/packages/builder/src/stores/routing.ts
+++ b/packages/builder/src/stores/routing.ts
@@ -4,7 +4,7 @@ import { derived, get } from "svelte/store"
 // Use direct imports to avoid circular dependency in licensing
 import { auth } from "@/stores/portal/auth"
 import { admin } from "@/stores/portal/admin"
-import { appStore } from "@/stores/builder/workspace"
+import { workspaceStore } from "@/stores/builder/workspace"
 import { bb, setSettingsRouteResolver } from "@/stores/bb"
 import { workspacesStore } from "@/stores/portal/workspaces"
 import {
@@ -15,8 +15,8 @@ import {
 } from "@/settings/routes"
 
 export const permittedRoutes = derived(
-  [admin, auth, appStore, workspacesStore],
-  ([$admin, $auth, $appStore, $workspacesStore]) => {
+  [admin, auth, workspaceStore, workspacesStore],
+  ([$admin, $auth, $workspaceStore, $workspacesStore]) => {
     const user = $auth?.user
 
     if (!user) {
@@ -24,7 +24,7 @@ export const permittedRoutes = derived(
     }
     const routes = [
       ...globalRoutes(user),
-      ...workspaceRoutes($appStore, $workspacesStore, user),
+      ...workspaceRoutes($workspaceStore, $workspacesStore, user),
       ...orgRoutes(user, $admin),
     ]
     return filterRoutes(routes)


### PR DESCRIPTION
## Description
Rename appStore to workspaceStore in builder package. No logic change, symbol-only renamings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the `appStore` store to `workspaceStore` in the `builder` package. This is a symbol-only rename; no logic or behavior changes.

**Refactors**
- Renames `AppMetaStore` to `WorkspaceMetaStore` and `INITIAL_APP_META_STATE` to `INITIAL_WORKSPACE_META_STATE`.
- Updates all imports, exports, and test mocks to use the new names.

<sup>Written for commit 0e01ba86a7a05990cdaa23253d9598f8075664aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

