### PR TITLE
docs: improve 502 bad gateway troubleshooting message (#19653)

### DIFF
--- a/hosting/proxy/error.html
+++ b/hosting/proxy/error.html
@@ -31,7 +31,7 @@
 
         var message
         if (status === 502) {
-          message = "Bad gateway. Please try again later."
+          message = "Bad gateway.<br/><br/><span style='font-size: 16px'>If this is a new installation, Budibase may still be starting up. Please wait a few minutes and try again.<br/><br/>If the problem persists, check your docker logs for errors.</span>"
         } else if (status === 503) {
           message = "Service Unavailable. Please try again later."
         } else if (status === 504) {


### PR DESCRIPTION
## Description
This PR resolves an issue where users receive a confusing 502 Bad Gateway error upon a fresh installation of Budibase via Docker. 

When Budibase is booting, the proxy starts immediately and listens on the main port (10000), but the backend services take time to start. I've updated `hosting/proxy/error.html` to display a more helpful troubleshooting message specific to 502 errors, advising the user to wait for services to boot or check their Docker logs.

## Addresses
- https://github.com/Budibase/budibase/issues/19653

## App Export
_N/A_

## Screenshots
_N/A_

## Launchcontrol
Updated the 502 Bad Gateway proxy error page to include helpful troubleshooting steps for new installations.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the 502 Bad Gateway proxy error page so fresh Docker installations see a helpful troubleshooting message instead of a generic "please try again later." The new message advises users to wait for services to boot or check their Docker logs, addressing issue #19653.

<sup>Written for commit a5bc95efacdb78b2cffc6667c9013719b06e5ec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

