### PR TITLE
Refactor app URLs and navigation to use /apps instead of /builder/apps

### DIFF
--- a/hosting/letsencrypt/nginx-ssl.conf
+++ b/hosting/letsencrypt/nginx-ssl.conf
@@ -32,6 +32,10 @@ server {
     }
 
     # Redirects for renamed routes
+    location = /builder/apps {
+        return 301 /apps;
+    }
+
     location ~ ^/builder/portal/apps(/.*)?$ {
         return 301 /builder/portal/workspaces$1;
     }
@@ -40,7 +44,7 @@ server {
         return 301 /builder/workspace$1;
     }
 
-    location ~ ^/(builder|app_) {
+    location ~ ^/(builder|apps|app_) {
         proxy_http_version  1.1;
         proxy_set_header    Connection          $connection_upgrade;
         proxy_set_header    Upgrade             $http_upgrade;

--- a/hosting/nginx.dev.conf
+++ b/hosting/nginx.dev.conf
@@ -197,6 +197,7 @@ http {
 
     location = /apps {
       proxy_pass      http://builder;
+      rewrite ^/apps$ /builder/apps break;
     }
 
     location /vite/ {

--- a/hosting/nginx.dev.conf
+++ b/hosting/nginx.dev.conf
@@ -154,6 +154,10 @@ http {
     }
 
     # Redirects for renamed routes
+    location = /builder/apps {
+      return 301 /apps;
+    }
+
     location ~ ^/builder/portal/apps(/.*)?$ {
       return 301 /builder/portal/workspaces$1;
     }
@@ -188,6 +192,10 @@ http {
       proxy_connect_timeout 120s;
       proxy_send_timeout 120s;
 
+      proxy_pass      http://builder;
+    }
+
+    location = /apps {
       proxy_pass      http://builder;
     }
 

--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -135,6 +135,10 @@ http {
     }
 
     # Redirects for renamed routes
+    location = /builder/apps {
+      return 301 $scheme://$host/apps;
+    }
+
     location ~ ^/builder/portal/apps(/.*)?$ {
       return 301 $scheme://$host/builder/portal/workspaces$1;
     }
@@ -143,7 +147,7 @@ http {
       return 301 $scheme://$host/builder/workspace$1;
     }
 
-    location ~ ^/(builder|app_) {
+    location ~ ^/(builder|apps|app_) {
       proxy_http_version  1.1;
 
       proxy_set_header    Connection          $connection_upgrade;

--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -51,6 +51,10 @@ server {
     }
 
     # Redirects for renamed routes
+    location = /builder/apps {
+        return 301 $scheme://$http_host/apps;
+    }
+
     location ~ ^/builder/portal/apps(/.*)?$ {
         return 301 $scheme://$http_host/builder/portal/workspaces$1;
     }
@@ -59,7 +63,7 @@ server {
         return 301 $scheme://$http_host/builder/workspace$1;
     }
 
-    location ~ ^/(builder|app_) {
+    location ~ ^/(builder|apps|app_) {
         # Buffer static builder/app responses (HTML, JS chunks, fonts, images)
         # so that browser cancels do not propagate to the upstream as
         # ERR_STREAM_PREMATURE_CLOSE.

--- a/packages/builder/src/pages/apps.svelte
+++ b/packages/builder/src/pages/apps.svelte
@@ -1,0 +1,1 @@
+<!-- routify:options rewrite="/builder/apps" -->

--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -194,13 +194,13 @@
         ) {
           return {
             type: "redirect",
-            path: canCreateApps ? "./onboarding" : "./apps",
+            path: canCreateApps ? "./onboarding" : "/apps",
           }
         }
 
         // Redirect non-builders to apps unless they're already there
-        if (!isBuilder && !$isActive("./apps")) {
-          return { type: "redirect", path: "./apps" }
+        if (!isBuilder && !$isActive("/apps")) {
+          return { type: "redirect", path: "/apps" }
         }
 
         // Default workspace selection for builders
@@ -211,7 +211,7 @@
           isBuilder &&
           $workspacesStore.apps.length &&
           !isOnWorkspaceRoute &&
-          !$isActive("./apps")
+          !$isActive("/apps")
         ) {
           // Find first editable app to redirect to
           const defaultApp = $enrichedApps.find(app => app.editable)

--- a/packages/builder/src/pages/builder/apps/index.svelte
+++ b/packages/builder/src/pages/builder/apps/index.svelte
@@ -135,7 +135,7 @@
               </MenuItem>
               {#if sdk.users.hasBuilderPermissions($auth.user)}
                 <MenuItem icon="code" on:click={() => $goto("/builder")}>
-                  {menuLabels.portal}
+                  {menuLabels.builder}
                 </MenuItem>
               {/if}
               <MenuItem icon="sign-out" on:click={logout}

--- a/packages/builder/src/pages/builder/get-started/index.svelte
+++ b/packages/builder/src/pages/builder/get-started/index.svelte
@@ -64,7 +64,7 @@
             cta
             disabled={loading}
             on:click={() => {
-              goto("../apps")
+              goto("/apps")
             }}
           >
             View app portal

--- a/packages/builder/src/pages/builder/onboarding/index.svelte
+++ b/packages/builder/src/pages/builder/onboarding/index.svelte
@@ -16,7 +16,7 @@
   let onboardingForbidden = false
 
   const goToApps = () => {
-    goto("../apps")
+    goto("/apps")
   }
 
   const createDefaultWorkspace = async () => {

--- a/packages/builder/src/pages/builder/workspaces.svelte
+++ b/packages/builder/src/pages/builder/workspaces.svelte
@@ -3,5 +3,5 @@
   // This should not be the case, and it has been fixed. This will fix any user that has it cached on the browser.
   import { redirect } from "@roxi/routify"
 
-  $: $redirect(`./apps`)
+  $: $redirect(`/apps`)
 </script>

--- a/packages/builder/src/pages/builder/workspaces.test.ts
+++ b/packages/builder/src/pages/builder/workspaces.test.ts
@@ -22,6 +22,6 @@ describe("builder workspaces redirect", () => {
   it("redirects legacy workspaces route to apps", () => {
     render(WorkspacesPage)
 
-    expect(mocks.redirect).toHaveBeenCalledWith("./apps")
+    expect(mocks.redirect).toHaveBeenCalledWith("/apps")
   })
 })

--- a/packages/client/src/components/app/UserMenu.svelte
+++ b/packages/client/src/components/app/UserMenu.svelte
@@ -62,7 +62,7 @@
     }
   }
 
-  const goToPortal = () => {
+  const goToPortal = (isBuilder: boolean) => {
     const targetUrl = isBuilder ? builderUrl() : portalUrl()
     window.location.href = targetUrl
   }
@@ -112,8 +112,16 @@
       </MenuItem>
     {/if}
 
-    <MenuItem icon="squares-four" on:click={goToPortal} disabled={embedded}>
-      {userMenuLabels.portal}
+    <MenuItem
+      icon="squares-four"
+      on:click={() => goToPortal(isBuilder)}
+      disabled={embedded}
+    >
+      {#if isBuilder}
+        {userMenuLabels.builder}
+      {:else}
+        {userMenuLabels.portal}
+      {/if}
     </MenuItem>
     <MenuItem
       icon="sign-out"

--- a/packages/client/src/components/app/UserMenu.svelte
+++ b/packages/client/src/components/app/UserMenu.svelte
@@ -45,8 +45,7 @@
     translationOverrides
   )
 
-  const { accountPortalAccountUrl, builderWorkspacesUrl, builderAppsUrl } =
-    helpers
+  const { accountPortalAccountUrl, builderUrl, portalUrl } = helpers
 
   const getText = (user?: User | ContextUser): string => {
     if (!user) {
@@ -64,10 +63,7 @@
   }
 
   const goToPortal = () => {
-    const builderBaseUrl = $environmentStore.accountPortalUrl
-    const targetUrl = isBuilder
-      ? builderWorkspacesUrl(builderBaseUrl)
-      : builderAppsUrl(builderBaseUrl)
+    const targetUrl = isBuilder ? builderUrl() : portalUrl()
     window.location.href = targetUrl
   }
 

--- a/packages/shared-core/src/constants/urls.ts
+++ b/packages/shared-core/src/constants/urls.ts
@@ -1,9 +1,9 @@
 export const BUILDER_URLS = {
-  WORKSPACES: "/builder/apps",
+  WORKSPACES: "/apps",
   SETTINGS_EMAIL: "/builder/settings/email",
   SETTINGS_AUTH: "/builder/settings/auth",
   SETTINGS_PEOPLE_USERS: "/builder/settings/people/users",
-  APPS: "/builder/apps",
+  APPS: "/apps",
 } as const
 
 export const ACCOUNT_PORTAL_PATHS = {

--- a/packages/shared-core/src/constants/urls.ts
+++ b/packages/shared-core/src/constants/urls.ts
@@ -1,4 +1,5 @@
 export const BUILDER_URLS = {
+  BUILDER: "/builder",
   WORKSPACES: "/apps",
   SETTINGS_EMAIL: "/builder/settings/email",
   SETTINGS_AUTH: "/builder/settings/auth",

--- a/packages/shared-core/src/helpers/index.ts
+++ b/packages/shared-core/src/helpers/index.ts
@@ -16,11 +16,11 @@ export {
   accountPortalAccountUrl,
   accountPortalBillingUrl,
   accountPortalUpgradeUrl,
-  builderWorkspacesUrl,
+  builderUrl,
   builderSettingsEmailUrl,
   builderSettingsAuthUrl,
   builderSettingsPeopleUsersUrl,
-  builderAppsUrl,
+  portalUrl,
   urlHelpers,
   applyBaseUrl,
 } from "./url"

--- a/packages/shared-core/src/helpers/tests/url.spec.ts
+++ b/packages/shared-core/src/helpers/tests/url.spec.ts
@@ -50,7 +50,7 @@ describe("url helpers", () => {
   describe("builder", () => {
     it("normalizes base when joining", () => {
       const url = builderWorkspacesUrl(`${BASE}/`)
-      expect(url).toEqual(`${BASE}/builder/apps`)
+      expect(url).toEqual(`${BASE}/apps`)
     })
   })
 })

--- a/packages/shared-core/src/helpers/tests/url.spec.ts
+++ b/packages/shared-core/src/helpers/tests/url.spec.ts
@@ -1,7 +1,7 @@
 import {
   accountPortalBillingUrl,
   accountPortalUpgradeUrl,
-  builderWorkspacesUrl,
+  builderUrl,
   applyBaseUrl,
 } from "../url"
 
@@ -49,8 +49,8 @@ describe("url helpers", () => {
 
   describe("builder", () => {
     it("normalizes base when joining", () => {
-      const url = builderWorkspacesUrl(`${BASE}/`)
-      expect(url).toEqual(`${BASE}/apps`)
+      const url = builderUrl(`${BASE}/`)
+      expect(url).toEqual(`${BASE}/builder`)
     })
   })
 })

--- a/packages/shared-core/src/helpers/url.ts
+++ b/packages/shared-core/src/helpers/url.ts
@@ -114,8 +114,8 @@ export const accountPortalUpgradeUrl = (
   return joinBaseAndPath(accountPortalUrl, ACCOUNT_PORTAL_PATHS.UPGRADE)
 }
 
-export const builderWorkspacesUrl = (builderBaseUrl?: string | null) =>
-  joinBaseAndPath(builderBaseUrl, BUILDER_URLS.WORKSPACES)
+export const builderUrl = (builderBaseUrl?: string | null) =>
+  joinBaseAndPath(builderBaseUrl, BUILDER_URLS.BUILDER)
 
 export const builderSettingsEmailUrl = (builderBaseUrl?: string | null) =>
   joinBaseAndPath(builderBaseUrl, BUILDER_URLS.SETTINGS_EMAIL)
@@ -126,18 +126,18 @@ export const builderSettingsAuthUrl = (builderBaseUrl?: string | null) =>
 export const builderSettingsPeopleUsersUrl = (builderBaseUrl?: string | null) =>
   joinBaseAndPath(builderBaseUrl, BUILDER_URLS.SETTINGS_PEOPLE_USERS)
 
-export const builderAppsUrl = (builderBaseUrl?: string | null) =>
+export const portalUrl = (builderBaseUrl?: string | null) =>
   joinBaseAndPath(builderBaseUrl, BUILDER_URLS.APPS)
 
 export const urlHelpers = {
   accountPortalAccountUrl,
   accountPortalBillingUrl,
   accountPortalUpgradeUrl,
-  builderWorkspacesUrl,
+  builderUrl,
   builderSettingsEmailUrl,
   builderSettingsAuthUrl,
   builderSettingsPeopleUsersUrl,
-  builderAppsUrl,
+  portalUrl,
 }
 
 export default urlHelpers

--- a/packages/shared-core/src/translations/userMenu.ts
+++ b/packages/shared-core/src/translations/userMenu.ts
@@ -19,6 +19,12 @@ export const userMenuTranslations = createTranslationDefinitions(category, [
     key: "portal",
     fullKey: "portal",
     name: "User menu portal label",
+    defaultValue: "Go to portal",
+  },
+  {
+    key: "builder",
+    fullKey: "builder",
+    name: "User menu developer mode label",
     defaultValue: "Open developer mode",
   },
   {


### PR DESCRIPTION
## Description
Remove the `/builder` path from `/builder/apps`. Having the `/builder` path in there is confusing. Also, some labeling was wrong when logging in as a non builder user.

## Screenshots
### Builder/admin flow
https://jam.dev/c/8b09b1a3-768d-486a-986e-84e531ec2a40

### User flow
https://jam.dev/c/cdf0107e-a230-4b76-91a5-82b49d030aeb

## Launchcontrol
Remove the `/builder` path from `/builder/apps` url

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the apps portal from `/builder/apps` to `/apps` and fixes user menu labels so non-builder users see "Go to portal" instead of the builder label. Old `/builder/apps` URLs redirect to `/apps`.

**Rollout**
- Nginx configs now redirect `/builder/apps` to `/apps` and route `/apps` to the builder upstream.
- The user menu label for builders changes to "developer mode" (`userMenuLabels.builder`); non-builders keep "Go to portal".
- `builderWorkspacesUrl` is renamed to `builderUrl`, and `builderAppsUrl` to `portalUrl`; update callers that import these helpers.

<sup>Written for commit aa5357784c1742db747b90a59e5c6a99805535c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

