### PR TITLE
fix: prevent litellm prisma crash from node snapshot options (#19638)

### DIFF
--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -554,7 +554,7 @@ else
         LITELLM_CONFIG_PATH="${DATA_DIR}/litellm/config.yaml"
     fi
 
-    pm2 start /opt/venv/litellm/bin/litellm \
+    NODE_OPTIONS="" pm2 start /opt/venv/litellm/bin/litellm \
       --name litellm \
       --interpreter /opt/venv/litellm/bin/python \
       --restart-delay 5000 \


### PR DESCRIPTION
## Description
This PR resolves an issue where configuring an AI model in a single-image Docker deployment fails with HTTP 500 because the internal LiteLLM gateway crashes on startup.

The crash occurs because the Budibase `Dockerfile` globally sets `NODE_OPTIONS="--no-node-snapshot"` to support `isolated-vm` for the backend Node services. However, `litellm` uses a Python Prisma wrapper which invokes the Node.js Prisma engine under the hood. The Prisma engine encounters a libuv assertion failure when it inherits the `--no-node-snapshot` option and fails to run the database migration.

**Fix:** Updated `hosting/single/runner.sh` to explicitly unset `NODE_OPTIONS` (e.g. `NODE_OPTIONS=""`) specifically for the PM2 command that spawns `litellm`. The Node-based Budibase services continue to inherit the required flag, while Prisma is protected from the incompatible Node option.

## Addresses
- https://github.com/Budibase/budibase/issues/19638

## App Export
_N/A_

## Screenshots
_N/A (Backend infrastructure fix)_

## Launchcontrol
Fixed a critical bug in the single Docker image where the internal AI Gateway (LiteLLM) would crash in a loop on startup, preventing users from adding AI models.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LiteLLM gateway crash on startup in single-image Docker deployments, which caused HTTP 500 errors when configuring AI models (issue #19638). The crash happened because the globally set `NODE_OPTIONS="--no-node-snapshot"` (needed for `isolated-vm`) breaks the Node-based Prisma engine that LiteLLM uses for migrations. The fix unsets `NODE_OPTIONS` for the `litellm` PM2 process only, leaving the other Budibase services unaffected.

<sup>Written for commit 761ad023f9a6d33470f96bc1720e8c7364ba4c2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

