### PR TITLE
Cloud backmerge

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,6 +6,7 @@ on:
     types: [opened,closed,synchronize]
     branches:
       - master
+      - cloud
 
 jobs:
   CLAssistant:


### PR DESCRIPTION
## Description
Cloud backmerge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the CLA Assistant workflow so CLA checks also run for PRs targeting the `cloud` branch. Previously only PRs targeting `master` were checked, allowing cloud PRs to merge without a signed CLA.

<sup>Written for commit 145fd2701a73a7b05945c6a04b50bb4ba96453d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

