### PR TITLE
fix: clear budibase:returnurl cookie across domains to prevent redire…

### DIFF
--- a/packages/frontend-core/src/utils/cookies.js
+++ b/packages/frontend-core/src/utils/cookies.js
@@ -17,8 +17,19 @@ export function getCookie(cookieName) {
   }
 }
 
-export function removeCookie(cookieName) {
+export function removeCookie(cookieName, domain) {
   if (getCookie(cookieName)) {
     document.cookie = `${cookieName}=; Max-Age=-99999999; Path=/;`
+    if (domain) {
+      document.cookie = `${cookieName}=; Max-Age=-99999999; Path=/; Domain=${domain};`
+    } else if (typeof window !== "undefined") {
+      const parts = window.location.hostname.split(".")
+      while (parts.length >= 2) {
+        const d = parts.join(".")
+        document.cookie = `${cookieName}=; Max-Age=-99999999; Path=/; Domain=${d};`
+        document.cookie = `${cookieName}=; Max-Age=-99999999; Path=/; Domain=.${d};`
+        parts.shift()
+      }
+    }
   }
 }

--- a/packages/server/src/api/controllers/ai/chatIdentityLinks.ts
+++ b/packages/server/src/api/controllers/ai/chatIdentityLinks.ts
@@ -238,6 +238,8 @@ export async function handoffChatLinkSession(
     throw new HTTPError("Link token is invalid or has expired", 400)
   }
 
+  utils.clearCookie(ctx, CHAT_LINK_RETURN_URL_COOKIE)
+
   ctx.type = "text/html"
   ctx.body = renderLinkConfirmationPage(
     confirmationSession,


### PR DESCRIPTION
## Description

This PR resolves an issue where clicking "Go to tenant" incorrectly redirects the user to the chat-link handoff endpoint due to a stale `budibase:returnurl` session cookie.

The issue occurs because `utils.setCookie` sets the handoff cookie on the root domain (e.g. `.budibase.app`), but the frontend `CookieUtils.removeCookie` was attempting to delete it without specifying the domain, which the browser rejects.

### Changes

- Updated `CookieUtils.removeCookie` in `frontend-core` to iteratively attempt removal on all parent domains of `window.location.hostname`. This ensures the cookie is properly cleared across subdomains.
- Added `utils.clearCookie(ctx, CHAT_LINK_RETURN_URL_COOKIE)` to `handoffChatLinkSession` in the server as a defense-in-depth measure, ensuring the backend clears the cookie once authentication succeeds.

## Addresses

https://github.com/Budibase/budibase/issues/19630

## App Export

N/A — This is a framework/platform-level bug and is not related to an individual app configuration.

## Screenshots

N/A — No UI changes; logic fix only.

## Launchcontrol

Fixed a bug where users could get repeatedly redirected to the chat-link handoff page when attempting to log in or navigate to a tenant.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Go to tenant" redirect loop caused by a stale `budibase:returnurl` cookie set on the root domain. The frontend now clears the cookie on all parent domains, and the backend clears it after successful authentication.

<sup>Written for commit ed72244456b795042b22f1462fe6c7dc5f0ae9b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

