### PR TITLE
fix: prune unused and deleted plugins from app metadata (#10161)

### DIFF
--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -357,6 +357,8 @@ export const publishWorkspaceInternal = async (
         const devId = dbCore.getDevWorkspaceID(appId)
         const prodId = dbCore.getProdWorkspaceID(appId)
 
+        await sdk.plugins.reconcileUsedPlugins()
+
         if (!(await sdk.workspaces.isWorkspacePublished(prodId))) {
           const allWorkspaceApps = await sdk.workspaceApps.fetch()
           for (const workspaceApp of allWorkspaceApps) {

--- a/packages/server/src/api/controllers/screen.ts
+++ b/packages/server/src/api/controllers/screen.ts
@@ -1,10 +1,4 @@
-import {
-  context,
-  db as dbCore,
-  events,
-  roles,
-  tenancy,
-} from "@budibase/backend-core"
+import { context, events, roles } from "@budibase/backend-core"
 import { sdk as sharedSdk } from "@budibase/shared-core"
 import {
   DeleteScreenResponse,
@@ -13,15 +7,14 @@ import {
   SaveScreenRequest,
   SaveScreenResponse,
   Screen,
-  ScreenProps,
   ScreenUsage,
   UsageInScreensResponse,
   UserCtx,
+  Workspace,
 } from "@budibase/types"
 import { DocumentType } from "../../db/utils"
 import sdk from "../../sdk"
 import { builderSocket } from "../../websockets"
-import { updateWorkspacePackage } from "./workspace"
 
 export async function fetch(ctx: UserCtx<void, FetchScreenResponse>) {
   const screens = await sdk.screens.fetch()
@@ -52,47 +45,13 @@ export async function save(
     ? await sdk.screens.create(screen)
     : await sdk.screens.update(screen)
 
-  // Find any custom components being used
-  let pluginNames: string[] = []
-  let pluginAdded = false
-  findPlugins(screen.props, pluginNames)
-  if (pluginNames.length) {
-    const globalDB = tenancy.getGlobalDB()
-    const pluginsResponse = await globalDB.allDocs(
-      dbCore.getPluginParams(null, {
-        include_docs: true,
-      })
-    )
-    const requiredPlugins = pluginsResponse.rows
-      .map((row: any) => row.doc)
-      .filter((plugin: Plugin) => {
-        return (
-          plugin.schema.type === "component" &&
-          pluginNames.includes(`plugin/${plugin.name}`)
-        )
-      })
+  const application = await db.get<Workspace>(DocumentType.WORKSPACE_METADATA)
+  const prevIds = new Set(
+    (application.usedPlugins || []).map((x: Plugin) => x._id)
+  )
 
-    // Update the app metadata
-    const application = await db.get<any>(DocumentType.WORKSPACE_METADATA)
-    let usedPlugins = application.usedPlugins || []
-
-    requiredPlugins.forEach((plugin: Plugin) => {
-      if (!usedPlugins.find((x: Plugin) => x._id === plugin._id)) {
-        pluginAdded = true
-        usedPlugins.push({
-          _id: plugin._id,
-          name: plugin.name,
-          version: plugin.version,
-          jsUrl: plugin.jsUrl,
-          hash: plugin.hash,
-        })
-      }
-    })
-
-    if (pluginAdded) {
-      await updateWorkspacePackage({ usedPlugins }, ctx.appId)
-    }
-  }
+  const usedPlugins = await sdk.plugins.reconcileUsedPlugins(db)
+  const pluginAdded = usedPlugins.some(plugin => !prevIds.has(plugin._id))
 
   if (screen.routing.homeScreen) {
     await sdk.screens.ensureHomepageUniqueness(screen)
@@ -132,6 +91,7 @@ export async function destroy(ctx: UserCtx<void, DeleteScreenResponse>) {
   await db.remove(id, ctx.params.screenRev)
 
   await sdk.navigation.deleteLink(screen.routing.route, screen.workspaceAppId)
+  await sdk.plugins.reconcileUsedPlugins(db)
 
   await events.screen.deleted(screen)
   ctx.body = {
@@ -143,21 +103,6 @@ export async function destroy(ctx: UserCtx<void, DeleteScreenResponse>) {
   if (workspaceApp) {
     builderSocket?.emitWorkspaceAppUpdate(ctx, workspaceApp)
   }
-}
-
-function findPlugins(component: ScreenProps, foundPlugins: string[]) {
-  if (!component) {
-    return
-  }
-  if (component._component.startsWith("plugin")) {
-    if (!foundPlugins.includes(component._component)) {
-      foundPlugins.push(component._component)
-    }
-  }
-  if (!component._children || !component._children.length) {
-    return
-  }
-  component._children.forEach(child => findPlugins(child, foundPlugins))
 }
 
 export async function usage(ctx: UserCtx<void, UsageInScreensResponse>) {

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -540,7 +540,10 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
         import("./templates/BudibaseApp.svelte"),
         import("svelte/server"),
       ])
-      const plugins = await objectStore.enrichPluginURLs(appInfo.usedPlugins)
+      const existingPlugins = await sdk.plugins.enrichUsedPluginSvelteMajors(
+        appInfo.usedPlugins
+      )
+      const plugins = await objectStore.enrichPluginURLs(existingPlugins)
       /*
        * Server rendering in svelte sadly does not support type checking, the .render function
        * always will just expect "any" when typing - so it is pointless for us to type the

--- a/packages/server/src/api/routes/tests/screen.spec.ts
+++ b/packages/server/src/api/routes/tests/screen.spec.ts
@@ -1,12 +1,16 @@
-import { events, roles } from "@budibase/backend-core"
+import { events, roles, tenancy } from "@budibase/backend-core"
 import { structures } from "@budibase/backend-core/tests"
 import {
   BuiltinPermissionID,
+  Plugin,
+  PluginSource,
+  PluginType,
   Role,
   Screen,
   SourceType,
   UsageInScreensResponse,
 } from "@budibase/types"
+import sdk from "../../../sdk"
 import { basicDatasourcePlus } from "../../../tests/utilities/structures"
 import * as setup from "./utilities"
 import { checkBuilderEndpoint } from "./utilities/TestFunctions"
@@ -322,6 +326,147 @@ describe("/screens", () => {
       const usage = await config.api.screen.usage(query._id!)
       expect(usage.sourceType).toEqual(SourceType.QUERY)
       confirmScreen(usage, screen)
+    })
+  })
+
+  describe("used plugins management", () => {
+    const pluginDoc: Plugin = {
+      _id: "plg_custom-component",
+      name: "custom-component",
+      version: "1.0.0",
+      description: "",
+      source: PluginSource.FILE,
+      package: {},
+      hash: "123",
+      schema: {
+        type: PluginType.COMPONENT,
+        metadata: {
+          svelteMajor: 5,
+        },
+      },
+    }
+
+    const createPluginScreen = (route = "/plugin-screen") => {
+      const screen = basicScreen(route)
+      screen.props._children = [
+        {
+          _id: "comp-1",
+          _component: "plugin/custom-component",
+          _instanceName: "CustomComponent",
+          _styles: { normal: {}, custom: {}, selected: {} },
+          _children: [],
+        },
+      ]
+      return screen
+    }
+
+    beforeEach(async () => {
+      await config.doInTenant(async () => {
+        const globalDB = tenancy.getGlobalDB()
+        try {
+          await globalDB.put(pluginDoc)
+        } catch (e) {
+          // Ignore if exists
+        }
+      })
+    })
+
+    it("should add used plugin when screen contains a plugin component", async () => {
+      await config.api.screen.save(createPluginScreen("/plugin-screen"))
+
+      await config.doInContext(config.devWorkspaceId!, async () => {
+        const app = await sdk.workspaces.metadata.get()
+        expect(app.usedPlugins?.length).toEqual(1)
+        expect(app.usedPlugins?.[0].name).toEqual("custom-component")
+      })
+    })
+
+    it("should prune unused plugin when plugin component is removed from screen", async () => {
+      const screen = await config.api.screen.save(
+        createPluginScreen("/plugin-screen")
+      )
+
+      await config.doInContext(config.devWorkspaceId!, async () => {
+        const app = await sdk.workspaces.metadata.get()
+        expect(app.usedPlugins?.length).toEqual(1)
+      })
+
+      screen.props._children = []
+      await config.api.screen.save(screen)
+
+      await config.doInContext(config.devWorkspaceId!, async () => {
+        const app = await sdk.workspaces.metadata.get()
+        expect(app.usedPlugins?.length).toEqual(0)
+      })
+    })
+
+    it("should prune unused plugin when screen containing it is deleted", async () => {
+      const screen = await config.api.screen.save(
+        createPluginScreen("/plugin-screen")
+      )
+
+      await config.doInContext(config.devWorkspaceId!, async () => {
+        const app = await sdk.workspaces.metadata.get()
+        expect(app.usedPlugins?.length).toEqual(1)
+      })
+
+      await config.api.screen.destroy(screen._id!, screen._rev!)
+
+      await config.doInContext(config.devWorkspaceId!, async () => {
+        const app = await sdk.workspaces.metadata.get()
+        expect(app.usedPlugins?.length).toEqual(0)
+      })
+    })
+
+    it("should retain plugin if at least one screen is still using it", async () => {
+      const screen1 = await config.api.screen.save(
+        createPluginScreen("/plugin-screen-1")
+      )
+      const screen2 = await config.api.screen.save(
+        basicScreen("/plugin-screen-2")
+      )
+
+      await config.doInContext(config.devWorkspaceId!, async () => {
+        const app = await sdk.workspaces.metadata.get()
+        expect(app.usedPlugins?.length).toEqual(1)
+      })
+
+      await config.api.screen.destroy(screen2._id!, screen2._rev!)
+
+      await config.doInContext(config.devWorkspaceId!, async () => {
+        const app = await sdk.workspaces.metadata.get()
+        expect(app.usedPlugins?.length).toEqual(1)
+      })
+
+      await config.api.screen.destroy(screen1._id!, screen1._rev!)
+
+      await config.doInContext(config.devWorkspaceId!, async () => {
+        const app = await sdk.workspaces.metadata.get()
+        expect(app.usedPlugins?.length).toEqual(0)
+      })
+    })
+
+    it("should filter out deleted plugins in enrichUsedPluginSvelteMajors", async () => {
+      await config.doInTenant(async () => {
+        const enriched = await sdk.plugins.enrichUsedPluginSvelteMajors([
+          pluginDoc,
+          {
+            _id: "plg_nonexistent",
+            name: "nonexistent",
+            version: "1.0.0",
+            description: "",
+            source: PluginSource.FILE,
+            package: {},
+            hash: "456",
+            schema: {
+              type: PluginType.COMPONENT,
+            },
+          },
+        ])
+
+        expect(enriched.length).toEqual(1)
+        expect(enriched[0]._id).toEqual("plg_custom-component")
+      })
     })
   })
 })

--- a/packages/server/src/sdk/plugins/index.ts
+++ b/packages/server/src/sdk/plugins/index.ts
@@ -13,6 +13,8 @@ import mappingFile from "./mapping.json"
 import sdk from "../../sdk"
 import { deleteFolderFileSystem } from "../../utilities/fileSystem"
 
+export * from "./usedPlugins"
+
 export async function fetch(type?: PluginType): Promise<Plugin[]> {
   const db = tenancy.getGlobalDB()
   const response = await db.allDocs(
@@ -175,33 +177,39 @@ export const enrichUsedPluginSvelteMajors = async (
     })
 
     const svelteMajorById = new Map<string, number>()
+    const existingPluginIds = new Set<string>()
     for (const row of response?.rows || []) {
-      const svelteMajor = row?.doc?.schema?.metadata?.svelteMajor
-      if (typeof row?.id === "string" && typeof svelteMajor === "number") {
-        svelteMajorById.set(row.id, svelteMajor)
+      if (row?.doc && typeof row?.id === "string") {
+        existingPluginIds.add(row.id)
+        const svelteMajor = row.doc.schema?.metadata?.svelteMajor
+        if (typeof svelteMajor === "number") {
+          svelteMajorById.set(row.id, svelteMajor)
+        }
       }
     }
 
-    return usedPlugins.map(plugin => {
-      const svelteMajor = svelteMajorById.get(plugin._id!)
-      if (typeof svelteMajor !== "number") {
-        return plugin
-      }
+    return usedPlugins
+      .filter(plugin => existingPluginIds.has(plugin._id!))
+      .map(plugin => {
+        const svelteMajor = svelteMajorById.get(plugin._id!)
+        if (typeof svelteMajor !== "number") {
+          return plugin
+        }
 
-      const schema = (plugin.schema || {}) as Plugin["schema"]
-      const metadata = schema?.metadata || {}
+        const schema = (plugin.schema || {}) as Plugin["schema"]
+        const metadata = schema?.metadata || {}
 
-      return {
-        ...plugin,
-        schema: {
-          ...schema,
-          metadata: {
-            ...metadata,
-            svelteMajor,
+        return {
+          ...plugin,
+          schema: {
+            ...schema,
+            metadata: {
+              ...metadata,
+              svelteMajor,
+            },
           },
-        },
-      }
-    })
+        }
+      })
   } catch (err) {
     return usedPlugins
   }

--- a/packages/server/src/sdk/plugins/usedPlugins.ts
+++ b/packages/server/src/sdk/plugins/usedPlugins.ts
@@ -1,0 +1,87 @@
+import { context, db as dbCore, tenancy } from "@budibase/backend-core"
+import {
+  Database,
+  Plugin,
+  PluginType,
+  ScreenProps,
+  Workspace,
+} from "@budibase/types"
+import * as screens from "../workspace/screens"
+import { DocumentType } from "../../db/utils"
+
+const collectPluginComponents = (
+  component?: ScreenProps,
+  pluginComponentNames?: Set<string>
+) => {
+  if (!component || !pluginComponentNames) {
+    return
+  }
+  if (
+    typeof component._component === "string" &&
+    component._component.startsWith("plugin/")
+  ) {
+    pluginComponentNames.add(component._component)
+  }
+  if (Array.isArray(component._children)) {
+    component._children.forEach(child =>
+      collectPluginComponents(child, pluginComponentNames)
+    )
+  }
+}
+
+export const reconcileUsedPlugins = async (
+  db: Database = context.getWorkspaceDB()
+): Promise<Plugin[]> => {
+  const allScreens = await screens.fetch(db)
+  const pluginComponentNames = new Set<string>()
+
+  for (const screen of allScreens) {
+    collectPluginComponents(screen.props, pluginComponentNames)
+  }
+
+  const application = await db.get<Workspace>(DocumentType.WORKSPACE_METADATA)
+  const currentUsedPlugins = application.usedPlugins || []
+
+  let nextUsedPlugins: Plugin[] = []
+  if (pluginComponentNames.size > 0) {
+    const globalDB = tenancy.getGlobalDB()
+    const pluginsResponse = await globalDB.allDocs<Plugin>(
+      dbCore.getPluginParams(null, {
+        include_docs: true,
+      })
+    )
+    const requiredPlugins = pluginsResponse.rows
+      .map(row => row.doc)
+      .filter((plugin?: Plugin): plugin is Plugin => {
+        return (
+          plugin?.schema?.type === PluginType.COMPONENT &&
+          pluginComponentNames.has(`plugin/${plugin.name}`)
+        )
+      })
+
+    nextUsedPlugins = requiredPlugins
+  }
+
+  const currentIds = currentUsedPlugins
+    .map(p => p._id)
+    .filter(Boolean)
+    .sort()
+    .join(",")
+  const nextIds = nextUsedPlugins
+    .map(p => p._id)
+    .filter(Boolean)
+    .sort()
+    .join(",")
+
+  if (
+    currentIds !== nextIds ||
+    currentUsedPlugins.length !== nextUsedPlugins.length
+  ) {
+    await db.put({
+      ...application,
+      usedPlugins: nextUsedPlugins,
+    })
+  }
+
+  return nextUsedPlugins
+}


### PR DESCRIPTION
## Description
When custom component plugins are added to screens, Budibase tracks them in the workspace metadata document (`workspace.usedPlugins`). However, when those components were deleted from a screen, when entire screens were removed, or when plugins were uninstalled globally, `usedPlugins` was never pruned.

As a consequence, the client application attempted to load bundle assets (`/api/assets/plugins/{pluginId}/...`) for non-existent or unused plugins on startup, resulting in 404 network errors in the browser console.

This PR adds automated reconciliation of `usedPlugins` to:
1. Prune unused plugins whenever screens are saved or deleted.
2. Synchronize active plugins before replicating dev-to-prod workspaces on publish.
3. Filter out deleted or missing plugins in `enrichUsedPluginSvelteMajors` when serving client assets.

## Addresses
- https://github.com/Budibase/budibase/issues/10161

## App Export
- N/A (Backend / metadata reconciliation change covered by automated integration test suite in `packages/server/src/api/routes/tests/screen.spec.ts`).

## Screenshots
_N/A (Non-UI backend bugfix)._

## Launchcontrol
Fixed an issue where deleting custom plugin components or screens did not remove them from the app metadata, preventing 404 network errors when loading the app.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes unused and deleted plugins from workspace metadata so the client stops loading bundles for plugins that no longer exist, eliminating 404 errors in the browser console.

**Bug Fixes**
- Recomputes `usedPlugins` from current screens after each screen save or delete.
- Reconciles active plugins before replicating a dev workspace to production on publish.
- Filters out plugins missing from the global database when serving client assets.

<sup>Written for commit a6514c0ab489615e847b23162948e0bf2879068c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

