### PR TITLE
ci: run CLA Assistant for cloud PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,6 +6,7 @@ on:
     types: [opened,closed,synchronize]
     branches:
       - master
+      - cloud
 
 jobs:
   CLAssistant:


### PR DESCRIPTION
## Description
Add the `cloud` release branch to the CLA Assistant `pull_request_target` trigger so cloud promotion PRs receive the required `CLAssistant` check.

## Addresses
- N/A (workflow fix)

## Launchcontrol
Cloud promotion PRs can now complete the CLA Assistant check required for merging.
